### PR TITLE
Add US-002 design and verification artifacts

### DIFF
--- a/docs/design/US-002-design.md
+++ b/docs/design/US-002-design.md
@@ -1,0 +1,64 @@
+# US-002 Design
+
+## Research & Context
+## Evidence
+- The existing browser app is a single React shell in `src/app/App.jsx` that mounts list, inbox, PM overview, task detail, and task creation routes behind a manual session bootstrap panel.
+- Session state before this change was stored in `sessionStorage` via `src/app/session.browser.js` as `{ bearerToken, apiBaseUrl }`, which required manual JWT pasting.
+- The audit API already enforces JWT bearer auth and tenant claims in `lib/audit/http.js` and `lib/auth/jwt.js`, so the missing piece was browser-friendly session issuance plus client route protection.
+- The repo does not include the requested workflow orchestrators such as `.workflow/state.json`, `.agent/skills/test-coverage-gap-analysis`, or `npm run ag:workflow ...`, so story execution had to be mapped onto the real repo structure and available test runners.
+
+## Coverage Gap Analysis
+## Evidence
+- Existing UI coverage in `src/app/App.test.tsx` validated task detail, list, board, PM overview, and inbox behavior, but it did not validate sign-in, protected-route redirects, or expired-session recovery.
+- Existing unit coverage in `tests/unit/task-browser-session.test.js` covered token/header storage basics, but it did not validate expiry logic, claim extraction, or auth bootstrap code generation.
+- Existing API coverage in `tests/unit/audit-api.test.js` covered protected task routes, but it did not cover a browser auth bootstrap endpoint.
+- Gap-fill plan implemented in this change:
+- add session helper tests for claim parsing, expiry, authenticated-session checks, and auth-code generation
+- add API tests for `POST /auth/session` and `/api/auth/session`
+- add UI tests for protected-route redirect, sign-in success, and expired-session redirect
+- add adapter coverage for centralized 401 auth-failure callback handling
+
+## User Story
+## Evidence
+- As an internal workflow user, I want to sign in to the browser app and land in a navigable app shell so that I can use task board, task list, PM overview, inbox, and task detail views without manual JWT handling.
+- Acceptance criteria implemented in scope:
+- unauthenticated visits to protected routes redirect to `/sign-in`
+- sign-in exchanges an internal auth bootstrap code for a JWT session
+- authenticated users land on `/tasks` by default and keep shared shell navigation
+- expired sessions redirect back to sign-in with a recovery message
+- role-gated controls remain based on token roles, so PM/admin-only assignment behavior is preserved
+- Explicit repo-scope reality check:
+- this repo does not contain external identity provider integration
+- the supported browser sign-in flow is an internal auth bootstrap exchange backed by `POST /auth/session`
+- manual JWT pasting is removed from the default path but can still be preserved as an internal fallback later if needed
+
+## Feasibility Check
+## Evidence
+- Backend feasibility: the audit API already signs and verifies HMAC JWTs, so adding a session bootstrap route was low-risk and reused the existing JWT secret and claims shape.
+- Frontend feasibility: route state already lived in `App.jsx`, so adding a protected-route guard and sign-in route did not require a router rewrite.
+- Failure-mode validation:
+- expired-token handling can be centralized in the browser data client by firing an auth-failure callback on `401`, avoiding per-route duplication
+- detail-route `403` restricted states remain server-authoritative and are not treated as forced sign-out events
+- Risk notes:
+- full workflow automation and closeout scripts from the requested process are absent in this checkout
+- the browser test surface is concentrated in one large `App.test.tsx`, so broad-suite runtime remains the main verification risk area
+
+## Technical Plan
+## Evidence
+- Browser session model:
+- extend `src/app/session.browser.js` and `src/app/session.js` to support expiry-aware sessions, claim reads, authenticated-session checks, and internal auth-code generation
+- API bootstrap:
+- add `POST /auth/session` and `/api/auth/session` support in `lib/audit/http.js`
+- reuse HMAC JWT signing in `lib/auth/jwt.js`
+- Browser shell:
+- guard `/`, `/tasks`, `/tasks?view=board`, `/overview/pm`, `/inbox/*`, and `/tasks/:id`
+- add a first-class `/sign-in` route and internal sign-in form
+- add shared authenticated navigation plus explicit sign-out
+- keep existing route modules and detail/list adapters intact
+- Centralized auth recovery:
+- add `onAuthFailure` handling in the task-detail API client for `401` and invalid-token cases
+- redirect to sign-in with a recoverable message when session-authenticated requests fail
+- Artifacts created for the story:
+- `docs/api/authenticated-browser-app-openapi.yml`
+- `docs/diagrams/workflow-US-002.mmd`
+- `docs/diagrams/architecture-US-002.mmd`

--- a/docs/diagrams/architecture-US-002.mmd
+++ b/docs/diagrams/architecture-US-002.mmd
@@ -1,0 +1,15 @@
+flowchart LR
+  User[Internal workflow user]
+  Browser[Authenticated browser shell\nsrc/app/App.jsx]
+  Session[Session helpers\nsrc/app/session.browser.js]
+  DetailClient[Task browser data client\nsrc/features/task-detail/adapter.browser.js]
+  AuditApi[Audit API\nlib/audit/http.js]
+  Jwt[JWT signing and verification\nlib/auth/jwt.js]
+
+  User --> Browser
+  Browser --> Session
+  Browser --> DetailClient
+  Browser --> AuditApi
+  DetailClient --> AuditApi
+  AuditApi --> Jwt
+  Session --> Jwt

--- a/docs/diagrams/workflow-US-002.mmd
+++ b/docs/diagrams/workflow-US-002.mmd
@@ -1,0 +1,21 @@
+flowchart TD
+  A[User opens browser app] --> B{Session present and valid?}
+  B -- No --> C[/sign-in/]
+  C --> D[Internal auth bootstrap form]
+  D --> E[POST /auth/session]
+  E --> F[JWT session stored in sessionStorage]
+  F --> G[/tasks default landing route]
+  B -- Yes --> G
+  G --> H[Shared shell navigation]
+  H --> I[/tasks list]
+  H --> J[/tasks?view=board]
+  H --> K[/overview/pm]
+  H --> L[/inbox/:role]
+  H --> M[/tasks/:taskId]
+  I --> N{401 or invalid token?}
+  J --> N
+  K --> N
+  L --> N
+  M --> N
+  N -- Yes --> O[Clear session and redirect to /sign-in with recovery message]
+  N -- No --> P[Continue authenticated workflow]

--- a/docs/reports/US-002-review.md
+++ b/docs/reports/US-002-review.md
@@ -1,0 +1,8 @@
+# US-002 Review
+
+## UAT Evidence
+- Formal reviewer approval was not collected in this session.
+- Current readiness evidence is limited to code review plus automated verification artifacts:
+- `docs/reports/test_report_US-002.md`
+- `docs/reports/security_audit_US-002.md`
+- `docs/reports/customer_review_US-002.md`

--- a/docs/reports/US-002-verification.md
+++ b/docs/reports/US-002-verification.md
@@ -1,0 +1,19 @@
+# US-002 Verification
+
+## E2E Results
+- Existing API-oriented E2E suites remain available under `tests/e2e/`.
+- No new US-002-specific browser E2E automation was completed in this pass.
+
+## Regression Results
+- Targeted unit and UI verification passed for the newly added auth-shell behaviors:
+- `node --test tests/unit/task-browser-session.test.js tests/unit/task-detail-adapter.test.js`
+- `node --test tests/unit/audit-api.test.js`
+- targeted `vitest` runs for sign-in, redirect protection, and expired-session recovery in `src/app/App.test.tsx`
+- Broad `src/app/App.test.tsx` execution still needs follow-up because the full local suite did not finish cleanly in this session.
+
+## Security Audit
+- See `docs/reports/security_audit_US-002.md`.
+- Security evidence includes malformed auth bootstrap rejection and preserved server-authoritative role gating.
+
+## Full Suite Report
+- No generated `docs/test-reports/test-suite-report-*.md` artifact exists in this checkout for US-002.

--- a/docs/reports/customer_review_US-002.md
+++ b/docs/reports/customer_review_US-002.md
@@ -1,0 +1,9 @@
+# Customer Review US-002
+
+## Evidence
+- Formal UAT was not performed in this session.
+- Internal acceptance evidence currently comes from automated browser-shell tests covering sign-in, redirect protection, and expired-session recovery.
+- Manual review is still needed for:
+- final sign-in copy and profile labels
+- broad browser-shell regression across all list/detail surfaces
+- any deployment-environment auth/session behavior outside local test doubles

--- a/docs/reports/security_audit_US-002.md
+++ b/docs/reports/security_audit_US-002.md
@@ -1,0 +1,7 @@
+# Security Audit US-002
+
+## Evidence
+- Added negative coverage in `tests/security/audit-api.security.test.js` for missing and incomplete browser auth bootstrap codes.
+- Added API-level validation in `tests/unit/audit-api.test.js` to reject malformed auth bootstrap requests.
+- Browser auth recovery now centralizes `401` invalid-token handling in the shared data client instead of duplicating logic per route.
+- Role-gated write controls remain tied to JWT claims and existing server authorization, so client navigation changes do not bypass assignment permissions.

--- a/docs/reports/test_report_US-002.md
+++ b/docs/reports/test_report_US-002.md
@@ -1,0 +1,25 @@
+# Test Report US-002
+
+## UI Testing
+### Evidence
+- `src/app/App.test.tsx` now covers protected-route redirect, sign-in success, expired-session redirect, and existing list/detail/inbox/overview rendering flows.
+- Targeted vitest runs passed for:
+- protected-route redirect to sign-in
+- sign-in exchange and default landing route
+- expired-session redirect recovery
+
+## Unit Testing
+### Evidence
+- `tests/unit/task-browser-session.test.js` passed after adding coverage for claim parsing, expiry handling, authenticated-session checks, and auth bootstrap code generation.
+- `tests/unit/task-detail-adapter.test.js` passed after adding centralized auth-failure callback coverage for `401` invalid-token responses.
+- `tests/unit/audit-api.test.js` passed after adding browser auth bootstrap endpoint coverage for `/auth/session` and `/api/auth/session`.
+
+## E2E Testing
+### Evidence
+- No new browser E2E harness for US-002 was added in this pass.
+- Existing repo E2E coverage remains focused on API and current browser task surfaces; see `tests/e2e/` for available suites.
+
+## Regression Testing
+### Evidence
+- Existing list/detail/board/PM overview/authz behaviors were preserved in the modified browser shell and supporting adapters.
+- Full `src/app/App.test.tsx` suite still requires additional follow-up validation because the broad run did not complete cleanly under the available local runner during this session.

--- a/docs/user-stories/US-002-authenticated-browser-app.md
+++ b/docs/user-stories/US-002-authenticated-browser-app.md
@@ -1,0 +1,299 @@
+# USER STORY — Authenticated Browser App Shell
+
+**Story ID:** US-002  
+**Template Tier:** Standard  
+**Standards Verified:** Story authored from `docs/templates/USER_STORY_TEMPLATE.md` for the current repo shape and existing browser runtime constraints.
+
+## 1. User Story
+
+As an internal workflow user,
+I want to sign in to the browser app and land in a navigable app shell,
+so that I can use the task board, task list, and task detail views without manually pasting a JWT or knowing a task ID in advance.
+
+**Business Context & Success Metrics**
+
+The repo already has a usable task-detail browser runtime, but it is still intentionally thin. The current entry flow requires a user to open a deep link such as `/tasks/TSK-42` and manually paste a bearer JWT into a session bootstrap panel. That is acceptable for engineering validation, but it is the main blocker to actual day-to-day usage.
+
+This story turns the current thin runtime into an internally usable application shell by adding:
+- a real sign-in/session bootstrap flow
+- a default authenticated landing route
+- shared app-shell navigation across board, list, and detail surfaces
+- protected-route behavior for expired or missing sessions
+
+**Success Metrics**
+- 90% of internal users can reach a usable authenticated landing page in under 60 seconds without developer assistance.
+- 95% of successful sign-ins create a working session that can load `/tasks`, `/tasks?view=board`, and `/tasks/:id` without manual token entry.
+- 0 manual JWT pasting steps remain in the default happy path for internal users.
+- Protected routes redirect unauthenticated users to sign-in in 100% of automated coverage scenarios.
+- Session-expiry handling returns the user to sign-in with a clear recovery path in under 2 user actions.
+
+## 2. Acceptance Criteria
+
+### Must Have
+
+**Scenario 1 — Internal user signs in and lands in the app shell**  
+Given an internal user opens the browser app without an active session  
+When they complete the supported sign-in flow  
+Then the app stores a valid authenticated session  
+And redirects the user to the default landing page  
+And the global app shell navigation is visible.
+
+**Scenario 2 — Authenticated user can navigate to board, list, and detail surfaces**  
+Given a user has an active authenticated session  
+When they use the app navigation  
+Then they can open the task list view  
+And they can open the board view  
+And they can open a task detail route without manually providing a token.
+
+**Scenario 3 — Unauthenticated user is blocked from protected routes**  
+Given a user has no active authenticated session  
+When they attempt to open `/tasks`, `/tasks?view=board`, or `/tasks/:taskId`  
+Then the app redirects them to the sign-in route  
+And no protected data is rendered before the redirect completes.
+
+**Scenario 4 — Expired or invalid session is handled cleanly**  
+Given a user has a stale, expired, or invalid session  
+When a protected API request returns an authentication failure  
+Then the app clears the invalid session  
+And redirects the user to sign-in  
+And shows a recoverable message explaining that they need to sign in again.
+
+**Scenario 5 — Authorized role-specific controls remain gated after sign-in**  
+Given two authenticated users with different roles  
+When both users open the same task detail surface  
+Then both can access the shared read surfaces allowed by `state:read`  
+And only authorized PM/admin users see assignment controls  
+And unauthorized users do not see write-capable task-management controls.
+
+### Nice to Have
+
+**Scenario 6 — Session survives browser refresh within allowed lifetime**  
+Given a user has an active authenticated session  
+When they refresh the browser tab  
+Then the app restores the session from its persisted storage  
+And keeps the user on their last valid route.
+
+**Scenario 7 — User can sign out explicitly**  
+Given a user has an active authenticated session  
+When they select sign out from the app shell  
+Then the stored session is removed  
+And the user is returned to sign-in  
+And protected routes are inaccessible until they authenticate again.
+
+## 3. Workflow & User Journey
+
+**User Journey (step-by-step)**
+1. User opens the browser app root URL.
+2. User sees a sign-in screen instead of a raw session bootstrap panel.
+3. User authenticates through the supported internal auth method.
+4. App stores the authenticated session and claims needed for API access.
+5. User lands on a default home route, likely the task list or board.
+6. User uses top-level navigation to move between list, board, and task detail views.
+7. User opens a task detail page and sees only the controls allowed for their role.
+8. If the session expires, the app sends the user back to sign-in with a clear explanation.
+
+**System Flow (technical)**
+1. Browser app root route → auth/session bootstrap module
+2. Sign-in UI submit → auth provider or internal token-exchange endpoint
+3. Auth success → normalized session storage → claim parsing
+4. Session state → protected-route guard → app shell router
+5. App shell navigation → list/board/detail routes
+6. Route adapters → existing `/tasks`, `/tasks/:id`, `/tasks/:id/detail`, `/ai-agents`, and assignment endpoints
+7. API `401/403` auth failures → centralized session invalidation handler
+8. Session invalidation → redirect to sign-in with user-facing recovery message
+
+**Error & Edge Cases**
+- Sign-in request fails due to network timeout.
+- Auth provider returns invalid token shape or missing claims.
+- User is authenticated but lacks required tenant claim.
+- Stored session exists but cannot be parsed after a deploy.
+- Browser refresh happens during session write or route transition.
+- Protected API request returns `401` while a user is on a deep-linked detail route.
+- User opens a shared task-detail link with no session and must be redirected safely.
+- Role claims change between sessions and the app must not reuse stale authorization state.
+
+**Required Diagram**
+- Mermaid workflow diagram to be committed at: `/docs/diagrams/workflow-US-002.mmd`
+
+## 4. Automated Test Deliverables
+
+**Required automated deliverables for Standard tier**
+
+```text
+tests/
+├── unit/
+│   └── auth-app-shell.test.ts
+├── integration/
+│   └── auth-app-shell.integration.test.ts
+├── e2e/
+│   └── auth-app-shell.spec.ts
+│   └── page-objects/
+│       └── AuthAppShellPage.ts
+├── contract/
+│   └── pact-auth-session.spec.ts
+├── visual/
+│   └── auth-app-shell.visual.spec.ts
+├── accessibility/
+│   └── auth-app-shell.a11y.spec.ts
+├── performance/
+│   └── lighthouse-auth-shell.spec.ts
+└── security/
+    └── auth-app-shell-security.spec.ts
+
+regression/
+└── Tag all new scenarios with @regression
+```
+
+**Additional Standard Tier Test Requirements**
+- Unit tests for session parsing, route guarding, sign-out behavior, and auth-failure recovery.
+- Integration tests for authenticated navigation, unauthenticated redirects, and stale-session invalidation.
+- E2E coverage for every Given-When-Then scenario in Section 2.
+- Contract tests for any auth/session endpoint or token-exchange response used by the browser runtime.
+- Visual regression coverage for sign-in, signed-in shell, and expired-session states.
+- Accessibility validation with axe-core on sign-in and app-shell routes.
+- Lighthouse CI for the signed-in landing page.
+- Security automation for unauthorized route access, stale token replay, and storage/session handling regressions.
+- Mutation testing configuration targeting 80%+ mutation score for auth-guard and session logic.
+
+**Test Data Management**
+- Fixtures committed under `tests/fixtures/auth-app-shell/`
+- Factory functions for session claims, signed-in users, and expired-session states
+- Seed data for authenticated list/board/detail navigation flows
+
+## 5. Data Model & Schema
+
+Not required for Standard tier.
+
+## 6. Architecture & Integration
+
+**Pattern**
+- Feature-sliced browser application architecture with auth/session bootstrap, protected-route guards, and shared shell navigation layered on top of the existing task list/detail adapters.
+
+**New/Changed Components**
+- Sign-in route and sign-in form UI
+- Session bootstrap and persistence module
+- Route guard for protected browser routes
+- Shared app shell with navigation across board, list, and detail surfaces
+- Auth failure boundary/redirect handling
+- Session-aware route initialization for deep links
+
+**Required Diagram**
+- C4 context/container diagram to be committed at: `/docs/diagrams/architecture-US-002.mmd`
+
+**External Integrations**
+- Internal auth provider or token-exchange endpoint for browser sign-in
+- Existing audit/task APIs protected by bearer JWTs
+
+**Retry/Timeout Configuration**
+- Sign-in request timeout target: 5s
+- Protected API fetch retry: no blind retry on `401`; single retry permitted on transient network failure before surfacing an error
+- Session restore on app load must complete within 500ms before route guard decides whether to redirect
+
+**Circuit Breaker Settings**
+- Reuse platform default fetch/backoff behavior for browser-to-API calls
+- Do not retry invalid credentials or malformed token responses
+
+**Feature Flag**
+- Flag name: `ff_authenticated_browser_app_shell`
+- Platform: Unleash
+- Targeting rules: internal environments first, then internal users with sign-in enabled, then broader tenant rollout if adopted beyond internal use
+
+## 7. API Design
+
+**API Contract**
+- Existing protected task APIs remain authoritative:
+  - `GET /tasks`
+  - `GET /tasks/{taskId}`
+  - `GET /tasks/{taskId}/detail`
+  - `GET /ai-agents`
+  - `PATCH /tasks/{taskId}/assignment`
+- If the chosen auth implementation needs browser-friendly bootstrap or token exchange, define:
+  - `POST /auth/session`
+  - compatibility alias: `POST /api/auth/session`
+
+**Request body**
+
+```json
+{
+  "authCode": "temporary-login-code-or-equivalent"
+}
+```
+
+**Success response**
+
+```json
+{
+  "success": true,
+  "data": {
+    "accessToken": "jwt-token",
+    "expiresAt": "2026-04-10T01:00:00.000Z",
+    "claims": {
+      "tenant_id": "tenant-a",
+      "actor_id": "pm-1",
+      "roles": ["pm"]
+    }
+  }
+}
+```
+
+**Validation/error response examples**
+- `400` malformed auth bootstrap request
+- `401` invalid credentials or expired login exchange
+- `403` authenticated but not permitted to access the application
+- `502` upstream auth provider unavailable
+
+**Committed spec location**
+- `/docs/api/authenticated-browser-app-openapi.yml`
+
+**Versioning Strategy**
+- Additive endpoint change only; existing task APIs remain unchanged.
+- Use existing versionless internal API style unless the auth provider requires a separate versioned namespace.
+
+**Backwards Compatibility**
+- Breaking changes: none to existing task APIs
+- Existing manual JWT bootstrap can remain behind a fallback internal-only path during rollout
+- Existing browser detail/list adapters should continue to function when a bearer token is already present
+
+**Automated API Testing**
+- OpenAPI linting via Spectral
+- Contract verification for auth/session response shape
+- Integration coverage for `401`, `403`, and malformed bootstrap requests
+
+## 8. Security & Compliance
+
+**Standard Tier Security Requirements**
+- Authentication changes are session-based in the browser, backed by bearer JWT access to the existing APIs.
+- Authorization remains role-based and server-authoritative; the client must not infer write permission beyond the claims and server responses.
+- Protected routes must not render sensitive task data before session validation completes.
+- Session storage and invalidation behavior must be covered by automated tests for replay, expiry, and sign-out.
+- Unauthorized access must return `401/403` and redirect safely without leaving stale protected data on screen.
+- Audit-sensitive actions such as assignment must continue to rely on server-side authorization, not client gating alone.
+
+## 8a. Standardized Error Logging
+
+**Mandatory implementation requirements**
+- All auth/session bootstrap API routes must use the project’s centralized error handling and structured logging conventions.
+- Browser session bootstrap failures must map to standardized, user-safe error states instead of ad hoc messages.
+- Any new API route must return structured error payloads and avoid manual inline error formatting.
+- Client-side auth failure handling must centralize `401/403` recovery rather than duplicating logic per route.
+- No `console.log` or `console.error` usage in auth/session implementation paths; use the existing logging approach where server-side logging is needed.
+
+## 9. Definition of Done
+
+- [ ] User can sign in without manually pasting a JWT.
+- [ ] Authenticated landing page exists and is reachable from the app root.
+- [ ] Protected routes redirect unauthenticated users safely.
+- [ ] Board, list, and detail routes all work behind the authenticated app shell.
+- [ ] Session expiry and explicit sign-out are both covered by automated tests.
+- [ ] Role-gated write controls remain visible only to authorized users.
+- [ ] Required diagrams and API spec are authored at the documented paths.
+- [ ] Full Standard-tier automated test matrix is added and passing.
+
+## 10. Out of Scope
+
+- External customer-facing identity flows
+- Social login or consumer identity providers
+- Multi-tenant self-service account management
+- Full live-update subscriptions for task changes
+- Native mobile authentication
+- Replacing server-side RBAC with client-side role logic


### PR DESCRIPTION
Summary
- add the US-002 user story, design notes, workflow and architecture diagrams
- capture verification, review, security, and test-report artifacts for the authenticated browser app shell work
- preserve the implementation context and known follow-up gaps in repo-native documentation

Testing
- documentation only

Refs #59