### PR TITLE
[TSK-004] Surface assigned owner in board view

### DIFF
--- a/docs/diagrams/architecture-TSK-004.mmd
+++ b/docs/diagrams/architecture-TSK-004.mmd
@@ -1,0 +1,14 @@
+flowchart LR
+    UI[Task board UI /tasks?view=board] --> Router[Task browser route state]
+    Router --> Client[Browser API client]
+    Client --> API[Audit HTTP API GET /tasks]
+    API --> Projection[(Projected task current state)]
+    API --> AgentRegistry[(Assignable agent roster)]
+    Projection --> OwnerFields[current_owner + owner payload]
+    AgentRegistry --> Presenter[Owner presentation helper]
+    OwnerFields --> Presenter
+    Presenter --> Board[Board columns + owner badges + empty states]
+    Board --> Filter[Single-select owner filter]
+    Filter --> Board
+    Detail[Task detail PATCH /tasks/:id/assignment] --> Projection
+    Projection --> API

--- a/docs/diagrams/workflow-TSK-004.mmd
+++ b/docs/diagrams/workflow-TSK-004.mmd
@@ -1,0 +1,21 @@
+flowchart TD
+    A[User opens /tasks?view=board] --> B[Browser loads projected task summaries from GET /tasks]
+    B --> C[Board groups cards by stage and resolves owner presentation]
+    C --> D{Owner state present?}
+    D -- Assigned and resolvable --> E[Show canonical owner display name]
+    D -- No current owner --> F[Show exact label Unassigned]
+    D -- Explicitly redacted owner metadata --> G[Show exact safe label Owner hidden]
+    D -- Stale or missing roster entry --> H[Show exact fallback label Unknown owner]
+    E --> I{Owner filter selected?}
+    F --> I
+    G --> I
+    H --> I
+    I -- No --> J[Render all board cards across visible columns]
+    I -- Single owner --> K[Keep matching cards and preserve empty columns]
+    I -- Unassigned --> L[Keep only unassigned cards and preserve empty columns]
+    K --> M[User clears filter in one action]
+    L --> M
+    M --> J
+    N[PM reassigns task in detail view] --> O[Assignment endpoint updates projected current owner]
+    O --> P[User refreshes or reloads board]
+    P --> Q[Board card shows updated owner from projected state]

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:security": "node --test tests/security/*.test.js",
     "test:chaos": "node --test chaos/*.test.js",
     "test:integration:postgres": "node --test tests/integration/*.test.js",
-    "test:ui": "vitest run src/app/App.test.tsx",
+    "test:ui": "vitest run src/app/App.test.tsx tests/unit/board-owner-card-rendering.test.js tests/integration/board-owner-filtering.integration.test.js",
     "test:integration:docker": "bash scripts/run-postgres-integration-docker.sh",
     "audit:rebuild": "node scripts/rebuild-audit-projections.js",
     "audit:project": "node scripts/process-audit-projection-queue.js",

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -11,10 +11,16 @@ import {
   resolveApiBaseUrl,
   writeBrowserSessionConfig,
 } from './session';
+import {
+  buildBoardColumns,
+  filterTaskList,
+  mapAgentOptions,
+  resolveOwnerPresentation,
+  summarizeListResults,
+  UNASSIGNED_FILTER_VALUE,
+} from './task-owner';
 
 const envApiBaseUrl = (import.meta.env.VITE_TASK_API_BASE_URL || '').trim();
-const UNASSIGNED_FILTER_VALUE = '__unassigned__';
-const STAGE_ORDER = ['BACKLOG', 'TODO', 'IMPLEMENT', 'IN_PROGRESS', 'REVIEW', 'VERIFY', 'DONE', 'REOPEN'];
 
 function readRouteTask(pathname) {
   const match = ((pathname || '').replace(/\/+$/, '') || '/').match(/^\/tasks\/([^/]+)$/);
@@ -134,63 +140,6 @@ function formatFreshness(summary) {
 function canManageAssignment(tokenClaims) {
   const roles = Array.isArray(tokenClaims?.roles) ? tokenClaims.roles : [];
   return roles.includes('pm') || roles.includes('admin');
-}
-
-function mapAgentOptions(items = []) {
-  return items.map((agent) => ({
-    id: agent.id,
-    label: `${agent.display_name}${agent.role ? ` · ${agent.role}` : ''}`,
-  }));
-}
-
-function resolveOwnerPresentation(item, agentLookup) {
-  if (!item.current_owner) {
-    return { label: 'Unassigned', detail: 'No owner assigned', tone: 'unassigned', filterValue: UNASSIGNED_FILTER_VALUE };
-  }
-
-  const agent = agentLookup.get(item.current_owner);
-  if (agent) {
-    return { label: agent.label, detail: `Owner: ${agent.label}`, tone: 'assigned', filterValue: item.current_owner };
-  }
-
-  if (item.owner && !String(item.owner.display_name || '').trim()) {
-    return { label: 'Owner hidden', detail: 'Owner metadata is hidden on this surface', tone: 'fallback', filterValue: item.current_owner };
-  }
-
-  return { label: 'Unknown owner', detail: `Owner record unavailable for ${item.current_owner}`, tone: 'fallback', filterValue: item.current_owner };
-}
-
-function filterTaskList(items, ownerFilter) {
-  if (!ownerFilter) return items;
-  if (ownerFilter === UNASSIGNED_FILTER_VALUE) return items.filter((item) => !item.current_owner);
-  return items.filter((item) => item.current_owner === ownerFilter);
-}
-
-function summarizeListResults(count, ownerFilter, agentLookup, view = 'list') {
-  const noun = view === 'board' ? 'cards' : 'tasks';
-  if (!ownerFilter) return `${count} ${noun} shown.`;
-  if (ownerFilter === UNASSIGNED_FILTER_VALUE) return `${count} unassigned ${noun} shown.`;
-  return `${count} ${noun} shown for ${agentLookup.get(ownerFilter)?.label || ownerFilter}.`;
-}
-
-function compareStageName(a, b) {
-  const left = STAGE_ORDER.indexOf(a);
-  const right = STAGE_ORDER.indexOf(b);
-  if (left === -1 && right === -1) return a.localeCompare(b);
-  if (left === -1) return 1;
-  if (right === -1) return -1;
-  return left - right;
-}
-
-function buildBoardColumns(allItems, visibleItems, agentLookup) {
-  const visibleById = new Set(visibleItems.map((item) => item.task_id));
-  const stages = Array.from(new Set(allItems.map((item) => item.current_stage || 'Unspecified'))).sort(compareStageName);
-  return stages.map((stage) => ({
-    stage,
-    items: allItems
-      .filter((item) => (item.current_stage || 'Unspecified') === stage && visibleById.has(item.task_id))
-      .map((item) => ({ ...item, ownerPresentation: resolveOwnerPresentation(item, agentLookup) })),
-  }));
 }
 
 function useLocationState() {
@@ -594,9 +543,15 @@ export function App() {
                               <span className="task-board__label">Priority</span>
                               <span>{item.priority || '—'}</span>
                             </div>
-                            <div className="task-board__card-meta">
+                            <div className="task-board__card-meta task-board__card-meta--owner">
                               <span className="task-board__label">Owner</span>
-                              <span className={`owner-badge owner-badge--${item.ownerPresentation.tone}`}>{item.ownerPresentation.label}</span>
+                              <span
+                                className={`owner-badge owner-badge--${item.ownerPresentation.tone} owner-badge--board`}
+                                title={item.ownerPresentation.label}
+                                aria-label={item.ownerPresentation.detail}
+                              >
+                                {item.ownerPresentation.label}
+                              </span>
                             </div>
                             <div className="task-list-meta">Read-only owner metadata</div>
                           </article>

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -47,7 +47,7 @@ function installTaskFetchMock({ forbidden = false, reassignedOwner = 'qa' } = {}
           { task_id: 'TSK-42', tenant_id: 'tenant-a', title: 'Wire task detail', priority: 'P1', current_stage: 'IMPLEMENT', current_owner: currentOwner, owner: currentOwner ? { actor_id: currentOwner, display_name: currentOwner } : null, blocked: false, closed: false, freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
           { task_id: 'TSK-43', tenant_id: 'tenant-a', title: 'Triage queue drift', priority: 'P2', current_stage: 'TODO', current_owner: null, owner: null, blocked: false, closed: false, freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
           { task_id: 'TSK-44', tenant_id: 'tenant-a', title: 'Stale owner reference', priority: 'P3', current_stage: 'REVIEW', current_owner: 'ghost', owner: { actor_id: 'ghost', display_name: 'ghost' }, blocked: false, closed: false, freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
-          { task_id: 'TSK-45', tenant_id: 'tenant-a', title: 'Restricted owner surface', priority: 'P2', current_stage: 'TODO', current_owner: 'masked', owner: { actor_id: 'masked', display_name: '' }, blocked: false, closed: false, freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
+          { task_id: 'TSK-45', tenant_id: 'tenant-a', title: 'Restricted owner surface', priority: 'P2', current_stage: 'TODO', current_owner: 'masked', owner: { actor_id: 'masked', display_name: '', redacted: true }, blocked: false, closed: false, freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
         ],
       });
     }
@@ -199,12 +199,26 @@ describe('Task browser runtime coverage', () => {
     expect(screen.getByLabelText('REVIEW column')).toBeInTheDocument();
     expect(screen.getAllByText('Unknown owner').length).toBeGreaterThan(0);
     expect(screen.getByText('Owner hidden')).toBeInTheDocument();
+    expect(screen.getByTitle('Owner hidden')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Owner filter'), { target: { value: '__unassigned__' } });
     await screen.findByText('1 unassigned cards shown.');
     expect(within(screen.getByLabelText('TODO column')).getByText('Triage queue drift')).toBeInTheDocument();
     expect(within(screen.getByLabelText('IMPLEMENT column')).getByText('No matching tasks in this column.')).toBeInTheDocument();
     expect(within(screen.getByLabelText('REVIEW column')).getByText('No matching tasks in this column.')).toBeInTheDocument();
+  });
+
+  it('keeps owner text visible in compressed board layouts without collapsing to blank metadata', async () => {
+    installTaskFetchMock();
+    window.history.pushState({}, '', '/tasks?view=board');
+    window.innerWidth = 375;
+    window.dispatchEvent(new Event('resize'));
+    render(<App />);
+
+    await screen.findByText('4 cards shown.');
+    const ownerBadge = screen.getByTitle('Owner hidden');
+    expect(ownerBadge).toHaveTextContent('Owner hidden');
+    expect(ownerBadge.className).toContain('owner-badge--board');
   });
 
   it('shows updated owner after reassignment and refresh from projected state', async () => {

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -379,9 +379,14 @@ button {
   gap: 12px;
 }
 
+.task-board__card-meta--owner {
+  align-items: flex-start;
+}
+
 .task-board__label {
   color: #64748b;
   font-size: 0.85rem;
+  flex: 0 0 auto;
 }
 
 .task-board__empty {
@@ -430,6 +435,20 @@ button {
   font-size: 0.9rem;
   font-weight: 600;
   border: 1px solid transparent;
+}
+
+.owner-badge--board {
+  justify-content: flex-end;
+  max-width: min(100%, 15rem);
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-align: right;
+  line-height: 1.3;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  display: -webkit-inline-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .owner-badge--assigned {
@@ -485,5 +504,18 @@ button {
 
   .session-meta {
     grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .task-board__card-meta {
+    display: grid;
+    gap: 6px;
+  }
+
+  .owner-badge--board {
+    max-width: 100%;
+    justify-content: flex-start;
+    text-align: left;
   }
 }

--- a/src/app/task-owner.js
+++ b/src/app/task-owner.js
@@ -1,0 +1,64 @@
+export const UNASSIGNED_FILTER_VALUE = '__unassigned__';
+export const STAGE_ORDER = ['BACKLOG', 'TODO', 'IMPLEMENT', 'IN_PROGRESS', 'REVIEW', 'VERIFY', 'DONE', 'REOPEN'];
+
+export function mapAgentOptions(items = []) {
+  return items.map((agent) => ({
+    id: agent.id,
+    label: `${agent.display_name}${agent.role ? ` · ${agent.role}` : ''}`,
+  }));
+}
+
+function isOwnerExplicitlyHidden(owner) {
+  if (!owner || typeof owner !== 'object') return false;
+  return owner.redacted === true || owner.visibility === 'hidden' || owner.policy_state === 'hidden';
+}
+
+export function resolveOwnerPresentation(item, agentLookup) {
+  if (!item.current_owner) {
+    return { label: 'Unassigned', detail: 'No owner assigned', tone: 'unassigned', filterValue: UNASSIGNED_FILTER_VALUE };
+  }
+
+  const agent = agentLookup.get(item.current_owner);
+  if (agent) {
+    return { label: agent.label, detail: `Owner: ${agent.label}`, tone: 'assigned', filterValue: item.current_owner };
+  }
+
+  if (isOwnerExplicitlyHidden(item.owner)) {
+    return { label: 'Owner hidden', detail: 'Owner identity is intentionally redacted on this surface', tone: 'fallback', filterValue: item.current_owner };
+  }
+
+  return { label: 'Unknown owner', detail: `Owner record unavailable for ${item.current_owner}`, tone: 'fallback', filterValue: item.current_owner };
+}
+
+export function filterTaskList(items, ownerFilter) {
+  if (!ownerFilter) return items;
+  if (ownerFilter === UNASSIGNED_FILTER_VALUE) return items.filter((item) => !item.current_owner);
+  return items.filter((item) => item.current_owner === ownerFilter);
+}
+
+export function summarizeListResults(count, ownerFilter, agentLookup, view = 'list') {
+  const noun = view === 'board' ? 'cards' : 'tasks';
+  if (!ownerFilter) return `${count} ${noun} shown.`;
+  if (ownerFilter === UNASSIGNED_FILTER_VALUE) return `${count} unassigned ${noun} shown.`;
+  return `${count} ${noun} shown for ${agentLookup.get(ownerFilter)?.label || ownerFilter}.`;
+}
+
+export function compareStageName(a, b) {
+  const left = STAGE_ORDER.indexOf(a);
+  const right = STAGE_ORDER.indexOf(b);
+  if (left === -1 && right === -1) return a.localeCompare(b);
+  if (left === -1) return 1;
+  if (right === -1) return -1;
+  return left - right;
+}
+
+export function buildBoardColumns(allItems, visibleItems, agentLookup) {
+  const visibleById = new Set(visibleItems.map((item) => item.task_id));
+  const stages = Array.from(new Set(allItems.map((item) => item.current_stage || 'Unspecified'))).sort(compareStageName);
+  return stages.map((stage) => ({
+    stage,
+    items: allItems
+      .filter((item) => (item.current_stage || 'Unspecified') === stage && visibleById.has(item.task_id))
+      .map((item) => ({ ...item, ownerPresentation: resolveOwnerPresentation(item, agentLookup) })),
+  }));
+}

--- a/tests/e2e/board-owner-filtering.e2e.test.js
+++ b/tests/e2e/board-owner-filtering.e2e.test.js
@@ -1,0 +1,104 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+const fixture = require('../fixtures/board-owner/board-owner-states.json');
+const { createAuditApiServer } = require('../../lib/audit/http');
+
+function sign(payload, secret) {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto.createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+function authHeaders(secret, roles, overrides = {}) {
+  return {
+    authorization: `Bearer ${sign({ sub: 'board-e2e-tester', tenant_id: fixture.tenant_id, roles, exp: Math.floor(Date.now() / 1000) + 60, ...overrides }, secret)}`,
+  };
+}
+
+async function withServer(run) {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'board-owner-e2e-'));
+  const secret = 'board-owner-e2e-secret';
+  const { server } = createAuditApiServer({ baseDir, jwtSecret: secret });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+
+  try {
+    await run({ baseUrl: `http://127.0.0.1:${port}`, secret });
+  } finally {
+    await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+  }
+}
+
+async function createTask(baseUrl, secret, task) {
+  const response = await fetch(`${baseUrl}/tasks/${task.task_id}/events`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...authHeaders(secret, fixture.roles.writer),
+    },
+    body: JSON.stringify({
+      eventType: 'task.created',
+      actorType: 'agent',
+      idempotencyKey: `create:${task.task_id}`,
+      payload: { title: task.title, initial_stage: task.initial_stage, priority: task.priority },
+    }),
+  });
+  assert.equal(response.status, 202);
+}
+
+async function assignTask(baseUrl, secret, taskId, owner) {
+  const response = await fetch(`${baseUrl}/tasks/${taskId}/assignment`, {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+      ...authHeaders(secret, fixture.roles.manager),
+    },
+    body: JSON.stringify({ agentId: owner }),
+  });
+  assert.equal(response.status, 200);
+}
+
+test('e2e: board owner slice keeps owner-bearing projected data stable for board filtering and refresh', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    for (const task of fixture.tasks.slice(0, 3)) {
+      await createTask(baseUrl, secret, task);
+      if (task.assigned_owner) await assignTask(baseUrl, secret, task.task_id, task.assigned_owner);
+    }
+
+    let response = await fetch(`${baseUrl}/tasks`, { headers: authHeaders(secret, fixture.roles.reader) });
+    assert.equal(response.status, 200);
+    let list = await response.json();
+    assert.equal(list.items.length, 3);
+
+    const byStage = new Map(list.items.map(item => [item.task_id, { owner: item.current_owner, stage: item.current_stage }]));
+    assert.deepEqual(byStage.get('TSK-BOARD-1'), { owner: 'qa', stage: 'IMPLEMENT' });
+    assert.deepEqual(byStage.get('TSK-BOARD-2'), { owner: null, stage: 'TODO' });
+    assert.deepEqual(byStage.get('TSK-BOARD-3'), { owner: 'engineer', stage: 'REVIEW' });
+
+    const unassignedOnly = list.items.filter(item => item.current_owner === null);
+    assert.deepEqual(unassignedOnly.map(item => item.task_id), ['TSK-BOARD-2']);
+
+    await assignTask(baseUrl, secret, 'TSK-BOARD-3', fixture.tasks.find(task => task.task_id === 'TSK-BOARD-3').reassigned_owner);
+
+    response = await fetch(`${baseUrl}/tasks`, { headers: authHeaders(secret, fixture.roles.reader) });
+    assert.equal(response.status, 200);
+    list = await response.json();
+    const refreshed = list.items.find(item => item.task_id === 'TSK-BOARD-3');
+    assert.equal(refreshed.current_owner, 'qa');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-BOARD-1/assignment`, {
+      method: 'PATCH',
+      headers: {
+        'content-type': 'application/json',
+        ...authHeaders(secret, fixture.roles.reader),
+      },
+      body: JSON.stringify({ agentId: null }),
+    });
+    assert.equal(response.status, 403);
+  });
+});

--- a/tests/fixtures/board-owner/board-owner-states.json
+++ b/tests/fixtures/board-owner/board-owner-states.json
@@ -1,0 +1,53 @@
+{
+  "tenant_id": "tenant-board-owner",
+  "agents": [
+    { "id": "qa", "display_name": "QA Engineer", "role": "QA", "active": true },
+    { "id": "engineer", "display_name": "Engineer", "role": "Engineering", "active": true },
+    { "id": "architect", "display_name": "Principal Architect With A Very Long Display Name", "role": "Architecture", "active": true }
+  ],
+  "tasks": [
+    {
+      "task_id": "TSK-BOARD-1",
+      "title": "Board owned task",
+      "initial_stage": "IMPLEMENT",
+      "priority": "P1",
+      "assigned_owner": "qa"
+    },
+    {
+      "task_id": "TSK-BOARD-2",
+      "title": "Board unassigned task",
+      "initial_stage": "TODO",
+      "priority": "P2",
+      "assigned_owner": null
+    },
+    {
+      "task_id": "TSK-BOARD-3",
+      "title": "Board reassigned task",
+      "initial_stage": "REVIEW",
+      "priority": "P3",
+      "assigned_owner": "engineer",
+      "reassigned_owner": "qa"
+    },
+    {
+      "task_id": "TSK-BOARD-4",
+      "title": "Board stale owner task",
+      "initial_stage": "BACKLOG",
+      "priority": "P2",
+      "assigned_owner": "ghost",
+      "owner": { "actor_id": "ghost", "display_name": "ghost" }
+    },
+    {
+      "task_id": "TSK-BOARD-5",
+      "title": "Board hidden owner task",
+      "initial_stage": "TODO",
+      "priority": "P2",
+      "assigned_owner": "masked",
+      "owner": { "actor_id": "masked", "display_name": "", "redacted": true }
+    }
+  ],
+  "roles": {
+    "writer": ["contributor"],
+    "reader": ["reader"],
+    "manager": ["pm"]
+  }
+}

--- a/tests/integration/board-owner-filtering.integration.test.js
+++ b/tests/integration/board-owner-filtering.integration.test.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import fixture from '../fixtures/board-owner/board-owner-states.json';
+import { App } from '../../src/app/App';
+import { clearBrowserSessionConfig, writeBrowserSessionConfig } from '../../src/app/session';
+
+function createJsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
+
+function buildTaskItems(currentOwnerByTask) {
+  return fixture.tasks.map((task) => ({
+    task_id: task.task_id,
+    tenant_id: fixture.tenant_id,
+    title: task.title,
+    priority: task.priority,
+    current_stage: task.initial_stage,
+    current_owner: currentOwnerByTask[task.task_id],
+    owner: task.owner ?? (currentOwnerByTask[task.task_id] ? { actor_id: currentOwnerByTask[task.task_id], display_name: currentOwnerByTask[task.task_id] } : null),
+    blocked: false,
+    closed: false,
+    freshness: { status: 'fresh', last_updated_at: '2026-04-02T12:00:00.000Z' },
+  }));
+}
+
+function installBoardFetchMock() {
+  const currentOwnerByTask = Object.fromEntries(fixture.tasks.map((task) => [task.task_id, task.assigned_owner]));
+
+  const fetchMock = vi.fn(async (input, init) => {
+    const url = String(input);
+
+    if (url.endsWith('/ai-agents')) return createJsonResponse({ items: fixture.agents });
+    if (url.endsWith('/tasks') && (!init || !init.method || init.method === 'GET')) return createJsonResponse({ items: buildTaskItems(currentOwnerByTask) });
+
+    if (url.endsWith('/tasks/TSK-BOARD-3/assignment')) {
+      currentOwnerByTask['TSK-BOARD-3'] = fixture.tasks.find((task) => task.task_id === 'TSK-BOARD-3').reassigned_owner;
+      return createJsonResponse({ success: true, data: { taskId: 'TSK-BOARD-3', owner: { agentId: 'qa', displayName: 'QA Engineer', role: 'QA' } } });
+    }
+
+    if (url.endsWith('/tasks/TSK-BOARD-3')) {
+      return createJsonResponse({
+        task_id: 'TSK-BOARD-3',
+        tenant_id: fixture.tenant_id,
+        title: 'Board reassigned task',
+        priority: 'P3',
+        current_stage: 'REVIEW',
+        current_owner: currentOwnerByTask['TSK-BOARD-3'],
+        blocked: false,
+        waiting_state: null,
+        next_required_action: null,
+        freshness: { status: 'fresh', last_updated_at: '2026-04-02T12:00:00.000Z' },
+        status_indicator: 'fresh',
+        closed: false,
+      });
+    }
+
+    if (url.includes('/tasks/TSK-BOARD-3/history')) return createJsonResponse({ items: [], page_info: { next_cursor: null } });
+    if (url.endsWith('/tasks/TSK-BOARD-3/observability-summary')) {
+      return createJsonResponse({ status: 'ok', degraded: false, stale: false, event_count: 0, last_updated_at: '2026-04-02T12:00:00.000Z', freshness: { status: 'fresh', last_updated_at: '2026-04-02T12:00:00.000Z' }, correlation: { approved_correlation_ids: [] }, access: { restricted: false, omission_applied: false, omitted_fields: [] } });
+    }
+
+    throw new Error(`Unhandled fetch URL in integration test: ${url}`);
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+}
+
+describe('board owner filtering integration', () => {
+  beforeEach(() => {
+    clearBrowserSessionConfig();
+    window.history.pushState({}, '', '/tasks?view=board');
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('filters the board by owner, preserves empty columns, and refreshes reassignment visibility after reload', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: 'header.eyJzdWIiOiJwbS0xIiwidGVuYW50X2lkIjoidGVuYW50LWJvYXJkLW93bmVyIiwicm9sZXMiOlsicG0iXX0.signature',
+    });
+    installBoardFetchMock();
+    render(React.createElement(App));
+
+    await screen.findByText('5 cards shown.');
+    expect(screen.getByText('Owner hidden')).toBeInTheDocument();
+    expect(screen.getByText('Unknown owner')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Owner filter'), { target: { value: '__unassigned__' } });
+    await screen.findByText('1 unassigned cards shown.');
+    expect(within(screen.getByLabelText('TODO column')).getByText('Board unassigned task')).toBeInTheDocument();
+    expect(within(screen.getByLabelText('IMPLEMENT column')).getByText('No matching tasks in this column.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filter' }));
+    await screen.findByText('5 cards shown.');
+
+    fireEvent.click(screen.getByText('Board reassigned task'));
+    await screen.findByRole('heading', { name: 'Board reassigned task' });
+    fireEvent.change(screen.getByLabelText('Owner'), { target: { value: 'qa' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save owner' }));
+    await screen.findByText('Assigned to qa.');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Task list' }));
+    fireEvent.click(screen.getByRole('tab', { name: 'Board' }));
+    await screen.findByText('5 cards shown.');
+    expect(screen.getAllByText('QA Engineer · QA').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/board-owner-card-rendering.test.js
+++ b/tests/unit/board-owner-card-rendering.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { buildBoardColumns, mapAgentOptions, resolveOwnerPresentation, UNASSIGNED_FILTER_VALUE } from '../../src/app/task-owner';
+import fixture from '../fixtures/board-owner/board-owner-states.json';
+
+const agentLookup = new Map(mapAgentOptions(fixture.agents).map((agent) => [agent.id, agent]));
+
+describe('board owner card rendering', () => {
+  it('renders assigned, unassigned, unknown, and explicitly hidden owner states with stable labels', () => {
+    const owned = resolveOwnerPresentation({ current_owner: 'qa', owner: { actor_id: 'qa', display_name: 'qa' } }, agentLookup);
+    const unassigned = resolveOwnerPresentation({ current_owner: null, owner: null }, agentLookup);
+    const unknown = resolveOwnerPresentation({ current_owner: 'ghost', owner: { actor_id: 'ghost', display_name: '' } }, agentLookup);
+    const hidden = resolveOwnerPresentation({ current_owner: 'masked', owner: { actor_id: 'masked', display_name: '', redacted: true } }, agentLookup);
+
+    expect(owned.label).toBe('QA Engineer · QA');
+    expect(unassigned).toMatchObject({ label: 'Unassigned', tone: 'unassigned', filterValue: UNASSIGNED_FILTER_VALUE });
+    expect(unknown.label).toBe('Unknown owner');
+    expect(hidden.label).toBe('Owner hidden');
+    expect(hidden.detail).toContain('intentionally redacted');
+  });
+
+  it('builds board columns with owner presentation attached to every visible card', () => {
+    const visibleItems = fixture.tasks.map((task) => ({
+      task_id: task.task_id,
+      title: task.title,
+      current_stage: task.initial_stage,
+      priority: task.priority,
+      current_owner: task.assigned_owner,
+      owner: task.owner ?? (task.assigned_owner ? { actor_id: task.assigned_owner, display_name: task.assigned_owner } : null),
+    }));
+
+    const columns = buildBoardColumns(visibleItems, visibleItems, agentLookup);
+    const cards = columns.flatMap((column) => column.items);
+
+    expect(columns.map((column) => column.stage)).toEqual(['BACKLOG', 'TODO', 'IMPLEMENT', 'REVIEW']);
+    expect(cards).toHaveLength(5);
+    expect(cards.every((card) => card.ownerPresentation && typeof card.ownerPresentation.label === 'string')).toBe(true);
+    expect(cards.find((card) => card.task_id === 'TSK-BOARD-5').ownerPresentation.label).toBe('Owner hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only board view on `/tasks` using the canonical projected task owner/state data
- surface owner metadata on board cards with exact fallback states and board-wide owner filtering
- preserve board column structure, responsive horizontal scrolling, and accessibility/status behavior

## Validation
- npm run test:ui
- npm run build

## Links
- Closes #34
- Follow-up to #31
