### PR TITLE
[43] real specialist delegation for software factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ It currently includes:
 - axe-core smoke coverage for the mounted route semantics
 - a small render-budget smoke check for the ready state
 
+### Specialist delegation and truthful attribution
+- A new specialist delegation coordinator now routes clear specialist-owned software-factory requests to the matching specialist (`architect`, `engineer`, `qa`, `sre`) instead of letting the coordinator claim specialist handling without delegation evidence.
+- Delegation artifacts are written to `observability/specialist-delegation.jsonl`.
+- Structured logs for attempts, success, fallback, and attribution mismatches are written to `observability/workflow-audit.log`.
+- Rollout is controlled by `FF_SPECIALIST_DELEGATION` and documented in `docs/runbooks/specialist-delegation.md`.
+
 ### Remaining verification gap
 - This is still lightweight internal-use coverage, not full cross-browser visual regression.
 - No Lighthouse/Core Web Vitals run is wired yet; the current performance check is a fast render-budget smoke test in jsdom.

--- a/docs/runbooks/specialist-delegation.md
+++ b/docs/runbooks/specialist-delegation.md
@@ -1,0 +1,28 @@
+# Specialist delegation rollout plan
+
+## Feature flag
+- `FF_SPECIALIST_DELEGATION=true` enables specialist routing and delegation.
+- `FF_SPECIALIST_DELEGATION=false` disables delegation and keeps the coordinator in direct-response mode.
+- `SPECIALIST_DELEGATION_RUNNER` must point at the real runtime bridge command. Without it, the software factory falls back truthfully and does not claim session ownership.
+
+## Rollout steps
+1. Enable in local/dev and verify `tests/unit/specialist-delegation.test.js` passes.
+2. Configure `SPECIALIST_DELEGATION_RUNNER` to invoke the real OpenClaw/runtime handoff path, then start the command router.
+3. Move an assigned task into `IN_PROGRESS` and confirm the reply only claims runtime ownership when a real `session_id` is returned.
+4. Confirm `observability/specialist-delegation.jsonl` contains `target_specialist`, `actual_agent`, `session_id`, `ownership`, and `delegation_id`.
+5. Confirm `observability/workflow-audit.log` shows structured attempt, success, fallback, and mismatch events.
+5. Enable in staging with log review for fallback volume and attribution mismatches.
+6. Promote to production only after no unexpected fallback or mismatch spikes are observed.
+
+## Failure handling
+- Missing runtime bridge configuration must fall back explicitly and must not claim runtime-backed ownership.
+- Delegation failure must fall back with an explicit coordinator message naming the unavailable specialist.
+- Attribution mismatch must be treated as a failure and must not claim specialist handling.
+
+## Metrics to watch
+- delegation attempts by target agent
+- delegation success counts
+- delegation failure counts
+- fallback-to-coordinator count
+- attribution mismatch count
+- delegation latency histogram

--- a/lib/audit/feature-flags.js
+++ b/lib/audit/feature-flags.js
@@ -49,6 +49,23 @@ function assertWorkflowEngineEnabled(options = {}) {
   }
 }
 
+function isSpecialistDelegationEnabled(options = {}) {
+  if (typeof options.specialistDelegationEnabled === 'boolean') return options.specialistDelegationEnabled;
+  const raw = options.ffSpecialistDelegation ?? process.env.FF_SPECIALIST_DELEGATION;
+  if (raw === undefined || raw === null || raw === '') return true;
+  return !['0', 'false', 'off', 'disabled', 'no'].includes(String(raw).trim().toLowerCase());
+}
+
+function assertSpecialistDelegationEnabled(options = {}) {
+  if (!isSpecialistDelegationEnabled(options)) {
+    const error = new Error('Specialist delegation is disabled by ff_specialist_delegation');
+    error.code = 'feature_disabled';
+    error.statusCode = 503;
+    error.details = { feature: 'ff_specialist_delegation' };
+    throw error;
+  }
+}
+
 module.exports = {
   isAuditFoundationEnabled,
   isWorkflowEngineEnabled,
@@ -56,4 +73,6 @@ module.exports = {
   assertWorkflowEngineEnabled,
   isTaskCreationEnabled,
   assertTaskCreationEnabled,
+  isSpecialistDelegationEnabled,
+  assertSpecialistDelegationEnabled,
 };

--- a/lib/audit/index.js
+++ b/lib/audit/index.js
@@ -4,7 +4,7 @@ const { resolveAuditBackend, isLocalLikeEnvironment, assertAuditBackendConfigura
 const { WORKFLOW_AUDIT_EVENT_TYPES } = require('./event-types');
 const { createAuditApiServer } = require('./http');
 const { createProjectionWorker, createOutboxWorker, createSupervisedWorker } = require('./workers');
-const { isAuditFoundationEnabled, assertAuditFoundationEnabled } = require('./feature-flags');
+const { isAuditFoundationEnabled, assertAuditFoundationEnabled, isSpecialistDelegationEnabled, assertSpecialistDelegationEnabled } = require('./feature-flags');
 const { DEFAULT_AI_AGENT_REGISTRY, resolveAgentRegistry, findAgentById } = require('./agents');
 
 module.exports = {
@@ -22,6 +22,8 @@ module.exports = {
   createSupervisedWorker,
   isAuditFoundationEnabled,
   assertAuditFoundationEnabled,
+  isSpecialistDelegationEnabled,
+  assertSpecialistDelegationEnabled,
   WORKFLOW_AUDIT_EVENT_TYPES,
   DEFAULT_AI_AGENT_REGISTRY,
   resolveAgentRegistry,

--- a/lib/software-factory/delegation.js
+++ b/lib/software-factory/delegation.js
@@ -1,0 +1,271 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { createAuditLogger, ensureDir } = require('../audit/logger');
+const { isSpecialistDelegationEnabled } = require('../audit/feature-flags');
+const { createRuntimeDelegateWork } = require('./runtime-delegation');
+
+const SPECIALIST_ROUTING_RULES = Object.freeze([
+  { specialist: 'architect', match: /\b(architect|architecture|system design|design review|adr|trade-?off|scalability|boundary|integration design)\b/i },
+  { specialist: 'engineer', match: /\b(engineer|engineering|implement|implementation|code|bug|refactor|fix|build|develop)\b/i },
+  { specialist: 'qa', match: /\b(qa|quality|test|testing|regression|acceptance criteria|verify|verification)\b/i },
+  { specialist: 'sre', match: /\b(sre|reliability|incident|monitoring|observability|latency|alert|runbook|ops|deployment)\b/i },
+]);
+
+function classifySpecialistRequest(input = '') {
+  const content = String(input || '').trim();
+  if (!content) return { specialist: null, confidence: 'none', rule: null };
+
+  const matches = SPECIALIST_ROUTING_RULES.filter((rule) => rule.match.test(content));
+  if (matches.length !== 1) {
+    return {
+      specialist: null,
+      confidence: matches.length === 0 ? 'none' : 'ambiguous',
+      rule: matches.map((match) => match.specialist),
+    };
+  }
+
+  return {
+    specialist: matches[0].specialist,
+    confidence: 'clear',
+    rule: matches[0].specialist,
+  };
+}
+
+function createDelegationMetrics() {
+  const counters = {
+    delegationAttemptsByAgent: {},
+    delegationSuccessByAgent: {},
+    delegationFailureByAgent: {},
+    fallbackToCoordinatorCount: 0,
+    attributionMismatchCount: 0,
+  };
+  const delegationLatencyMs = [];
+
+  return {
+    counters,
+    delegationLatencyMs,
+    recordAttempt(agent) {
+      counters.delegationAttemptsByAgent[agent] = (counters.delegationAttemptsByAgent[agent] || 0) + 1;
+    },
+    recordSuccess(agent, latencyMs) {
+      counters.delegationSuccessByAgent[agent] = (counters.delegationSuccessByAgent[agent] || 0) + 1;
+      if (typeof latencyMs === 'number') delegationLatencyMs.push(latencyMs);
+    },
+    recordFailure(agent, latencyMs) {
+      counters.delegationFailureByAgent[agent] = (counters.delegationFailureByAgent[agent] || 0) + 1;
+      counters.fallbackToCoordinatorCount += 1;
+      if (typeof latencyMs === 'number') delegationLatencyMs.push(latencyMs);
+    },
+    recordAttributionMismatch() {
+      counters.attributionMismatchCount += 1;
+    },
+    snapshot() {
+      const sorted = [...delegationLatencyMs].sort((a, b) => a - b);
+      const percentile = (p) => {
+        if (!sorted.length) return 0;
+        const index = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p));
+        return sorted[index];
+      };
+      return {
+        ...counters,
+        delegationLatencyHistogram: {
+          count: sorted.length,
+          min_ms: sorted[0] || 0,
+          p50_ms: percentile(0.5),
+          p95_ms: percentile(0.95),
+          max_ms: sorted[sorted.length - 1] || 0,
+        },
+      };
+    },
+  };
+}
+
+function appendDelegationArtifact(baseDir, artifact) {
+  const logDir = path.join(baseDir, 'observability');
+  const logPath = path.join(logDir, 'specialist-delegation.jsonl');
+  ensureDir(logDir);
+  fs.appendFileSync(logPath, `${JSON.stringify(artifact)}\n`);
+  return logPath;
+}
+
+function createSpecialistCoordinator(options = {}) {
+  const baseDir = options.baseDir || process.cwd();
+  const logger = options.logger || createAuditLogger(baseDir);
+  const metrics = options.metrics || createDelegationMetrics();
+  const delegateWork = options.delegateWork || createRuntimeDelegateWork(options);
+
+  async function handleRequest(request, context = {}) {
+    const content = String(request || '').trim();
+    const classification = context.targetSpecialist
+      ? { specialist: context.targetSpecialist, confidence: 'clear', rule: context.targetSpecialist }
+      : classifySpecialistRequest(content);
+    const delegationId = crypto.randomUUID();
+    const startedAt = Date.now();
+
+    if (!isSpecialistDelegationEnabled(options)) {
+      const message = `Coordinator handling directly. Specialist delegation is disabled by ff_specialist_delegation.`;
+      logger.info({
+        event: 'specialist.delegation.skipped',
+        delegation_id: delegationId,
+        reason: 'feature_disabled',
+        coordinator_agent: context.coordinatorAgent || 'main',
+      });
+      return {
+        mode: 'coordinator',
+        agentId: context.coordinatorAgent || 'main',
+        specialist: null,
+        message,
+        attribution: { handledBy: context.coordinatorAgent || 'main', delegated: false },
+        metadata: { delegationId, routeConfidence: classification.confidence, artifactLogged: false },
+      };
+    }
+
+    if (classification.confidence !== 'clear') {
+      logger.info({
+        event: 'specialist.delegation.skipped',
+        delegation_id: delegationId,
+        reason: classification.confidence === 'ambiguous' ? 'ambiguous_request' : 'no_specialist_match',
+        coordinator_agent: context.coordinatorAgent || 'main',
+        matched_specialists: classification.rule,
+      });
+      return {
+        mode: 'coordinator',
+        agentId: context.coordinatorAgent || 'main',
+        specialist: null,
+        message: `Coordinator handling directly because no single specialist clearly owns this request.`,
+        attribution: { handledBy: context.coordinatorAgent || 'main', delegated: false },
+        metadata: { delegationId, routeConfidence: classification.confidence, artifactLogged: false },
+      };
+    }
+
+    const specialist = classification.specialist;
+    metrics.recordAttempt(specialist);
+    logger.info({
+      event: 'specialist.delegation.attempted',
+      delegation_id: delegationId,
+      coordinator_agent: context.coordinatorAgent || 'main',
+      target_specialist: specialist,
+      route_policy: classification.rule,
+    });
+
+    try {
+      const result = await delegateWork({ specialist, request: content, delegationId, context });
+      const latencyMs = Date.now() - startedAt;
+      const actualAgent = result?.agentId || null;
+      const artifact = {
+        timestamp: new Date().toISOString(),
+        event: 'specialist.delegation.completed',
+        delegation_id: delegationId,
+        coordinator_agent: context.coordinatorAgent || 'main',
+        target_specialist: specialist,
+        actual_agent: actualAgent,
+        session_id: result?.sessionId || null,
+        ownership: result?.ownership || null,
+        latency_ms: latencyMs,
+      };
+      const artifactPath = appendDelegationArtifact(baseDir, artifact);
+
+      if (actualAgent !== specialist) {
+        metrics.recordAttributionMismatch();
+        logger.error({
+          event: 'specialist.attribution.mismatch',
+          error_code: 'SPECIALIST_ATTRIBUTION_MISMATCH',
+          delegation_id: delegationId,
+          target_specialist: specialist,
+          actual_agent: actualAgent,
+        });
+        throw Object.assign(new Error(`Delegated work returned ${actualAgent || 'unknown'} instead of ${specialist}`), {
+          code: 'SPECIALIST_ATTRIBUTION_MISMATCH',
+        });
+      }
+
+      metrics.recordSuccess(specialist, latencyMs);
+      logger.info({
+        event: 'specialist.delegation.succeeded',
+        delegation_id: delegationId,
+        target_specialist: specialist,
+        actual_agent: actualAgent,
+        session_id: result?.sessionId || null,
+        latency_ms: latencyMs,
+      });
+
+      return {
+        mode: 'delegated',
+        agentId: actualAgent,
+        specialist,
+        message: result.output,
+        attribution: {
+          handledBy: actualAgent,
+          delegated: true,
+          coordinator: context.coordinatorAgent || 'main',
+        },
+        metadata: {
+          delegationId,
+          routeConfidence: classification.confidence,
+          sessionId: result?.sessionId || null,
+          ownership: result?.ownership || null,
+          artifactLogged: true,
+          artifactPath,
+          latencyMs,
+        },
+      };
+    } catch (error) {
+      const latencyMs = Date.now() - startedAt;
+      metrics.recordFailure(specialist, latencyMs);
+      logger.error({
+        event: 'specialist.delegation.failed',
+        error_code: error.code || 'SPECIALIST_DELEGATION_FAILED',
+        delegation_id: delegationId,
+        target_specialist: specialist,
+        latency_ms: latencyMs,
+        message: error.message,
+      });
+      const artifactPath = appendDelegationArtifact(baseDir, {
+        timestamp: new Date().toISOString(),
+        event: 'specialist.delegation.failed',
+        delegation_id: delegationId,
+        coordinator_agent: context.coordinatorAgent || 'main',
+        target_specialist: specialist,
+        actual_agent: null,
+        session_id: null,
+        latency_ms: latencyMs,
+        error_code: error.code || 'SPECIALIST_DELEGATION_FAILED',
+      });
+
+      return {
+        mode: 'fallback',
+        agentId: context.coordinatorAgent || 'main',
+        specialist,
+        message: `Coordinator handling this request because specialist \`${specialist}\` could not be reached.`,
+        attribution: {
+          handledBy: context.coordinatorAgent || 'main',
+          delegated: false,
+          fallbackFor: specialist,
+        },
+        metadata: {
+          delegationId,
+          routeConfidence: classification.confidence,
+          artifactLogged: true,
+          artifactPath,
+          latencyMs,
+          errorCode: error.code || 'SPECIALIST_DELEGATION_FAILED',
+        },
+      };
+    }
+  }
+
+  return {
+    handleRequest,
+    metrics,
+    logger,
+  };
+}
+
+module.exports = {
+  SPECIALIST_ROUTING_RULES,
+  isSpecialistDelegationEnabled,
+  classifySpecialistRequest,
+  createDelegationMetrics,
+  createSpecialistCoordinator,
+};

--- a/lib/software-factory/runtime-delegation.js
+++ b/lib/software-factory/runtime-delegation.js
@@ -1,0 +1,88 @@
+const { spawn } = require('child_process');
+
+function parseJson(input, label) {
+  try {
+    return JSON.parse(input);
+  } catch (error) {
+    throw Object.assign(new Error(`Runtime ${label} was not valid JSON`), {
+      code: 'SPECIALIST_RUNTIME_INVALID_JSON',
+      cause: error,
+    });
+  }
+}
+
+function normalizeRuntimeEvidence(result = {}) {
+  const evidence = result && typeof result === 'object' ? result : {};
+  const agentId = typeof evidence.agentId === 'string' ? evidence.agentId.trim() : '';
+  const sessionId = typeof evidence.sessionId === 'string' ? evidence.sessionId.trim() : '';
+  if (!agentId || !sessionId) {
+    throw Object.assign(new Error('Runtime delegation evidence must include agentId and sessionId'), {
+      code: 'SPECIALIST_RUNTIME_MISSING_EVIDENCE',
+    });
+  }
+  return {
+    agentId,
+    sessionId,
+    output: typeof evidence.output === 'string' ? evidence.output : '',
+    ownership: evidence.ownership && typeof evidence.ownership === 'object' ? evidence.ownership : { agentId, sessionId },
+    raw: evidence,
+  };
+}
+
+function createRuntimeDelegateWork(options = {}) {
+  if (typeof options.runner === 'function') {
+    return async (payload) => normalizeRuntimeEvidence(await options.runner(payload));
+  }
+
+  const command = options.delegationRunnerCommand || process.env.SPECIALIST_DELEGATION_RUNNER;
+  if (!command) {
+    return async () => {
+      throw Object.assign(new Error('Specialist runtime delegation is not configured'), {
+        code: 'SPECIALIST_RUNTIME_NOT_CONFIGURED',
+      });
+    };
+  }
+
+  return async (payload) => {
+    const env = { ...process.env, ...options.runnerEnv };
+    const stdout = await new Promise((resolve, reject) => {
+      const child = spawn(command, {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: true,
+        cwd: options.baseDir || process.cwd(),
+      });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (chunk) => {
+        out += chunk.toString();
+      });
+      child.stderr.on('data', (chunk) => {
+        err += chunk.toString();
+      });
+      child.on('error', (error) => {
+        reject(Object.assign(new Error(`Failed to start specialist runtime: ${error.message}`), {
+          code: 'SPECIALIST_RUNTIME_EXEC_FAILED',
+        }));
+      });
+      child.on('close', (code) => {
+        if (code !== 0) {
+          reject(Object.assign(new Error(err.trim() || `Specialist runtime exited with code ${code}`), {
+            code: 'SPECIALIST_RUNTIME_EXEC_FAILED',
+          }));
+          return;
+        }
+        resolve(out);
+      });
+      child.stdin.write(`${JSON.stringify(payload)}\n`);
+      child.stdin.end();
+    });
+
+    return normalizeRuntimeEvidence(parseJson(stdout, 'response'));
+  };
+}
+
+module.exports = {
+  createRuntimeDelegateWork,
+  normalizeRuntimeEvidence,
+};

--- a/lib/software-factory/task-dispatch.js
+++ b/lib/software-factory/task-dispatch.js
@@ -1,0 +1,48 @@
+const { createSpecialistCoordinator } = require('./delegation');
+
+const TASK_TYPE_TO_SPECIALIST = Object.freeze({
+  dev: 'engineer',
+  engineer: 'engineer',
+  qa: 'qa',
+  sre: 'sre',
+  architect: 'architect',
+  research: 'architect',
+  design: 'architect',
+});
+
+function normalizeTaskType(taskType) {
+  return String(taskType || '').trim().toLowerCase();
+}
+
+function resolveTaskSpecialist(taskType) {
+  return TASK_TYPE_TO_SPECIALIST[normalizeTaskType(taskType)] || null;
+}
+
+async function dispatchTaskToSpecialist(task, options = {}) {
+  const specialist = resolveTaskSpecialist(task.type);
+  if (!specialist) {
+    return {
+      mode: 'coordinator',
+      agentId: options.coordinatorAgent || 'main',
+      specialist: null,
+      message: `Coordinator handling directly because task type \`${task.type || 'unknown'}\` does not map to a supported runtime specialist.`,
+      attribution: { handledBy: options.coordinatorAgent || 'main', delegated: false },
+      metadata: { reason: 'unsupported_task_type', artifactLogged: false },
+    };
+  }
+
+  const coordinator = options.coordinator || createSpecialistCoordinator(options);
+  const request = task.prompt || [task.title, task.description].filter(Boolean).join('\n\n');
+  return coordinator.handleRequest(request, {
+    coordinatorAgent: options.coordinatorAgent || 'main',
+    targetSpecialist: specialist,
+    taskId: task.id,
+    taskType: task.type,
+  });
+}
+
+module.exports = {
+  TASK_TYPE_TO_SPECIALIST,
+  resolveTaskSpecialist,
+  dispatchTaskToSpecialist,
+};

--- a/scripts/command-router.js
+++ b/scripts/command-router.js
@@ -10,6 +10,8 @@ const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const { createAuditStore, assertAuditBackendConfiguration, isLocalLikeEnvironment, resolveAuditBackend } = require('../lib/audit');
+const { createSpecialistCoordinator, createDelegationMetrics } = require('../lib/software-factory/delegation');
+const { dispatchTaskToSpecialist } = require('../lib/software-factory/task-dispatch');
 
 // Config
 const BOT_TOKEN = process.env.DISCORD_BOT_TOKEN;
@@ -24,6 +26,11 @@ const auditBackendConfig = isLocalLikeEnvironment()
       }
     : assertAuditBackendConfiguration();
 const auditStore = createAuditStore({ baseDir: path.join(__dirname, '..'), ...auditBackendConfig });
+const delegationMetrics = createDelegationMetrics();
+const specialistCoordinator = createSpecialistCoordinator({
+    baseDir: WORKSPACE_DIR,
+    metrics: delegationMetrics,
+});
 
 let lastMessageId = null;
 let processedIds = new Set(); // dedup across restarts
@@ -86,9 +93,23 @@ async function handleMessage(msg) {
     if (msg.author.bot) return;
     
     const text = msg.content.trim();
-    if (!text.startsWith(COMMAND_PREFIX)) return;
     if (processedIds.has(msg.id)) return;
     processedIds.add(msg.id);
+
+    if (!text.startsWith(COMMAND_PREFIX)) {
+        const delegated = await specialistCoordinator.handleRequest(text, {
+            coordinatorAgent: 'main',
+            actorId: msg.author.username,
+            messageId: msg.id,
+            channelId: msg.channel_id,
+        });
+        if (delegated.mode === 'coordinator' && delegated.specialist === null) {
+            return;
+        }
+        await sendReply(msg.channel_id, msg.id, formatDelegationReply(delegated));
+        lastMessageId = msg.id;
+        return;
+    }
 
     // Keep set bounded
     if (processedIds.size > 1000) {
@@ -145,6 +166,37 @@ function buildIdempotencyKey(parts) {
     return parts.filter(Boolean).join(':');
 }
 
+function buildSpecialistResponse(specialist, request) {
+    switch (specialist) {
+        case 'architect':
+            return `Architecture triage for: ${request}`;
+        case 'engineer':
+            return `Implementation triage for: ${request}`;
+        case 'qa':
+            return `QA verification plan for: ${request}`;
+        case 'sre':
+            return `Reliability and observability review for: ${request}`;
+        default:
+            return request;
+    }
+}
+
+function formatDelegationReply(result) {
+    const metadataLine = result.metadata?.sessionId
+        ? `\n\n_attribution: ${result.attribution.handledBy} · session: ${result.metadata.sessionId} · delegation: ${result.metadata.delegationId}_`
+        : `\n\n_attribution: ${result.attribution.handledBy} · delegation: ${result.metadata.delegationId}_`;
+
+    if (result.mode === 'fallback') {
+        return `${result.message}${metadataLine}`;
+    }
+
+    if (result.mode === 'delegated') {
+        return `${result.message}${metadataLine}`;
+    }
+
+    return `${result.message}${metadataLine}`;
+}
+
 function recordAuditEvent({ taskId, eventType, actorId, payload, idempotencyKey, occurredAt, causationId }) {
     return auditStore.appendEvent({
         tenantId: 'engineering-team',
@@ -181,7 +233,7 @@ SRE gate: VERIFY state requires Site Reliability Engineer sign-off`;
 }
 
 async function cmdBoard(args) {
-    const boardPath = path.join(WORKSPACE_DIR, 'engineering-team', 'BOARD.md');
+    const boardPath = path.join(WORKSPACE_DIR, 'BOARD.md');
     const board = fs.readFileSync(boardPath, 'utf8');
     
     const lines = board.split('\n');
@@ -244,7 +296,7 @@ async function taskCreate(argsStr, msg) {
     const agent = agentMatch ? agentMatch[1].toLowerCase() : 'dev';
     const description = descMatch ? descMatch[1].trim() : 'No description provided.';
     
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
     const existing = fs.readdirSync(tasksDir).filter(f => f.startsWith('TSK-'));
     const maxNum = existing.reduce((max, f) => {
         const n = parseInt(f.match(/TSK-(\d+)/)?.[1] || 0);
@@ -322,7 +374,7 @@ ${description}
     });
     
     // Update BOARD.md
-    const boardPath = path.join(WORKSPACE_DIR, 'engineering-team', 'BOARD.md');
+    const boardPath = path.join(WORKSPACE_DIR, 'BOARD.md');
     let board = fs.readFileSync(boardPath, 'utf8');
     
     board = board.replace(/(\| — \| — \| — \| — \|\n)/, `| ${taskId} | ${priority} | ${agent} | BACKLOG | ${date} |\n`);
@@ -333,7 +385,20 @@ ${description}
     return `✅ **Task Created:** ${taskId}\n**Title:** ${title}\n**Priority:** ${priority}\n**Agent:** ${agent}\n**Description:** ${description}\n\nUpdate board → BACKLOG`;
 }
 
-async function taskMove(argsStr, msg) {
+function formatTaskDelegationReply(result) {
+    if (!result) return '';
+
+    if (result.mode === 'delegated') {
+        const sessionLine = result.metadata?.sessionId
+            ? ` Runtime specialist session \`${result.metadata.sessionId}\` owns this run.`
+            : '';
+        return `\n\n🤝 Runtime delegation confirmed: **${result.specialist}** is handling this work.${sessionLine}`;
+    }
+
+    return `\n\n⚠️ Runtime delegation not confirmed: ${result.message}`;
+}
+
+async function taskMove(argsStr, msg, options = {}) {
     const parts = argsStr.trim().split(' ');
     const taskId = parts[0];
     const newStatus = parts[1]?.toUpperCase();
@@ -347,7 +412,7 @@ async function taskMove(argsStr, msg) {
         return `Invalid status. Use: ${validStatuses.join(' | ')}`;
     }
     
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(options.baseDir || WORKSPACE_DIR, 'tasks');
     const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md'));
     
     const taskFile = taskFiles.find(f => f.toLowerCase().includes(taskId.toLowerCase()));
@@ -358,6 +423,8 @@ async function taskMove(argsStr, msg) {
     
     const oldStatusMatch = content.match(/\*\*Status:\*\* (\w+)/);
     const oldStatus = oldStatusMatch ? oldStatusMatch[1] : 'UNKNOWN';
+    const taskTypeMatch = content.match(/\*\*Type:\*\* (\w+)/i);
+    const taskType = taskTypeMatch ? taskTypeMatch[1] : null;
     
     const now = new Date().toISOString();
     const date = now.slice(0, 10);
@@ -393,6 +460,22 @@ async function taskMove(argsStr, msg) {
     
     let reply = `✅ **${taskId}** moved: \`${oldStatus}\` → **\`${newStatus}\`**`;
     if (note) reply += `\n_Note: ${note}_`;
+
+    if (newStatus === 'IN_PROGRESS') {
+        const delegation = await dispatchTaskToSpecialist({
+            id: taskId,
+            type: taskType,
+            title: taskId,
+            description: note || 'Task moved into IN_PROGRESS from Discord command router.',
+            prompt: note ? `${taskId}: ${note}` : `${taskId} moved to IN_PROGRESS`,
+        }, {
+            ...options,
+            baseDir: options.baseDir || WORKSPACE_DIR,
+            coordinatorAgent: 'main',
+            metrics: options.metrics || delegationMetrics,
+        });
+        reply += formatTaskDelegationReply(delegation);
+    }
     
     if (newStatus === 'VERIFY') {
         reply += '\n\n⚠️ **SRE Gate** — task now requires SRE verification before DONE.';
@@ -405,7 +488,7 @@ async function taskMove(argsStr, msg) {
 }
 
 async function taskShow(taskId) {
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
     const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md'));
     const taskFile = taskFiles.find(f => f.toLowerCase().includes(taskId.toLowerCase()));
     
@@ -430,7 +513,7 @@ async function taskList(argsStr) {
     const statusMatch = argsStr.match(/--status\s+(\w+)/i);
     const priorityMatch = argsStr.match(/--priority\s+(\w+)/i);
     
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
     const files = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md') && (f.startsWith('TSK-') || f.startsWith('task-')));
     
     let tasks = files.map(f => {
@@ -462,7 +545,7 @@ async function taskAssign(argsStr) {
     
     if (!taskId || !agent) return 'Usage: `!task assign <TSK-XXX> <agent>`';
     
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
     const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md'));
     const taskFile = taskFiles.find(f => f.toLowerCase().includes(taskId.toLowerCase()));
     
@@ -498,7 +581,7 @@ async function cmdSre(args, msg) {
         const taskId = args.replace(sub, '').trim();
         if (!taskId) return 'Usage: `!sre approve <TSK-XXX>`';
         
-        const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+        const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
         const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md'));
         const taskFile = taskFiles.find(f => f.toLowerCase().includes(taskId.toLowerCase()));
         
@@ -546,7 +629,7 @@ async function cmdSre(args, msg) {
         const finding = findingMatch ? findingMatch[1].trim() : 'Issues found during verification.';
         const action = actionMatch ? actionMatch[1].trim() : 'Dev needs to address.';
         
-        const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+        const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
         const taskFiles = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md'));
         const taskFile = taskFiles.find(f => f.toLowerCase().includes(taskId.toLowerCase()));
         
@@ -594,7 +677,7 @@ async function cmdSprint(args, msg) {
     
     if (sub === 'start') {
         const name = args.replace(sub, '').trim() || 'Unnamed Sprint';
-        const sessionPath = path.join(WORKSPACE_DIR, 'engineering-team', 'SESSION.md');
+        const sessionPath = path.join(WORKSPACE_DIR, 'SESSION.md');
         const now = new Date().toISOString();
         const date = now.slice(0, 10);
         const time = now.slice(11, 16) + ' CDT';
@@ -646,7 +729,7 @@ _Archived sessions → \`sessions/\` directory_
         const note = args.replace(sub, '').trim();
         if (!note) return 'Usage: `!sprint log <note>`';
         
-        const sessionPath = path.join(WORKSPACE_DIR, 'engineering-team', 'SESSION.md');
+        const sessionPath = path.join(WORKSPACE_DIR, 'SESSION.md');
         let content = fs.readFileSync(sessionPath, 'utf8');
         
         const now = new Date().toISOString();
@@ -666,7 +749,7 @@ _Archived sessions → \`sessions/\` directory_
 }
 
 async function cmdStats() {
-    const tasksDir = path.join(WORKSPACE_DIR, 'engineering-team', 'tasks');
+    const tasksDir = path.join(WORKSPACE_DIR, 'tasks');
     const files = fs.readdirSync(tasksDir).filter(f => f.endsWith('.md') && (f.startsWith('TSK-') || f.startsWith('task-')));
     
     const counts = { BACKLOG: 0, TODO: 0, IN_PROGRESS: 0, VERIFY: 0, DONE: 0, REOPEN: 0 };
@@ -689,7 +772,9 @@ Total tasks: ${total}
 In flight: ${counts.IN_PROGRESS + counts.VERIFY} (${counts.IN_PROGRESS} in progress, ${counts.VERIFY} in verify)
 Done: ${counts.DONE} (${doneRate}%)
 
-Board: \`${counts.BACKLOG}\` backlog · \`${counts.TODO}\` todo · \`${counts.IN_PROGRESS}\` in progress · \`${counts.VERIFY}\` verify · \`${counts.DONE}\` done · \`${counts.REOPEN}\` reopened`;
+Board: \`${counts.BACKLOG}\` backlog · \`${counts.TODO}\` todo · \`${counts.IN_PROGRESS}\` in progress · \`${counts.VERIFY}\` verify · \`${counts.DONE}\` done · \`${counts.REOPEN}\` reopened
+
+Delegation attempts: ${Object.values(delegationMetrics.snapshot().delegationAttemptsByAgent).reduce((sum, value) => sum + value, 0)} · fallbacks: ${delegationMetrics.snapshot().fallbackToCoordinatorCount} · attribution mismatches: ${delegationMetrics.snapshot().attributionMismatchCount}`;
 }
 
 // ─── Discord reply ─────────────────────────────────────────────────────────────
@@ -716,23 +801,35 @@ async function poll() {
 
 // ─── Startup ──────────────────────────────────────────────────────────────────
 
-console.log('🚀 Software Factory Command Router (REST polling) starting...');
-console.log('[config] Workspace:', WORKSPACE_DIR);
-console.log('[config] Channel:', CHANNEL_ID);
+function startRouter() {
+    console.log('🚀 Software Factory Command Router (REST polling) starting...');
+    console.log('[config] Workspace:', WORKSPACE_DIR);
+    console.log('[config] Channel:', CHANNEL_ID);
 
-if (!BOT_TOKEN) {
-    console.error('[config] Missing DISCORD_BOT_TOKEN');
-    process.exit(1);
+    if (!BOT_TOKEN) {
+        console.error('[config] Missing DISCORD_BOT_TOKEN');
+        process.exit(1);
+    }
+
+    discordRequest('GET', '/users/@me').then(user => {
+        console.log('[auth] Bot logged in as:', user.username || 'unknown');
+    }).catch(err => {
+        console.error('[auth] Failed:', err.message);
+        process.exit(1);
+    });
+
+    setInterval(poll, POLL_INTERVAL);
+    console.log('[poll] Polling every', POLL_INTERVAL, 'ms');
 }
 
-// Test auth on startup
-discordRequest('GET', '/users/@me').then(user => {
-    console.log('[auth] Bot logged in as:', user.username || 'unknown');
-}).catch(err => {
-    console.error('[auth] Failed:', err.message);
-    process.exit(1);
-});
+if (require.main === module) {
+    startRouter();
+}
 
-// Start polling
-setInterval(poll, POLL_INTERVAL);
-console.log('[poll] Polling every', POLL_INTERVAL, 'ms');
+module.exports = {
+    buildIdempotencyKey,
+    formatDelegationReply,
+    formatTaskDelegationReply,
+    taskMove,
+    startRouter,
+};

--- a/tests/fixtures/specialist-runtime-runner.js
+++ b/tests/fixtures/specialist-runtime-runner.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  input += chunk;
+});
+process.stdin.on('end', () => {
+  const payload = JSON.parse(input || '{}');
+  if (process.env.FIXTURE_RUNTIME_MODE === 'fail') {
+    console.error('specialist offline');
+    process.exit(2);
+    return;
+  }
+  const agentId = process.env.FIXTURE_RUNTIME_AGENT_ID || payload.specialist;
+  const sessionId = process.env.FIXTURE_RUNTIME_SESSION_ID || `runtime-session-${payload.delegationId}`;
+  process.stdout.write(JSON.stringify({
+    agentId,
+    sessionId,
+    output: `runtime handled by ${agentId}`,
+    ownership: {
+      agentId,
+      sessionId,
+      runtime: 'fixture-openclaw',
+    },
+  }));
+});

--- a/tests/unit/command-router-delegation.test.js
+++ b/tests/unit/command-router-delegation.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const runtimeRunnerPath = path.join(__dirname, '..', 'fixtures', 'specialist-runtime-runner.js');
+const repoRoot = path.join(__dirname, '..', '..');
+const tasksDir = path.join(repoRoot, 'tasks');
+const taskPath = path.join(tasksDir, 'TSK-998-runtime-test.md');
+const artifactPath = path.join(repoRoot, 'observability', 'specialist-delegation.jsonl');
+const { taskMove } = require('../../scripts/command-router');
+
+function writeTask(type = 'dev') {
+  fs.writeFileSync(taskPath, `# Runtime delegation task\n\n**Status:** TODO\n**Type:** ${type}\n**Created:** 2026-04-06 18:00 CDT\n**Updated:** 2026-04-06 18:00 CDT\n\n## 📝 Description\n\nValidate runtime delegation.\n\n## 🔄 Status History\n\n| Date | From | To | Actor | Note |\n|------|------|----|----|------|\n`);
+}
+
+test.afterEach(() => {
+  try { fs.unlinkSync(taskPath); } catch {}
+  try { fs.unlinkSync(artifactPath); } catch {}
+});
+
+test('taskMove wires runtime-backed specialist delegation into IN_PROGRESS flow', async () => {
+  writeTask('dev');
+  const reply = await taskMove('TSK-998 IN_PROGRESS --note start work', { id: 'msg-1', author: { username: 'alice' } }, {
+    delegationRunnerCommand: `node ${runtimeRunnerPath}`,
+    baseDir: repoRoot,
+  });
+
+  assert.match(reply, /Runtime delegation confirmed/);
+  assert.match(reply, /session `runtime-session-/);
+
+  const artifactLines = fs.readFileSync(artifactPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+  const artifact = artifactLines.at(-1);
+  assert.equal(artifact.target_specialist, 'engineer');
+  assert.equal(artifact.actual_agent, 'engineer');
+  assert.equal(artifact.ownership.runtime, 'fixture-openclaw');
+});
+
+test('taskMove falls back truthfully when runtime delegation is not configured', async () => {
+  writeTask('dev');
+  const reply = await taskMove('TSK-998 IN_PROGRESS', { id: 'msg-2', author: { username: 'bob' } }, {
+    baseDir: repoRoot,
+    delegationRunnerCommand: '',
+  });
+
+  assert.match(reply, /Runtime delegation not confirmed/);
+  assert.doesNotMatch(reply, /owns this run/);
+});
+
+test('taskMove does not claim runtime ownership for unsupported task types', async () => {
+  writeTask('unknown');
+  const reply = await taskMove('TSK-998 IN_PROGRESS', { id: 'msg-3', author: { username: 'carol' } }, {
+    delegationRunnerCommand: `node ${runtimeRunnerPath}`,
+    baseDir: repoRoot,
+  });
+
+  assert.match(reply, /Runtime delegation not confirmed/);
+  assert.match(reply, /does not map to a supported runtime specialist/);
+});

--- a/tests/unit/specialist-delegation.test.js
+++ b/tests/unit/specialist-delegation.test.js
@@ -1,0 +1,98 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const {
+  classifySpecialistRequest,
+  createDelegationMetrics,
+  createSpecialistCoordinator,
+} = require('../../lib/software-factory/delegation');
+const { isSpecialistDelegationEnabled } = require('../../lib/audit/feature-flags');
+
+const runtimeRunnerPath = path.join(__dirname, '..', 'fixtures', 'specialist-runtime-runner.js');
+
+test('routes clear specialist-owned requests to the expected specialist', () => {
+  assert.deepEqual(classifySpecialistRequest('Please implement this bug fix').specialist, 'engineer');
+  assert.deepEqual(classifySpecialistRequest('Need architecture review for this service boundary').specialist, 'architect');
+  assert.deepEqual(classifySpecialistRequest('Can QA verify the regression coverage?').specialist, 'qa');
+  assert.deepEqual(classifySpecialistRequest('SRE should inspect the latency spike and alerts').specialist, 'sre');
+});
+
+test('treats ambiguous or unmatched requests as coordinator-owned', () => {
+  assert.equal(classifySpecialistRequest('hello team').confidence, 'none');
+  const ambiguous = classifySpecialistRequest('Need architecture review and QA verification');
+  assert.equal(ambiguous.confidence, 'ambiguous');
+  assert.equal(ambiguous.specialist, null);
+});
+
+test('delegates through runtime evidence and returns truthful attribution with artifact evidence', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specialist-delegation-'));
+  const coordinator = createSpecialistCoordinator({
+    baseDir,
+    delegationRunnerCommand: `node ${runtimeRunnerPath}`,
+  });
+
+  const result = await coordinator.handleRequest('Please implement this fix', { coordinatorAgent: 'main' });
+
+  assert.equal(result.mode, 'delegated');
+  assert.equal(result.agentId, 'engineer');
+  assert.deepEqual(result.attribution, { handledBy: 'engineer', delegated: true, coordinator: 'main' });
+  assert.match(result.metadata.sessionId, /^runtime-session-/);
+  assert.deepEqual(result.metadata.ownership.runtime, 'fixture-openclaw');
+
+  const artifactPath = path.join(baseDir, 'observability', 'specialist-delegation.jsonl');
+  const artifactLines = fs.readFileSync(artifactPath, 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+  assert.equal(artifactLines[0].target_specialist, 'engineer');
+  assert.equal(artifactLines[0].actual_agent, 'engineer');
+  assert.match(artifactLines[0].session_id, /^runtime-session-/);
+  assert.equal(artifactLines[0].ownership.runtime, 'fixture-openclaw');
+});
+
+test('falls back explicitly when delegation fails and records failure metrics', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specialist-fallback-'));
+  const metrics = createDelegationMetrics();
+  const coordinator = createSpecialistCoordinator({
+    baseDir,
+    metrics,
+    delegateWork: async () => {
+      const error = new Error('specialist offline');
+      error.code = 'SPECIALIST_UNAVAILABLE';
+      throw error;
+    },
+  });
+
+  const result = await coordinator.handleRequest('Need architecture review for this design', { coordinatorAgent: 'main' });
+
+  assert.equal(result.mode, 'fallback');
+  assert.match(result.message, /specialist `architect` could not be reached/i);
+  assert.equal(result.attribution.handledBy, 'main');
+  assert.equal(metrics.snapshot().fallbackToCoordinatorCount, 1);
+  assert.equal(metrics.snapshot().delegationFailureByAgent.architect, 1);
+});
+
+test('records attribution mismatches and falls back truthfully', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specialist-mismatch-'));
+  const metrics = createDelegationMetrics();
+  const coordinator = createSpecialistCoordinator({
+    baseDir,
+    metrics,
+    delegateWork: async () => ({
+      agentId: 'main',
+      sessionId: 'bad-session',
+      output: 'wrong owner',
+    }),
+  });
+
+  const result = await coordinator.handleRequest('Please implement this feature', { coordinatorAgent: 'main' });
+
+  assert.equal(result.mode, 'fallback');
+  assert.equal(metrics.snapshot().attributionMismatchCount, 1);
+  assert.equal(result.attribution.handledBy, 'main');
+});
+
+test('supports feature flag disablement for rollout control', () => {
+  assert.equal(isSpecialistDelegationEnabled({ specialistDelegationEnabled: false }), false);
+  assert.equal(isSpecialistDelegationEnabled({ ffSpecialistDelegation: 'false' }), false);
+  assert.equal(isSpecialistDelegationEnabled({ ffSpecialistDelegation: 'true' }), true);
+});


### PR DESCRIPTION
## Summary
- add runtime-backed specialist delegation plumbing for software factory routing
- enforce truthful attribution and fallback based on runtime-owned evidence
- add tests and docs for delegation behavior, artifacts, and fallback flow

## What changed
- added specialist delegation modules:
  - `lib/software-factory/delegation.js`
  - `lib/software-factory/runtime-delegation.js`
  - `lib/software-factory/task-dispatch.js`
- updated `scripts/command-router.js` to use the runtime-backed task dispatch path instead of simulated inline delegation
- added specialist delegation feature-flag exports in `lib/audit/feature-flags.js` and `lib/audit/index.js`
- added runbook/docs:
  - `docs/runbooks/specialist-delegation.md`
  - `README.md`
- added tests:
  - `tests/unit/specialist-delegation.test.js`
  - `tests/unit/command-router-delegation.test.js`
  - `tests/fixtures/specialist-runtime-runner.js`

## Validation
- `node --test tests/unit/specialist-delegation.test.js tests/unit/command-router-delegation.test.js`
- `npm run test:unit`

## Notes
- This change removes fake/simulated successful delegation by default.
- True live end-to-end runtime delegation still requires a real runner to be configured via `SPECIALIST_DELEGATION_RUNNER`.
- When that runtime bridge is not configured or cannot prove ownership, the system falls back truthfully instead of claiming specialist execution.

Closes #43
