### PR TITLE
Add explicit Vercel handlers for versioned API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Point the browser app at the API:
 - This repo can now run on a single Vercel project with the SPA plus serverless API routes.
 - The Vercel API adapter lives under `api/` and wraps `lib/audit/http.js`.
 - Vercel also includes an explicit `api/v1/[...route].js` entry so `/api/v1/*` versioned task-platform routes resolve consistently in production.
+- Vercel additionally exposes explicit `api/v1/tasks.js`, `api/v1/tasks/[...route].js`, and `api/v1/ai-agents.js` handlers so the versioned task-platform routes do not depend on nested catch-all matching quirks.
 - To avoid route collisions between SPA paths like `/tasks/...` and API paths like `/tasks/...`, set `VITE_TASK_API_BASE_URL=/backend` in Vercel.
 - `vercel.json` rewrites `/backend/*` to the Vercel API functions and falls back non-API browser routes to `index.html`.
 - Required backend env vars in Vercel: `DATABASE_URL`, `AUTH_JWT_SECRET`, and any optional issuer/audience or browser-auth-code settings your environment enforces.

--- a/api/v1/ai-agents.js
+++ b/api/v1/ai-agents.js
@@ -1,0 +1,5 @@
+const { handleRequest } = require('../_server');
+
+module.exports = (req, res) => {
+  handleRequest(req, res);
+};

--- a/api/v1/tasks.js
+++ b/api/v1/tasks.js
@@ -1,0 +1,5 @@
+const { handleRequest } = require('../_server');
+
+module.exports = (req, res) => {
+  handleRequest(req, res);
+};

--- a/api/v1/tasks/[...route].js
+++ b/api/v1/tasks/[...route].js
@@ -1,0 +1,5 @@
+const { handleRequest } = require('../../_server');
+
+module.exports = (req, res) => {
+  handleRequest(req, res);
+};


### PR DESCRIPTION
## Summary
- add explicit Vercel handlers for /api/v1/ai-agents and /api/v1/tasks
- add an explicit nested handler for /api/v1/tasks/* routes
- document the explicit versioned route strategy in the README

## Verification
- node -e "for (const file of ['./api/v1/ai-agents','./api/v1/tasks','./api/v1/tasks/[...route]']) { const mod=require(file); console.log(file, typeof mod); }"
- git diff --check -- README.md api/v1/ai-agents.js api/v1/tasks.js 'api/v1/tasks/[...route].js'

## Context
- /api/healthz and /api/ai-agents are live on Vercel
- /api/v1/* still returned Vercel 404s after adding a generic api/v1 catch-all
- this change makes the specific versioned entrypoints first-class