### PR TITLE
Handle task-detail auth failures consistently

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "serve:browser": "node scripts/serve-browser-dist.js",
     "docker:browser": "docker build -f Dockerfile.browser -t engineering-team-task-browser .",
     "test": "npm run test:unit && node --test tests/contract/*.test.js tests/integration/role-inbox-filtering.integration.test.js tests/integration/pm-overview-filtering.integration.test.js tests/integration/task-list-owner-filters.integration.test.js tests/e2e/*.test.js tests/property/*.test.js tests/performance/*.test.js tests/security/*.test.js chaos/*.test.js && npm run test:browser",
-    "test:unit": "node --test tests/unit/audit-api.test.js tests/unit/browser-session-storage.test.js tests/unit/task-detail-adapter.test.js tests/unit/task-detail-responsive.test.js tests/unit/specialist-delegation.test.js && npm run test:ui:vitest",
+    "test:unit": "node --test tests/unit/audit-api.test.js tests/unit/task-browser-session.test.js tests/unit/task-detail-adapter.test.js tests/unit/task-detail-responsive.test.js tests/unit/specialist-delegation.test.js && npm run test:ui:vitest",
     "test:contract": "node --test tests/contract/*.test.js",
     "test:e2e": "node --test tests/e2e/*.test.js",
     "test:property": "node --test tests/property/*.test.js",

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -41,6 +41,76 @@ button {
   padding: 48px 24px 64px;
 }
 
+.app-shell--auth {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+}
+
+.app-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+  padding: 16px 18px;
+  border: 1px solid #cbd5e1;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+}
+
+.app-nav__links,
+.app-nav__session {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.auth-card {
+  width: min(100%, 560px);
+  display: grid;
+  gap: 18px;
+  padding: 28px;
+  border: 1px solid #cbd5e1;
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(241, 245, 249, 0.98));
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.08);
+}
+
+.auth-card__intro {
+  display: grid;
+  gap: 8px;
+}
+
+.auth-form select {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 10px 12px;
+  background: #fff;
+}
+
+.auth-status {
+  margin: 0;
+  padding: 12px 14px;
+  border-radius: 14px;
+}
+
+.auth-status--notice {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border: 1px solid #bfdbfe;
+}
+
+.auth-status--error {
+  background: #fff1f2;
+  color: #be123c;
+  border: 1px solid #fecdd3;
+}
+
 .page-header {
   display: flex;
   gap: 24px;
@@ -84,6 +154,10 @@ button {
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.9);
   box-shadow: 0 12px 32px rgba(15, 23, 42, 0.06);
+}
+
+.session-form--summary {
+  align-content: start;
 }
 
 .route-form label,

--- a/src/features/task-detail/adapter.browser.js
+++ b/src/features/task-detail/adapter.browser.js
@@ -165,14 +165,21 @@ async function parseJsonResponse(response) {
   return payload;
 }
 
-export function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders } = {}) {
+export function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders, onAuthFailure } = {}) {
   const request = async (path, init = {}) => {
     const response = await fetchImpl(`${baseUrl}${path}`, {
       method: init.method || 'GET',
       headers: { ...(typeof getHeaders === 'function' ? await getHeaders() : undefined), ...(init.headers || {}) },
       body: init.body,
     });
-    return parseJsonResponse(response);
+    try {
+      return await parseJsonResponse(response);
+    } catch (error) {
+      if ((error?.status === 401 || error?.code === 'invalid_token' || error?.code === 'missing_auth_context') && typeof onAuthFailure === 'function') {
+        onAuthFailure(error);
+      }
+      throw error;
+    }
   };
 
   return {

--- a/src/features/task-detail/adapter.js
+++ b/src/features/task-detail/adapter.js
@@ -167,14 +167,21 @@ async function parseJsonResponse(response) {
   return payload;
 }
 
-function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders } = {}) {
+function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders, onAuthFailure } = {}) {
   const request = async (path, init = {}) => {
     const response = await fetchImpl(`${baseUrl}${path}`, {
       method: init.method || 'GET',
       headers: { ...(typeof getHeaders === 'function' ? await getHeaders() : undefined), ...(init.headers || {}) },
       body: init.body,
     });
-    return parseJsonResponse(response);
+    try {
+      return await parseJsonResponse(response);
+    } catch (error) {
+      if ((error?.status === 401 || error?.code === 'invalid_token' || error?.code === 'missing_auth_context') && typeof onAuthFailure === 'function') {
+        onAuthFailure(error);
+      }
+      throw error;
+    }
   };
 
   return {

--- a/tests/unit/task-detail-adapter.test.js
+++ b/tests/unit/task-detail-adapter.test.js
@@ -57,6 +57,30 @@ test('task detail client prefers dedicated detail view model endpoint when avail
   assert.equal(model.shell.historyItems[0].title, 'Stage changed');
 });
 
+test('task detail client surfaces auth failures through the shared auth callback', async () => {
+  let authFailure = null;
+  const client = createTaskDetailApiClient({
+    baseUrl: 'http://audit.local',
+    onAuthFailure: (error) => {
+      authFailure = error;
+    },
+    fetchImpl: async () => ({
+      ok: false,
+      status: 401,
+      json: async () => ({
+        error: {
+          code: 'invalid_token',
+          message: 'jwt expired',
+        },
+      }),
+    }),
+  });
+
+  await assert.rejects(() => client.fetchTaskList(), /jwt expired/);
+  assert.equal(authFailure.status, 401);
+  assert.equal(authFailure.code, 'invalid_token');
+});
+
 
 test('dedicated detail payload avoids extra linked-resource fetches and caps request count at one', async () => {
   let requestCount = 0;


### PR DESCRIPTION
Summary
- route task-detail API auth failures through the shared auth callback so expired or invalid sessions recover consistently
- add the missing auth-shell styles that the previous browser sign-in flow depends on
- point the unit test script at the current task-browser session suite

Testing
- npm run test:unit

Refs #59