### PR TITLE
Fix Vercel routing for versioned task-platform API

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Point the browser app at the API:
 ### Vercel deployment
 - This repo can now run on a single Vercel project with the SPA plus serverless API routes.
 - The Vercel API adapter lives under `api/` and wraps `lib/audit/http.js`.
+- Vercel also includes an explicit `api/v1/[...route].js` entry so `/api/v1/*` versioned task-platform routes resolve consistently in production.
 - To avoid route collisions between SPA paths like `/tasks/...` and API paths like `/tasks/...`, set `VITE_TASK_API_BASE_URL=/backend` in Vercel.
 - `vercel.json` rewrites `/backend/*` to the Vercel API functions and falls back non-API browser routes to `index.html`.
 - Required backend env vars in Vercel: `DATABASE_URL`, `AUTH_JWT_SECRET`, and any optional issuer/audience or browser-auth-code settings your environment enforces.

--- a/api/v1/[...route].js
+++ b/api/v1/[...route].js
@@ -1,0 +1,5 @@
+const { handleRequest } = require('../_server');
+
+module.exports = (req, res) => {
+  handleRequest(req, res);
+};


### PR DESCRIPTION
## Summary
- add an explicit Vercel function entrypoint for api/v1 catch-all routing
- document the versioned Vercel route behavior in the README

## Verification
- node -e "const mod=require('./api/v1/[...route]'); console.log(typeof mod);"
- git diff --check -- 'api/v1/[...route].js' README.md

## Context
- /api/healthz and /api/ai-agents are already live on Vercel
- /api/v1/* was still returning Vercel 404s without an explicit api/v1 function entry