### PR TITLE
Fix browser auth bootstrap hardening and post-sign-in restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,15 +83,16 @@ Task-detail contract notes for approval readiness:
 - App runtime: `src/app/`
 - Route/page module still lives at `src/features/task-detail/route.js`
 - Feature shell still lives at `src/features/task-detail/`
-- Internal-use auth bootstrap is intentionally minimal: paste a bearer JWT into the session panel and the browser stores it in `sessionStorage` for the current tab only.
+- Internal-use auth bootstrap now starts at `/sign-in` and exchanges a trusted browser auth code for a tab-scoped JWT session stored in `sessionStorage`.
+- The app protects `/tasks`, `/tasks?view=board`, `/overview/pm`, `/inbox/:role`, and `/tasks/:taskId`; unauthenticated or expired sessions are redirected back to `/sign-in`.
 - PM/admin tokens also unlock the task assignment control, which reads `GET /ai-agents` and writes `PATCH /tasks/:taskId/assignment`.
 - Reader-level tokens still see owner metadata on `GET /tasks/:taskId` and `GET /tasks`; they just do not get assignment controls.
 
 Run it locally:
 - `npm install`
 - `npm run dev`
-- open `http://127.0.0.1:5173/tasks/TSK-42`
-- if the API requires auth, paste a JWT into the **Session bootstrap** panel
+- open `http://127.0.0.1:5173/`
+- sign in through the internal browser auth form using a trusted browser auth code from the approved internal auth source
 
 Point the browser app at the API:
 - same-origin default: leave `VITE_TASK_API_BASE_URL` empty

--- a/docs/api/authenticated-browser-app-openapi.yml
+++ b/docs/api/authenticated-browser-app-openapi.yml
@@ -1,0 +1,77 @@
+openapi: 3.1.0
+info:
+  title: Authenticated Browser App Session API
+  version: 0.1.0
+  description: Browser-facing internal auth bootstrap endpoint for the authenticated app shell.
+paths:
+  /auth/session:
+    post:
+      summary: Exchange a trusted internal browser auth code for a browser JWT session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - authCode
+              properties:
+                authCode:
+                  type: string
+                  description: Signed browser bootstrap artifact from the trusted internal auth source.
+            examples:
+              trustedBootstrap:
+                value:
+                  authCode: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.trusted-browser-bootstrap.signature
+      responses:
+        '200':
+          description: Session created
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - success
+                  - data
+                properties:
+                  success:
+                    type: boolean
+                    const: true
+                  data:
+                    type: object
+                    required:
+                      - accessToken
+                      - expiresAt
+                      - claims
+                    properties:
+                      accessToken:
+                        type: string
+                        description: Bearer JWT for the task and audit APIs.
+                      expiresAt:
+                        type: string
+                        format: date-time
+                      claims:
+                        type: object
+                        required:
+                          - tenant_id
+                          - actor_id
+                          - roles
+                        properties:
+                          tenant_id:
+                            type: string
+                          actor_id:
+                            type: string
+                          roles:
+                            type: array
+                            items:
+                              type: string
+        '400':
+          description: Missing authCode
+        '401':
+          description: Invalid, expired, or untrusted auth bootstrap code
+  /api/auth/session:
+    post:
+      summary: Compatibility alias for the browser session bootstrap endpoint
+      responses:
+        '200':
+          description: Same contract as POST /auth/session

--- a/lib/audit/http.js
+++ b/lib/audit/http.js
@@ -3,7 +3,7 @@ const http = require('http');
 const { URL } = require('url');
 const { createAuditStore } = require('./store');
 const { authorize } = require('./authz');
-const { verifyHmacJwt, getBearerToken, buildPrincipalFromClaims } = require('../auth/jwt');
+const { verifyHmacJwt, signHmacJwt, getBearerToken, buildPrincipalFromClaims, verifyBrowserAuthCode } = require('../auth/jwt');
 const { createAuditLogger } = require('./logger');
 const {
   isAuditFoundationEnabled,
@@ -25,6 +25,7 @@ const TECHNICAL_SPEC_FIELDS = Object.freeze(['summary', 'scope', 'design', 'roll
 const MONITORING_SPEC_FIELDS = Object.freeze(['service', 'dashboardUrls', 'alertPolicies', 'runbook', 'successMetrics']);
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 const GITHUB_PR_URL_PATTERN = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+(?:\/?\S*)?$/i;
+const BROWSER_SESSION_TTL_SECONDS = 60 * 60;
 
 function parseJson(req) {
   return new Promise((resolve, reject) => {
@@ -859,6 +860,26 @@ function createReviewQuestionId() {
   return `rq-${crypto.randomUUID().slice(0, 8)}`;
 }
 
+function requireTrustedBrowserAuthCode(authCode, options = {}) {
+  const raw = String(authCode || '').trim();
+  if (!raw) {
+    throw createHttpError(400, 'missing_auth_code', 'The authCode field is required.');
+  }
+
+  try {
+    return verifyBrowserAuthCode(
+      raw,
+      options.browserAuthCodeSecret || process.env.AUTH_BROWSER_AUTH_CODE_SECRET || options.jwtSecret || process.env.AUTH_JWT_SECRET,
+      {
+        issuer: options.browserAuthCodeIssuer || process.env.AUTH_BROWSER_AUTH_CODE_ISSUER,
+        audience: options.browserAuthCodeAudience || process.env.AUTH_BROWSER_AUTH_CODE_AUDIENCE,
+      },
+    );
+  } catch {
+    throw createHttpError(401, 'invalid_auth_code', 'The sign-in code is invalid, expired, or untrusted.');
+  }
+}
+
 function canAskReviewQuestion(context) {
   return hasAnyRole(context, ['architect', 'admin']);
 }
@@ -917,6 +938,35 @@ function createAuditApiServer(options = {}) {
     try {
       if (routePath === '/healthz') {
         return sendJson(res, 200, { ok: true, backend: store.kind, ff_audit_foundation: isAuditFoundationEnabled(options) }, requestId);
+      }
+
+      if (routePath === '/auth/session' && req.method === 'POST') {
+        const body = await parseJson(req);
+        const { actorId, tenantId, roles } = requireTrustedBrowserAuthCode(body.authCode, options);
+        const expiresAt = new Date(Date.now() + BROWSER_SESSION_TTL_SECONDS * 1000).toISOString();
+        const claims = {
+          sub: actorId,
+          tenant_id: tenantId,
+          roles,
+          exp: Math.floor(Date.parse(expiresAt) / 1000),
+        };
+        const jwtIssuer = options.jwtIssuer || process.env.AUTH_JWT_ISSUER;
+        const jwtAudience = options.jwtAudience || process.env.AUTH_JWT_AUDIENCE;
+        if (jwtIssuer) claims.iss = jwtIssuer;
+        if (jwtAudience) claims.aud = jwtAudience;
+
+        return sendJson(res, 200, {
+          success: true,
+          data: {
+            accessToken: signHmacJwt(claims, options.jwtSecret || process.env.AUTH_JWT_SECRET),
+            expiresAt,
+            claims: {
+              tenant_id: tenantId,
+              actor_id: actorId,
+              roles,
+            },
+          },
+        }, requestId);
       }
 
       if (!isAuditFoundationEnabled(options)) {

--- a/lib/auth/jwt.js
+++ b/lib/auth/jwt.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto');
+const BROWSER_AUTH_CODE_TOKEN_USE = 'browser_auth_code';
 
 function base64UrlDecode(value) {
   const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
@@ -44,6 +45,70 @@ function verifyHmacJwt(token, secret, options = {}) {
   return payload;
 }
 
+function signHmacJwt(payload, secret, header = { alg: 'HS256', typ: 'JWT' }) {
+  if (!secret) throw new Error('AUTH_JWT_SECRET is required');
+
+  const headerPart = Buffer.from(JSON.stringify(header)).toString('base64url');
+  const payloadPart = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${headerPart}.${payloadPart}`)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  return `${headerPart}.${payloadPart}.${signature}`;
+}
+
+function normalizeRoles(roles) {
+  return Array.isArray(roles)
+    ? roles.map((value) => String(value || '').trim()).filter(Boolean)
+    : String(roles || '').split(',').map((value) => value.trim()).filter(Boolean);
+}
+
+function signBrowserAuthCode({ actorId, tenantId, roles }, secret, options = {}) {
+  const normalizedRoles = normalizeRoles(roles);
+  const now = Math.floor((options.nowMs || Date.now()) / 1000);
+  const payload = {
+    sub: String(actorId || '').trim(),
+    tenant_id: String(tenantId || '').trim(),
+    roles: normalizedRoles,
+    token_use: BROWSER_AUTH_CODE_TOKEN_USE,
+    iat: now,
+    exp: now + (Number.isFinite(options.ttlSeconds) ? options.ttlSeconds : 300),
+  };
+
+  if (!payload.sub || !payload.tenant_id || !payload.roles.length) {
+    throw new Error('browser auth code requires actor, tenant, and roles');
+  }
+  if (options.issuer) payload.iss = options.issuer;
+  if (options.audience) payload.aud = options.audience;
+  return signHmacJwt(payload, secret);
+}
+
+function verifyBrowserAuthCode(authCode, secret, options = {}) {
+  const claims = verifyHmacJwt(authCode, secret, {
+    issuer: options.issuer,
+    audience: options.audience,
+  });
+  const roles = normalizeRoles(claims.roles);
+
+  if (claims.token_use !== BROWSER_AUTH_CODE_TOKEN_USE) {
+    throw new Error('invalid auth code purpose');
+  }
+  if (!claims.sub || !claims.tenant_id || !roles.length) {
+    throw new Error('invalid auth code claims');
+  }
+
+  return {
+    actorId: claims.sub,
+    tenantId: claims.tenant_id,
+    roles,
+    claims,
+  };
+}
+
 function getBearerToken(req) {
   const authorization = req.headers.authorization || req.headers.Authorization;
   if (!authorization) return null;
@@ -60,13 +125,17 @@ function buildPrincipalFromClaims(claims, options = {}) {
   return {
     tenantId: claims[tenantClaim] || null,
     actorId: claims[actorClaim] || null,
-    roles: Array.isArray(roles) ? roles : String(roles || '').split(',').map(value => value.trim()).filter(Boolean),
+    roles: normalizeRoles(roles),
     claims,
     authType: 'jwt',
   };
 }
 
 module.exports = {
+  BROWSER_AUTH_CODE_TOKEN_USE,
+  signBrowserAuthCode,
+  signHmacJwt,
+  verifyBrowserAuthCode,
   verifyHmacJwt,
   getBearerToken,
   buildPrincipalFromClaims,

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -7,10 +7,13 @@ import { StageTransition } from '../features/task-detail/StageTransition';
 import { TaskCreationPage } from '../features/task-creation/TaskCreationPage';
 import {
   buildAuthHeaders,
-  clearBrowserSessionConfig,
-  decodeJwtPayload,
+  hasSessionExpired,
+  isAuthenticatedSession,
   readBrowserSessionConfig,
+  readSessionClaims,
   resolveApiBaseUrl,
+  sanitizeNextRoute,
+  splitRouteTarget,
   writeBrowserSessionConfig,
 } from './session.browser';
 import {
@@ -33,6 +36,80 @@ import {
 const envApiBaseUrl = (import.meta.env.VITE_TASK_API_BASE_URL || '').trim();
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 const GITHUB_PR_URL_PATTERN = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+(?:\/?\S*)?$/i;
+const SIGN_IN_PATH = '/sign-in';
+const SIGN_IN_TIMEOUT_MS = 5000;
+
+function matchSignInRoute(pathname = '') {
+  return ((pathname || '').replace(/\/+$/, '') || '/') === SIGN_IN_PATH;
+}
+
+function isProtectedRoute(pathname = '') {
+  const normalizedPath = ((pathname || '').replace(/\/+$/, '') || '/');
+  return normalizedPath === '/'
+    || matchTaskListRoute(normalizedPath)
+    || matchCreateTaskRoute(normalizedPath)
+    || Boolean(matchRoleInboxRoute(normalizedPath))
+    || Boolean(matchPmOverviewRoute(normalizedPath))
+    || Boolean(readRouteTask(normalizedPath));
+}
+
+function buildSignInSearch(nextPath = '/tasks', reason = '') {
+  const params = new URLSearchParams();
+  const next = sanitizeNextRoute(nextPath);
+  if (next && next !== '/tasks') params.set('next', next);
+  if (reason) params.set('reason', reason);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+}
+
+function readSignInState(search = '') {
+  const params = new URLSearchParams(search);
+  return {
+    next: sanitizeNextRoute(params.get('next') || '/tasks'),
+    reason: params.get('reason') || '',
+  };
+}
+
+function defaultSignInDraft(apiBaseUrl = '') {
+  return {
+    apiBaseUrl,
+    authCode: '',
+  };
+}
+
+function toSessionConfigFromExchange(data, apiBaseUrl) {
+  return writeBrowserSessionConfig({
+    bearerToken: data?.accessToken || '',
+    apiBaseUrl,
+    expiresAt: data?.expiresAt || '',
+  });
+}
+
+async function exchangeSessionForAuthCode({ apiBaseUrl, authCode, fetchImpl = window.fetch.bind(window) }) {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), SIGN_IN_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(`${apiBaseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ authCode }),
+      signal: controller.signal,
+    });
+    const payload = await response.json();
+    if (!response.ok) {
+      throw new Error(payload?.error?.message || 'Sign-in failed.');
+    }
+    return payload?.data || {};
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      throw new Error('Sign-in timed out. Try again.');
+    }
+    throw error;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
 
 function readRouteTask(pathname) {
   const match = ((pathname || '').replace(/\/+$/, '') || '/').match(/^\/tasks\/([^/]+)$/);
@@ -358,9 +435,10 @@ function useLocationState() {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  const navigate = React.useCallback((pathname, search = '') => {
+  const navigate = React.useCallback((pathname, search = '', options = {}) => {
     const nextUrl = `${pathname}${search}`;
-    window.history.pushState({}, '', nextUrl);
+    if (options.replace) window.history.replaceState({}, '', nextUrl);
+    else window.history.pushState({}, '', nextUrl);
     setLocationState({ pathname, search });
   }, []);
 
@@ -370,7 +448,9 @@ function useLocationState() {
 export function App() {
   const [{ pathname, search }, navigate] = useLocationState();
   const [sessionConfig, setSessionConfig] = React.useState(() => readBrowserSessionConfig());
-  const [draftSessionConfig, setDraftSessionConfig] = React.useState(() => readBrowserSessionConfig());
+  const [signInDraft, setSignInDraft] = React.useState(() => defaultSignInDraft(readBrowserSessionConfig().apiBaseUrl || envApiBaseUrl));
+  const [signInStatus, setSignInStatus] = React.useState({ kind: 'idle', message: '' });
+  const [authNotice, setAuthNotice] = React.useState('');
   const [model, setModel] = React.useState(() => {
     if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname)) return buildListLoadingModel(pathname, search);
     return matchTaskRoute(pathname) ? buildLoadingModel(pathname, search) : buildRouteMissModel(pathname);
@@ -387,6 +467,20 @@ export function App() {
   const [architectHandoffStatus, setArchitectHandoffStatus] = React.useState({ kind: 'idle', message: '' });
   const [engineerSubmissionDraft, setEngineerSubmissionDraft] = React.useState(() => normalizeEngineerSubmissionDraft());
   const [engineerSubmissionStatus, setEngineerSubmissionStatus] = React.useState({ kind: 'idle', message: '' });
+  const signInState = React.useMemo(() => readSignInState(search), [search]);
+  const tokenClaims = readSessionClaims(sessionConfig);
+  const resolvedApiBaseUrl = resolveApiBaseUrl(sessionConfig, envApiBaseUrl);
+  const isAuthenticated = isAuthenticatedSession(sessionConfig);
+
+  const clearSessionForSignIn = React.useCallback((message, reason = 'expired') => {
+    const preserved = writeBrowserSessionConfig({
+      apiBaseUrl: resolvedApiBaseUrl,
+    });
+    setSessionConfig(preserved);
+    setSignInDraft((current) => ({ ...current, apiBaseUrl: preserved.apiBaseUrl || current.apiBaseUrl }));
+    setAuthNotice(message);
+    navigate(SIGN_IN_PATH, buildSignInSearch(`${pathname}${search}`, reason), { replace: true });
+  }, [navigate, pathname, resolvedApiBaseUrl, search]);
 
   const taskClient = React.useMemo(() => {
     const baseUrl = resolveApiBaseUrl(sessionConfig, envApiBaseUrl);
@@ -394,8 +488,9 @@ export function App() {
       baseUrl,
       fetchImpl: (...args) => window.fetch(...args),
       getHeaders: () => buildAuthHeaders(sessionConfig),
+      onAuthFailure: () => clearSessionForSignIn('Your session expired. Sign in again to continue.'),
     });
-  }, [sessionConfig]);
+  }, [clearSessionForSignIn, sessionConfig]);
 
   const pageModule = React.useMemo(() => {
     return createTaskDetailPageModule({
@@ -404,8 +499,38 @@ export function App() {
   }, [taskClient]);
 
   React.useEffect(() => {
-    setDraftSessionConfig(sessionConfig);
-  }, [sessionConfig]);
+    setSignInDraft((current) => ({
+      ...current,
+      apiBaseUrl: resolvedApiBaseUrl || current.apiBaseUrl,
+    }));
+  }, [resolvedApiBaseUrl]);
+
+  React.useEffect(() => {
+    if (hasSessionExpired(sessionConfig) && String(sessionConfig.bearerToken || '').trim()) {
+      clearSessionForSignIn('Your session expired. Sign in again to continue.');
+      return;
+    }
+
+    if (!isAuthenticated) {
+      if (matchSignInRoute(pathname)) return;
+      if (!isProtectedRoute(pathname)) {
+        navigate(SIGN_IN_PATH, buildSignInSearch('/tasks'), { replace: true });
+        return;
+      }
+      navigate(SIGN_IN_PATH, buildSignInSearch(`${pathname}${search}`), { replace: true });
+      return;
+    }
+
+    if (pathname === '/') {
+      navigate('/tasks', '', { replace: true });
+      return;
+    }
+
+    if (matchSignInRoute(pathname)) {
+      const nextRoute = splitRouteTarget(signInState.next);
+      navigate(nextRoute.pathname, nextRoute.search, { replace: true });
+    }
+  }, [clearSessionForSignIn, isAuthenticated, navigate, pathname, search, sessionConfig, signInState.next]);
 
   React.useEffect(() => {
     if (model.kind === 'detail') {
@@ -424,6 +549,12 @@ export function App() {
 
   React.useEffect(() => {
     let cancelled = false;
+
+    if (!isAuthenticated) {
+      return () => {
+        cancelled = true;
+      };
+    }
 
     if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname)) {
       setModel(buildListLoadingModel(pathname, search));
@@ -497,11 +628,17 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [pageModule, pathname, search, taskClient]);
+  }, [isAuthenticated, pageModule, pathname, search, taskClient]);
 
   React.useEffect(() => {
     let cancelled = false;
-    const tokenClaims = decodeJwtPayload(sessionConfig.bearerToken || '');
+    if (!isAuthenticated) {
+      setAgentOptions([]);
+      setAgentOptionsState({ kind: 'idle', message: '' });
+      return () => {
+        cancelled = true;
+      };
+    }
 
     setAgentOptionsState({ kind: 'loading', message: 'Loading canonical role roster.' });
     taskClient.fetchAssignableAgents()
@@ -528,7 +665,7 @@ export function App() {
     return () => {
       cancelled = true;
     };
-  }, [taskClient, sessionConfig.bearerToken]);
+  }, [isAuthenticated, taskClient, tokenClaims]);
 
   const setTab = React.useCallback(
     (tab) => {
@@ -552,8 +689,6 @@ export function App() {
     navigate('/tasks', writeTaskListUrlState({ view }, search));
   }, [navigate, search]);
 
-  const tokenClaims = decodeJwtPayload(sessionConfig.bearerToken || '');
-  const resolvedApiBaseUrl = resolveApiBaseUrl(sessionConfig, envApiBaseUrl);
   const assignmentEnabled = model.kind === 'detail' && Boolean(model.route?.taskId) && canManageAssignment(tokenClaims);
   const architectHandoffEnabled = model.kind === 'detail' && Boolean(model.route?.taskId) && canManageArchitectHandoff(tokenClaims);
   const engineerSubmissionEnabled = model.kind === 'detail' && Boolean(model.route?.taskId) && canManageEngineerSubmission(tokenClaims);
@@ -614,6 +749,33 @@ export function App() {
     }
   }, [reloadTask, routeTaskId, taskClient]);
 
+  const handleSignIn = React.useCallback(async (event) => {
+    event.preventDefault();
+    const apiBaseUrl = String(signInDraft.apiBaseUrl || '').trim().replace(/\/+$/, '');
+    const authCode = String(signInDraft.authCode || '').trim();
+
+    setSignInStatus({ kind: 'loading', message: 'Signing in…' });
+
+    try {
+      const sessionData = await exchangeSessionForAuthCode({
+        apiBaseUrl,
+        authCode,
+      });
+      const nextConfig = toSessionConfigFromExchange(sessionData, apiBaseUrl);
+      setSessionConfig(nextConfig);
+      setAuthNotice('');
+      setSignInStatus({ kind: 'success', message: 'Signed in.' });
+      const nextRoute = splitRouteTarget(signInState.next);
+      navigate(nextRoute.pathname, nextRoute.search, { replace: true });
+    } catch (error) {
+      setSignInStatus({ kind: 'error', message: error?.message || 'Sign-in failed.' });
+    }
+  }, [navigate, signInDraft, signInState.next]);
+
+  const handleSignOut = React.useCallback(() => {
+    clearSessionForSignIn('You signed out of the workflow app.', 'signed_out');
+  }, [clearSessionForSignIn]);
+
   const handleTaskCreated = React.useCallback(() => {
     navigate('/tasks');
   }, [navigate]);
@@ -652,13 +814,81 @@ export function App() {
           ? summarizeRoleInboxResults(roleInboxItems.length, activeInboxRole)
           : roleInboxState.message
         : summarizeListResults(visibleListItems.length, listFilters.owner, agentLookup, listFilters.view)
-    : '';
+      : '';
+
+  if (!isAuthenticated) {
+    return (
+      <main className="app-shell app-shell--auth">
+        <section className="auth-card" aria-label="Sign-in screen">
+          <div className="auth-card__intro">
+            <p className="eyebrow">Authenticated browser shell for US-002</p>
+            <h1>Sign in to the workflow app</h1>
+            <p className="lede">Submit a trusted internal browser auth code to start a tab-scoped session for the task list, board, PM overview, inboxes, and task detail routes.</p>
+          </div>
+
+          {authNotice ? (
+            <p className="auth-status auth-status--notice" role="status">
+              {authNotice}
+            </p>
+          ) : null}
+
+          <form className="session-form auth-form" onSubmit={handleSignIn}>
+            <label>
+              Trusted auth code
+              <input
+                name="authCode"
+                value={signInDraft.authCode}
+                onChange={(event) => setSignInDraft((current) => ({ ...current, authCode: event.target.value }))}
+                placeholder="Paste the signed browser auth code"
+              />
+            </label>
+
+            <label>
+              API base URL
+              <input
+                name="apiBaseUrl"
+                value={signInDraft.apiBaseUrl}
+                onChange={(event) => setSignInDraft((current) => ({ ...current, apiBaseUrl: event.target.value }))}
+                placeholder={envApiBaseUrl || 'same-origin'}
+              />
+            </label>
+
+            <div className="session-form__actions">
+              <button type="submit" disabled={signInStatus.kind === 'loading'}>
+                {signInStatus.kind === 'loading' ? 'Signing in…' : 'Sign in'}
+              </button>
+            </div>
+
+            {signInStatus.kind === 'error' ? (
+              <p className="auth-status auth-status--error" role="alert">{signInStatus.message}</p>
+            ) : null}
+          </form>
+        </section>
+      </main>
+    );
+  }
 
   return (
     <main className="app-shell">
+      <nav className="app-nav" aria-label="Primary navigation">
+        <div className="app-nav__links">
+          <button type="button" className={model.kind === 'list' && !isPmOverview && !activeInboxRole && listFilters.view !== 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks')}>Task list</button>
+          <button type="button" className={model.kind === 'list' && !isPmOverview && !activeInboxRole && listFilters.view === 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks', writeTaskListUrlState({ view: 'board' }, ''))}>Board</button>
+          <button type="button" className={isPmOverview ? '' : 'button-secondary'} onClick={() => navigate('/overview/pm')}>PM overview</button>
+          {ROLE_INBOXES.map((role) => (
+            <button key={role} type="button" className={activeInboxRole === role ? '' : 'button-secondary'} onClick={() => navigate(`/inbox/${role}`)}>
+              {getRoleInboxLabel(role)} inbox
+            </button>
+          ))}
+        </div>
+        <div className="app-nav__session">
+          <span>{tokenClaims?.sub || 'unknown actor'} · {tokenClaims?.tenant_id || 'unknown tenant'}</span>
+          <button type="button" className="button-secondary" onClick={handleSignOut}>Sign out</button>
+        </div>
+      </nav>
       <header className="page-header">
         <div>
-          <p className="eyebrow">Thin browser runtime for issue #26</p>
+          <p className="eyebrow">Authenticated browser shell for US-002</p>
           <h1>{model.kind === 'list' ? (isPmOverview ? 'PM Overview' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} Inbox` : 'Task list') : model.detail?.task?.title || model.summary.title || 'Task detail'}</h1>
           <p className="lede">
             {model.kind === 'list'
@@ -699,54 +929,10 @@ export function App() {
             </div>
           </form>
 
-          <form
-            className="session-form"
-            onSubmit={(event) => {
-              event.preventDefault();
-              const nextConfig = writeBrowserSessionConfig(draftSessionConfig);
-              setSessionConfig(nextConfig);
-            }}
-          >
+          <section className="session-form session-form--summary" aria-label="Current session">
             <div className="session-form__header">
-              <strong>Session bootstrap</strong>
-              <span>Tab-scoped bearer token for internal use.</span>
-            </div>
-
-            <label>
-              API base URL
-              <input
-                name="apiBaseUrl"
-                value={draftSessionConfig.apiBaseUrl}
-                placeholder={envApiBaseUrl || 'same-origin'}
-                onChange={(event) => setDraftSessionConfig((current) => ({ ...current, apiBaseUrl: event.target.value }))}
-              />
-            </label>
-
-            <label>
-              Bearer token
-              <textarea
-                name="bearerToken"
-                value={draftSessionConfig.bearerToken}
-                placeholder="Paste a JWT for the audit/task-detail APIs"
-                onChange={(event) => setDraftSessionConfig((current) => ({ ...current, bearerToken: event.target.value }))}
-                rows={4}
-              />
-            </label>
-
-            <div className="session-form__actions">
-              <button type="submit">Apply session</button>
-              <button
-                type="button"
-                className="button-secondary"
-                onClick={() => {
-                  clearBrowserSessionConfig();
-                  const cleared = { bearerToken: '', apiBaseUrl: '' };
-                  setDraftSessionConfig(cleared);
-                  setSessionConfig(cleared);
-                }}
-              >
-                Clear
-              </button>
+              <strong>Current session</strong>
+              <span>Signed-in browser access for internal use.</span>
             </div>
 
             <dl className="session-meta">
@@ -767,7 +953,7 @@ export function App() {
                 <dd>{Array.isArray(tokenClaims?.roles) && tokenClaims.roles.length ? tokenClaims.roles.join(', ') : 'none'}</dd>
               </div>
             </dl>
-          </form>
+          </section>
         </div>
       </header>
 

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -25,10 +25,33 @@ function mergeValue(base: any, override: any): any {
   return override;
 }
 
+function makeToken(claims: Record<string, unknown>) {
+  return `header.${btoa(JSON.stringify(claims)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')}.signature`;
+}
+
+const TRUSTED_AUTH_CODE = 'signed-browser-auth-code';
+
+function makeFutureExpiry(hoursAhead = 24) {
+  return new Date(Date.now() + hoursAhead * 60 * 60 * 1000).toISOString();
+}
+
+function makeFutureExp(hoursAhead = 24) {
+  return Math.floor(Date.parse(makeFutureExpiry(hoursAhead)) / 1000);
+}
+
+function makePastExpiry(hoursAgo = 24) {
+  return new Date(Date.now() - hoursAgo * 60 * 60 * 1000).toISOString();
+}
+
+function makePastExp(hoursAgo = 24) {
+  return Math.floor(Date.parse(makePastExpiry(hoursAgo)) / 1000);
+}
+
 function installTaskFetchMock({
   forbidden = false,
   reassignedOwner = 'qa',
   aiAgentsStatus = 200,
+  authSessionStatus = 200,
   tasksOverride,
   detailOverride,
   summaryOverride,
@@ -47,6 +70,44 @@ function installTaskFetchMock({
 
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
+
+    if (url.endsWith('/auth/session') && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body || '{}'));
+      if (authSessionStatus !== 200) {
+        return createJsonResponse({
+          error: {
+            code: 'invalid_auth_code',
+            message: 'The sign-in code was rejected.',
+          },
+        }, authSessionStatus);
+      }
+      if (body.authCode !== TRUSTED_AUTH_CODE) {
+        return createJsonResponse({
+          error: {
+            code: 'invalid_auth_code',
+            message: 'The sign-in code was rejected.',
+          },
+        }, 401);
+      }
+
+      return createJsonResponse({
+        success: true,
+        data: {
+          accessToken: makeToken({
+            sub: 'pm-1',
+            tenant_id: 'tenant-a',
+            roles: ['pm', 'reader'],
+            exp: makeFutureExp(),
+          }),
+          expiresAt: makeFutureExpiry(),
+          claims: {
+            tenant_id: 'tenant-a',
+            actor_id: 'pm-1',
+            roles: ['pm', 'reader'],
+          },
+        },
+      });
+    }
 
     if (forbidden) {
       return createJsonResponse(
@@ -273,7 +334,16 @@ function installTaskFetchMock({
 describe('Task browser runtime coverage', () => {
   beforeEach(() => {
     window.history.pushState({}, '', '/tasks/TSK-42');
-    clearBrowserSessionConfig();
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'reader-1',
+        tenant_id: 'tenant-a',
+        roles: ['reader'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
   });
 
   afterEach(() => {
@@ -288,6 +358,148 @@ describe('Task browser runtime coverage', () => {
     await screen.findByRole('heading', { name: 'Wire task detail' });
     expect(screen.getByLabelText('Task summary')).toBeInTheDocument();
     expect(screen.getByText('Assignment controls are available to PM/admin bearer tokens.')).toBeInTheDocument();
+  });
+
+  it('redirects protected routes to sign-in when no browser session exists', async () => {
+    clearBrowserSessionConfig();
+    installTaskFetchMock();
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(window.location.pathname).toBe('/sign-in');
+    expect(screen.queryByText('Wire task detail')).not.toBeInTheDocument();
+  });
+
+  it('exchanges an internal sign-in code for a session and lands on the default app shell', async () => {
+    clearBrowserSessionConfig();
+    const fetchMock = installTaskFetchMock();
+    window.history.pushState({}, '', '/sign-in');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    fireEvent.change(screen.getByLabelText('Trusted auth code'), { target: { value: TRUSTED_AUTH_CODE } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('heading', { name: 'Task list' });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/session'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ authCode: TRUSTED_AUTH_CODE }),
+      }),
+    );
+    expect(screen.getByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign out' })).toBeInTheDocument();
+  });
+
+  it('restores board view query state after sign-in', async () => {
+    clearBrowserSessionConfig();
+    installTaskFetchMock();
+    window.history.pushState({}, '', '/tasks?view=board');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(window.location.pathname).toBe('/sign-in');
+    expect(window.location.search).toContain('next=%2Ftasks%3Fview%3Dboard');
+
+    fireEvent.change(screen.getByLabelText('Trusted auth code'), { target: { value: TRUSTED_AUTH_CODE } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('heading', { name: 'Task list' });
+    await screen.findByText('6 cards shown.');
+    expect(window.location.pathname).toBe('/tasks');
+    expect(window.location.search).toBe('?view=board');
+    expect(screen.getByRole('tab', { name: 'Board' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByLabelText('TODO column')).toBeInTheDocument();
+  });
+
+  it('restores PM overview bucket query state after session recovery sign-in', async () => {
+    clearBrowserSessionConfig();
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'pm-1',
+        tenant_id: 'tenant-a',
+        roles: ['pm', 'reader'],
+        exp: makePastExp(),
+      }),
+      expiresAt: makePastExpiry(),
+    });
+    installTaskFetchMock();
+    window.history.pushState({}, '', '/overview/pm?bucket=needs-routing-attention');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(window.location.pathname).toBe('/sign-in');
+    expect(window.location.search).toContain('next=%2Foverview%2Fpm%3Fbucket%3Dneeds-routing-attention');
+
+    fireEvent.change(screen.getByLabelText('Trusted auth code'), { target: { value: TRUSTED_AUTH_CODE } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('heading', { name: 'PM Overview' });
+    await screen.findByText('2 tasks shown in Needs routing attention.');
+    expect(window.location.pathname).toBe('/overview/pm');
+    expect(window.location.search).toBe('?bucket=needs-routing-attention');
+    expect(screen.getByLabelText('Bucket filter')).toHaveValue('needs-routing-attention');
+  });
+
+  it('restores task detail query state after sign-in', async () => {
+    clearBrowserSessionConfig();
+    installTaskFetchMock();
+    window.history.pushState({}, '', '/tasks/TSK-42?tab=telemetry');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(window.location.pathname).toBe('/sign-in');
+    expect(window.location.search).toContain('next=%2Ftasks%2FTSK-42%3Ftab%3Dtelemetry');
+
+    fireEvent.change(screen.getByLabelText('Trusted auth code'), { target: { value: TRUSTED_AUTH_CODE } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    expect(window.location.pathname).toBe('/tasks/TSK-42');
+    expect(window.location.search).toBe('?tab=telemetry');
+    expect(screen.getByRole('tabpanel')).toHaveAttribute('aria-labelledby', 'task-activity-tab-telemetry');
+    expect(await screen.findByText('Freshness', { selector: 'p' })).toBeInTheDocument();
+  });
+
+  it('restores inbox pathname and search exactly after sign-in', async () => {
+    clearBrowserSessionConfig();
+    installTaskFetchMock();
+    window.history.pushState({}, '', '/inbox/qa?source=alert');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(window.location.pathname).toBe('/sign-in');
+    expect(window.location.search).toContain('next=%2Finbox%2Fqa%3Fsource%3Dalert');
+
+    fireEvent.change(screen.getByLabelText('Trusted auth code'), { target: { value: TRUSTED_AUTH_CODE } });
+    fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+    await screen.findByRole('heading', { name: 'QA Inbox' });
+    expect(window.location.pathname).toBe('/inbox/qa');
+    expect(window.location.search).toBe('?source=alert');
+    expect(await screen.findByText('Review test plan')).toBeInTheDocument();
+  });
+
+  it('redirects an expired session back to sign-in with a recovery message', async () => {
+    clearBrowserSessionConfig();
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'pm-1',
+        tenant_id: 'tenant-a',
+        roles: ['pm', 'reader'],
+        exp: makePastExp(),
+      }),
+      expiresAt: makePastExpiry(),
+    });
+    installTaskFetchMock();
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Sign in to the workflow app' });
+    expect(screen.getByText('Your session expired. Sign in again to continue.')).toBeInTheDocument();
+    expect(window.location.pathname).toBe('/sign-in');
   });
 
   it('renders linked PR, child task, and spec detail from the dedicated detail model', async () => {

--- a/src/app/session.browser.js
+++ b/src/app/session.browser.js
@@ -1,4 +1,5 @@
 export const STORAGE_KEY = 'engineering-team.task-browser-session';
+export const DEFAULT_POST_SIGN_IN_ROUTE = '/tasks';
 
 function getSessionStorage(storage = globalThis.sessionStorage) {
   return storage;
@@ -7,14 +8,15 @@ function getSessionStorage(storage = globalThis.sessionStorage) {
 export function readBrowserSessionConfig(storage = getSessionStorage()) {
   try {
     const raw = storage?.getItem(STORAGE_KEY);
-    if (!raw) return { bearerToken: '', apiBaseUrl: '' };
+    if (!raw) return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
     const parsed = JSON.parse(raw);
     return {
       bearerToken: typeof parsed?.bearerToken === 'string' ? parsed.bearerToken : '',
       apiBaseUrl: typeof parsed?.apiBaseUrl === 'string' ? parsed.apiBaseUrl : '',
+      expiresAt: typeof parsed?.expiresAt === 'string' ? parsed.expiresAt : '',
     };
   } catch {
-    return { bearerToken: '', apiBaseUrl: '' };
+    return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
   }
 }
 
@@ -22,6 +24,7 @@ export function writeBrowserSessionConfig(config, storage = getSessionStorage())
   const next = {
     bearerToken: typeof config?.bearerToken === 'string' ? config.bearerToken.trim() : '',
     apiBaseUrl: typeof config?.apiBaseUrl === 'string' ? config.apiBaseUrl.trim().replace(/\/+$/, '') : '',
+    expiresAt: typeof config?.expiresAt === 'string' ? config.expiresAt.trim() : '',
   };
 
   storage?.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -30,7 +33,7 @@ export function writeBrowserSessionConfig(config, storage = getSessionStorage())
 
 export function clearBrowserSessionConfig(storage = getSessionStorage()) {
   storage?.removeItem(STORAGE_KEY);
-  return { bearerToken: '', apiBaseUrl: '' };
+  return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
 }
 
 export function buildAuthHeaders(config = {}) {
@@ -56,4 +59,48 @@ export function decodeJwtPayload(token = '') {
   } catch {
     return null;
   }
+}
+
+export function readSessionClaims(config = {}) {
+  return decodeJwtPayload(config?.bearerToken || '') || null;
+}
+
+export function hasSessionExpired(config = {}, now = new Date()) {
+  const explicitExpiry = typeof config?.expiresAt === 'string' ? config.expiresAt.trim() : '';
+  if (explicitExpiry) {
+    const expiresAt = Date.parse(explicitExpiry);
+    if (Number.isFinite(expiresAt)) {
+      return now.valueOf() >= expiresAt;
+    }
+  }
+
+  const claims = readSessionClaims(config);
+  if (!Number.isFinite(claims?.exp)) return false;
+  return now.valueOf() >= claims.exp * 1000;
+}
+
+export function isAuthenticatedSession(config = {}, now = new Date()) {
+  const claims = readSessionClaims(config);
+  if (!claims?.sub || !claims?.tenant_id) return false;
+  if (!String(config?.bearerToken || '').trim()) return false;
+  return !hasSessionExpired(config, now);
+}
+
+export function sanitizeNextRoute(value) {
+  if (!value || typeof value !== 'string') return DEFAULT_POST_SIGN_IN_ROUTE;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return DEFAULT_POST_SIGN_IN_ROUTE;
+
+  const hashIndex = trimmed.indexOf('#');
+  const withoutHash = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
+  if (!withoutHash || withoutHash.startsWith('/sign-in')) return DEFAULT_POST_SIGN_IN_ROUTE;
+  return withoutHash || DEFAULT_POST_SIGN_IN_ROUTE;
+}
+
+export function splitRouteTarget(value) {
+  const sanitized = sanitizeNextRoute(value);
+  const queryIndex = sanitized.indexOf('?');
+  return queryIndex >= 0
+    ? { pathname: sanitized.slice(0, queryIndex) || DEFAULT_POST_SIGN_IN_ROUTE, search: sanitized.slice(queryIndex) }
+    : { pathname: sanitized, search: '' };
 }

--- a/src/app/session.js
+++ b/src/app/session.js
@@ -1,4 +1,5 @@
 const STORAGE_KEY = 'engineering-team.task-browser-session';
+const DEFAULT_POST_SIGN_IN_ROUTE = '/tasks';
 
 function getSessionStorage(storage = globalThis.sessionStorage) {
   return storage;
@@ -7,14 +8,15 @@ function getSessionStorage(storage = globalThis.sessionStorage) {
 function readBrowserSessionConfig(storage = getSessionStorage()) {
   try {
     const raw = storage?.getItem(STORAGE_KEY);
-    if (!raw) return { bearerToken: '', apiBaseUrl: '' };
+    if (!raw) return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
     const parsed = JSON.parse(raw);
     return {
       bearerToken: typeof parsed?.bearerToken === 'string' ? parsed.bearerToken : '',
       apiBaseUrl: typeof parsed?.apiBaseUrl === 'string' ? parsed.apiBaseUrl : '',
+      expiresAt: typeof parsed?.expiresAt === 'string' ? parsed.expiresAt : '',
     };
   } catch {
-    return { bearerToken: '', apiBaseUrl: '' };
+    return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
   }
 }
 
@@ -22,6 +24,7 @@ function writeBrowserSessionConfig(config, storage = getSessionStorage()) {
   const next = {
     bearerToken: typeof config?.bearerToken === 'string' ? config.bearerToken.trim() : '',
     apiBaseUrl: typeof config?.apiBaseUrl === 'string' ? config.apiBaseUrl.trim().replace(/\/+$/, '') : '',
+    expiresAt: typeof config?.expiresAt === 'string' ? config.expiresAt.trim() : '',
   };
 
   storage?.setItem(STORAGE_KEY, JSON.stringify(next));
@@ -30,7 +33,7 @@ function writeBrowserSessionConfig(config, storage = getSessionStorage()) {
 
 function clearBrowserSessionConfig(storage = getSessionStorage()) {
   storage?.removeItem(STORAGE_KEY);
-  return { bearerToken: '', apiBaseUrl: '' };
+  return { bearerToken: '', apiBaseUrl: '', expiresAt: '' };
 }
 
 function buildAuthHeaders(config = {}) {
@@ -58,12 +61,62 @@ function decodeJwtPayload(token = '') {
   }
 }
 
+function readSessionClaims(config = {}) {
+  return decodeJwtPayload(config?.bearerToken || '') || null;
+}
+
+function hasSessionExpired(config = {}, now = new Date()) {
+  const explicitExpiry = typeof config?.expiresAt === 'string' ? config.expiresAt.trim() : '';
+  if (explicitExpiry) {
+    const expiresAt = Date.parse(explicitExpiry);
+    if (Number.isFinite(expiresAt)) {
+      return now.valueOf() >= expiresAt;
+    }
+  }
+
+  const claims = readSessionClaims(config);
+  if (!Number.isFinite(claims?.exp)) return false;
+  return now.valueOf() >= claims.exp * 1000;
+}
+
+function isAuthenticatedSession(config = {}, now = new Date()) {
+  const claims = readSessionClaims(config);
+  if (!claims?.sub || !claims?.tenant_id) return false;
+  if (!String(config?.bearerToken || '').trim()) return false;
+  return !hasSessionExpired(config, now);
+}
+
+function sanitizeNextRoute(value) {
+  if (!value || typeof value !== 'string') return DEFAULT_POST_SIGN_IN_ROUTE;
+  const trimmed = value.trim();
+  if (!trimmed.startsWith('/') || trimmed.startsWith('//')) return DEFAULT_POST_SIGN_IN_ROUTE;
+
+  const hashIndex = trimmed.indexOf('#');
+  const withoutHash = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
+  if (!withoutHash || withoutHash.startsWith('/sign-in')) return DEFAULT_POST_SIGN_IN_ROUTE;
+  return withoutHash || DEFAULT_POST_SIGN_IN_ROUTE;
+}
+
+function splitRouteTarget(value) {
+  const sanitized = sanitizeNextRoute(value);
+  const queryIndex = sanitized.indexOf('?');
+  return queryIndex >= 0
+    ? { pathname: sanitized.slice(0, queryIndex) || DEFAULT_POST_SIGN_IN_ROUTE, search: sanitized.slice(queryIndex) }
+    : { pathname: sanitized, search: '' };
+}
+
 module.exports = {
+  DEFAULT_POST_SIGN_IN_ROUTE,
   STORAGE_KEY,
   buildAuthHeaders,
   clearBrowserSessionConfig,
   decodeJwtPayload,
+  hasSessionExpired,
+  isAuthenticatedSession,
+  readSessionClaims,
   readBrowserSessionConfig,
   resolveApiBaseUrl,
+  sanitizeNextRoute,
+  splitRouteTarget,
   writeBrowserSessionConfig,
 };

--- a/tests/contract/audit-openapi.contract.test.js
+++ b/tests/contract/audit-openapi.contract.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const { createAuditApiServer } = require('../../lib/audit/http');
+const { signBrowserAuthCode } = require('../../lib/auth/jwt');
 
 function sign(payload, secret) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
@@ -33,9 +34,19 @@ async function withServer(run) {
   }
 }
 
+function browserAuthCode(secret, payload = {}, options = {}) {
+  return signBrowserAuthCode({
+    actorId: 'pm-1',
+    tenantId: 'tenant-contract',
+    roles: ['pm', 'reader'],
+    ...payload,
+  }, secret, options);
+}
+
 test('openapi contract documents the live audit routes and auth model', () => {
   const spec = fs.readFileSync(path.join(__dirname, '../../docs/api/audit-foundation-openapi.yml'), 'utf8');
   const ownerReadSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-owner-surfaces-openapi.yml'), 'utf8');
+  const browserAuthSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/authenticated-browser-app-openapi.yml'), 'utf8');
 
   for (const snippet of [
     '/tasks:',
@@ -68,6 +79,17 @@ test('openapi contract documents the live audit routes and auth model', () => {
     'Assignment mutation stays on `PATCH /tasks/{id}/assignment`.',
   ]) {
     assert.match(ownerReadSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  for (const snippet of [
+    '/auth/session:',
+    '/api/auth/session:',
+    'authCode',
+    'accessToken',
+    'expiresAt',
+    'Signed browser bootstrap artifact from the trusted internal auth source.',
+  ]) {
+    assert.match(browserAuthSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 });
 
@@ -160,5 +182,24 @@ test('documented endpoints satisfy the runtime contract', async () => {
       headers: authHeaders(secret, { roles: ['admin'] }),
     });
     assert.equal(response.status, 202);
+  });
+});
+
+test('browser auth bootstrap endpoint satisfies the documented session contract', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret),
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.equal(typeof payload.data.accessToken, 'string');
+    assert.equal(payload.data.claims.actor_id, 'pm-1');
+    assert.equal(payload.data.claims.tenant_id, 'tenant-contract');
+    assert.deepEqual(payload.data.claims.roles, ['pm', 'reader']);
   });
 });

--- a/tests/security/audit-api.security.test.js
+++ b/tests/security/audit-api.security.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const { createAuditApiServer } = require('../../lib/audit/http');
+const { signBrowserAuthCode } = require('../../lib/auth/jwt');
 
 function sign(payload, secret, header = { alg: 'HS256', typ: 'JWT' }) {
   const headerPart = Buffer.from(JSON.stringify(header)).toString('base64url');
@@ -21,10 +22,19 @@ async function withServer(run, options = {}) {
   const { port } = server.address();
 
   try {
-    await run({ baseUrl: `http://127.0.0.1:${port}`, secret });
+    await run({ baseUrl: `http://127.0.0.1:${port}`, secret, baseDir });
   } finally {
     await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
   }
+}
+
+function browserAuthCode(secret, payload = {}, options = {}) {
+  return signBrowserAuthCode({
+    actorId: 'pm-1',
+    tenantId: 'tenant-sec',
+    roles: ['pm', 'reader'],
+    ...payload,
+  }, secret, options);
 }
 
 test('rejects tampered, expired, and issuer-mismatched bearer tokens', async () => {
@@ -146,4 +156,81 @@ test('reader scope keeps owner metadata visible while assignment remains forbidd
     });
     assert.equal(response.status, 403);
   });
+});
+
+test('browser auth bootstrap rejects missing and incomplete auth codes', async () => {
+  await withServer(async ({ baseUrl, secret, baseDir }) => {
+    let response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error.code, 'missing_auth_code');
+
+    response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: 'actor=pm-1;roles=pm,reader',
+      }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error.code, 'invalid_auth_code');
+
+    response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode('wrong-secret'),
+      }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error.code, 'invalid_auth_code');
+
+    response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret, {}, { issuer: 'unexpected-issuer' }),
+      }),
+    });
+    assert.equal(response.status, 200);
+
+    const log = fs.readFileSync(path.join(baseDir, 'observability', 'workflow-audit.log'), 'utf8');
+    assert.match(log, /"path":"\/auth\/session"/);
+    assert.match(log, /"error_code":"invalid_auth_code"/);
+    assert.match(log, /"request_id":"/);
+  });
+
+  await withServer(async ({ baseUrl, secret }) => {
+    const response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret, {}, { issuer: 'unexpected-issuer' }),
+      }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error.code, 'invalid_auth_code');
+  }, { browserAuthCodeIssuer: 'expected-issuer' });
+});
+
+test('browser bootstrap tokens stay usable when the API enforces issuer and audience verification', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret),
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+
+    const followUp = await fetch(`${baseUrl}/tasks`, {
+      headers: { authorization: `Bearer ${payload.data.accessToken}` },
+    });
+    assert.equal(followUp.status, 200);
+  }, { jwtIssuer: 'expected-issuer', jwtAudience: 'expected-audience' });
 });

--- a/tests/unit/audit-api.test.js
+++ b/tests/unit/audit-api.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const { createAuditApiServer } = require('../../lib/audit/http');
+const { signBrowserAuthCode } = require('../../lib/auth/jwt');
 
 function sign(payload, secret) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
@@ -17,6 +18,15 @@ function authHeaders(secret, payload = {}) {
   return {
     authorization: `Bearer ${sign({ sub: 'principal-engineer', tenant_id: 'tenant-a', roles: ['admin'], exp: Math.floor(Date.now() / 1000) + 60, ...payload }, secret)}`,
   };
+}
+
+function browserAuthCode(secret, payload = {}, options = {}) {
+  return signBrowserAuthCode({
+    actorId: 'pm-1',
+    tenantId: 'tenant-a',
+    roles: ['pm', 'reader'],
+    ...payload,
+  }, secret, options);
 }
 
 async function withServer(run, options = {}) {
@@ -63,6 +73,100 @@ test('enforces bearer-token auth context and isolates reads by tenant claim', as
     assert.equal(wrongTenantState.status, 404);
     assert.equal((await wrongTenantState.json()).error.code, 'task_not_found');
   });
+});
+
+test('issues browser bootstrap sessions from the auth exchange endpoint and supports the /api alias', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    let response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret),
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+    assert.equal(payload.success, true);
+    assert.ok(payload.data.accessToken);
+    assert.equal(payload.data.claims.actor_id, 'pm-1');
+    assert.equal(payload.data.claims.tenant_id, 'tenant-a');
+    assert.deepEqual(payload.data.claims.roles, ['pm', 'reader']);
+
+    const sessionRead = await fetch(`${baseUrl}/tasks`, {
+      headers: {
+        authorization: `Bearer ${payload.data.accessToken}`,
+      },
+    });
+    assert.equal(sessionRead.status, 200);
+
+    response = await fetch(`${baseUrl}/api/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret, {
+          actorId: 'engineer-1',
+          roles: ['engineer', 'reader', 'contributor'],
+        }),
+      }),
+    });
+    assert.equal(response.status, 200);
+    const aliasPayload = await response.json();
+    assert.equal(aliasPayload.success, true);
+    assert.equal(aliasPayload.data.claims.actor_id, 'engineer-1');
+  });
+});
+
+test('rejects malformed browser auth bootstrap requests', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    let response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    assert.equal(response.status, 400);
+    assert.equal((await response.json()).error.code, 'missing_auth_code');
+
+    response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ authCode: 'tenant=tenant-a;roles=reader' }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error.code, 'invalid_auth_code');
+
+    response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ authCode: `${browserAuthCode(secret)}tampered` }),
+    });
+    assert.equal(response.status, 401);
+    assert.equal((await response.json()).error.code, 'invalid_auth_code');
+  });
+});
+
+test('browser bootstrap session tokens include configured issuer and audience claims', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const response = await fetch(`${baseUrl}/auth/session`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        authCode: browserAuthCode(secret),
+      }),
+    });
+    assert.equal(response.status, 200);
+    const payload = await response.json();
+
+    const sessionRead = await fetch(`${baseUrl}/tasks`, {
+      headers: {
+        authorization: `Bearer ${payload.data.accessToken}`,
+      },
+    });
+    assert.equal(sessionRead.status, 200);
+
+    const claims = JSON.parse(Buffer.from(payload.data.accessToken.split('.')[1], 'base64url').toString('utf8'));
+    assert.equal(claims.iss, 'expected-issuer');
+    assert.equal(claims.aud, 'expected-audience');
+  }, { jwtIssuer: 'expected-issuer', jwtAudience: 'expected-audience' });
 });
 
 test('enforces role-based permissions for writes and metrics', async () => {

--- a/tests/unit/audit-jwt-auth.test.js
+++ b/tests/unit/audit-jwt-auth.test.js
@@ -1,7 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const crypto = require('crypto');
-const { verifyHmacJwt } = require('../../lib/auth/jwt');
+const { signBrowserAuthCode, verifyBrowserAuthCode, verifyHmacJwt } = require('../../lib/auth/jwt');
 
 function sign(payload, secret) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
@@ -16,4 +16,33 @@ test('verifies HS256 bearer tokens', () => {
   const claims = verifyHmacJwt(token, secret);
   assert.equal(claims.sub, 'principal-engineer');
   assert.equal(claims.tenant_id, 'tenant-a');
+});
+
+test('signs and verifies trusted browser auth codes with normalized claims', () => {
+  const secret = 'browser-auth-secret';
+  const authCode = signBrowserAuthCode({
+    actorId: 'pm-1',
+    tenantId: 'tenant-a',
+    roles: ['pm', 'reader'],
+  }, secret, {
+    issuer: 'internal-auth',
+    audience: 'browser-shell',
+  });
+
+  const verified = verifyBrowserAuthCode(authCode, secret, {
+    issuer: 'internal-auth',
+    audience: 'browser-shell',
+  });
+
+  assert.equal(verified.actorId, 'pm-1');
+  assert.equal(verified.tenantId, 'tenant-a');
+  assert.deepEqual(verified.roles, ['pm', 'reader']);
+  assert.equal(verified.claims.sub, 'pm-1');
+  assert.equal(verified.claims.tenant_id, 'tenant-a');
+  assert.deepEqual(verified.claims.roles, ['pm', 'reader']);
+  assert.equal(verified.claims.token_use, 'browser_auth_code');
+  assert.equal(verified.claims.iss, 'internal-auth');
+  assert.equal(verified.claims.aud, 'browser-shell');
+  assert.equal(typeof verified.claims.iat, 'number');
+  assert.equal(typeof verified.claims.exp, 'number');
 });

--- a/tests/unit/task-browser-session.test.js
+++ b/tests/unit/task-browser-session.test.js
@@ -5,8 +5,13 @@ const {
   buildAuthHeaders,
   clearBrowserSessionConfig,
   decodeJwtPayload,
+  hasSessionExpired,
+  isAuthenticatedSession,
+  readSessionClaims,
   readBrowserSessionConfig,
   resolveApiBaseUrl,
+  sanitizeNextRoute,
+  splitRouteTarget,
   writeBrowserSessionConfig,
 } = require('../../src/app/session');
 
@@ -27,9 +32,17 @@ function createStorage() {
 
 test('browser session config round-trips through storage', () => {
   const storage = createStorage();
-  const written = writeBrowserSessionConfig({ bearerToken: ' abc ', apiBaseUrl: 'http://api.local///' }, storage);
+  const written = writeBrowserSessionConfig({
+    bearerToken: ' abc ',
+    apiBaseUrl: 'http://api.local///',
+    expiresAt: '2026-04-10T01:00:00.000Z',
+  }, storage);
 
-  assert.deepEqual(written, { bearerToken: 'abc', apiBaseUrl: 'http://api.local' });
+  assert.deepEqual(written, {
+    bearerToken: 'abc',
+    apiBaseUrl: 'http://api.local',
+    expiresAt: '2026-04-10T01:00:00.000Z',
+  });
   assert.deepEqual(readBrowserSessionConfig(storage), written);
 });
 
@@ -54,10 +67,75 @@ test('decodeJwtPayload decodes base64url claims for display', () => {
   });
 });
 
+test('readSessionClaims decodes actor, tenant, and role metadata from the stored token', () => {
+  globalThis.atob = (input) => Buffer.from(input, 'base64').toString('utf8');
+  const payload = Buffer.from(JSON.stringify({
+    sub: 'pm-1',
+    tenant_id: 'tenant-a',
+    roles: ['pm', 'reader'],
+    exp: Math.floor(Date.parse('2026-04-10T01:00:00.000Z') / 1000),
+  })).toString('base64url');
+
+  const claims = readSessionClaims({
+    bearerToken: `header.${payload}.sig`,
+  });
+
+  assert.deepEqual(claims, {
+    sub: 'pm-1',
+    tenant_id: 'tenant-a',
+    roles: ['pm', 'reader'],
+    exp: Math.floor(Date.parse('2026-04-10T01:00:00.000Z') / 1000),
+  });
+});
+
+test('isAuthenticatedSession requires a non-expired token with tenant and actor claims', () => {
+  globalThis.atob = (input) => Buffer.from(input, 'base64').toString('utf8');
+  const activePayload = Buffer.from(JSON.stringify({
+    sub: 'pm-1',
+    tenant_id: 'tenant-a',
+    roles: ['pm', 'reader'],
+    exp: Math.floor(Date.parse('2026-04-10T01:00:00.000Z') / 1000),
+  })).toString('base64url');
+  const expiredPayload = Buffer.from(JSON.stringify({
+    sub: 'pm-1',
+    tenant_id: 'tenant-a',
+    roles: ['pm', 'reader'],
+    exp: Math.floor(Date.parse('2026-04-08T01:00:00.000Z') / 1000),
+  })).toString('base64url');
+
+  assert.equal(isAuthenticatedSession({ bearerToken: `header.${activePayload}.sig` }, new Date('2026-04-09T12:00:00.000Z')), true);
+  assert.equal(isAuthenticatedSession({ bearerToken: `header.${expiredPayload}.sig` }, new Date('2026-04-09T12:00:00.000Z')), false);
+  assert.equal(isAuthenticatedSession({ bearerToken: '' }, new Date('2026-04-09T12:00:00.000Z')), false);
+});
+
+test('hasSessionExpired honors explicit expiry timestamps', () => {
+  assert.equal(hasSessionExpired({ expiresAt: '2026-04-09T11:59:59.000Z' }, new Date('2026-04-09T12:00:00.000Z')), true);
+  assert.equal(hasSessionExpired({ expiresAt: '2026-04-09T12:00:01.000Z' }, new Date('2026-04-09T12:00:00.000Z')), false);
+});
+
+test('sanitizeNextRoute preserves in-app query strings and blocks unsafe redirects', () => {
+  assert.equal(sanitizeNextRoute('/tasks?view=board'), '/tasks?view=board');
+  assert.equal(sanitizeNextRoute('/overview/pm?bucket=needs-attention#ignored'), '/overview/pm?bucket=needs-attention');
+  assert.equal(sanitizeNextRoute('https://example.com'), '/tasks');
+  assert.equal(sanitizeNextRoute('//example.com/tasks'), '/tasks');
+  assert.equal(sanitizeNextRoute('/sign-in?next=/tasks'), '/tasks');
+});
+
+test('splitRouteTarget separates pathname and query string for post-sign-in restore', () => {
+  assert.deepEqual(splitRouteTarget('/tasks?view=board'), {
+    pathname: '/tasks',
+    search: '?view=board',
+  });
+  assert.deepEqual(splitRouteTarget('/overview/pm'), {
+    pathname: '/overview/pm',
+    search: '',
+  });
+});
+
 test('clearBrowserSessionConfig removes persisted state', () => {
   const storage = createStorage();
   writeBrowserSessionConfig({ bearerToken: 'jwt', apiBaseUrl: 'http://api.local' }, storage);
   clearBrowserSessionConfig(storage);
 
-  assert.deepEqual(readBrowserSessionConfig(storage), { bearerToken: '', apiBaseUrl: '' });
+  assert.deepEqual(readBrowserSessionConfig(storage), { bearerToken: '', apiBaseUrl: '', expiresAt: '' });
 });


### PR DESCRIPTION
Summary
- harden /auth/session so browser sessions are only minted from a verified trusted auth code and propagate configured issuer/audience claims
- update the browser bootstrap flow to use the trusted auth exchange and preserve pathname plus query string across post-sign-in restoration
- add regression coverage for auth bootstrap denial logging, issuer/audience compatibility, and query-bearing route restores

Testing
- node --test tests/unit/task-browser-session.test.js tests/unit/audit-api.test.js tests/security/audit-api.security.test.js
- npx vitest run src/app/App.test.tsx -t "restores board view query state after sign-in|restores PM overview bucket query state after session recovery sign-in|restores task detail query state after sign-in|restores inbox pathname and search exactly after sign-in" --maxWorkers=1

Closes #60
Closes #61
Closes #62