### PR TITLE
Await versioned task-platform reads

### DIFF
--- a/lib/audit/http.js
+++ b/lib/audit/http.js
@@ -1432,11 +1432,11 @@ function createAuditApiServer(options = {}) {
       if (routePath === '/v1/tasks' && req.method === 'GET') {
         const context = requireTenantAccess(req, options);
         requirePermission(context, 'state:read');
-        const data = taskPlatform.listTasks({
+        const data = await withErrorHandling(async () => taskPlatform.listTasks({
           tenantId: context.tenantId,
           ownerAgentId: url.searchParams.has('ownerAgentId') ? url.searchParams.get('ownerAgentId') : undefined,
           status: url.searchParams.has('status') ? url.searchParams.get('status') : undefined,
-        });
+        }))();
         return sendJson(res, 200, { data }, requestId);
       }
 
@@ -1479,7 +1479,10 @@ function createAuditApiServer(options = {}) {
       if (v1TaskMatch && req.method === 'GET') {
         const context = requireTenantAccess(req, options);
         requirePermission(context, 'state:read');
-        const data = taskPlatform.getTask({ tenantId: context.tenantId, taskId: v1TaskMatch[1] });
+        const data = await withErrorHandling(async () => taskPlatform.getTask({
+          tenantId: context.tenantId,
+          taskId: v1TaskMatch[1],
+        }))();
         if (!data) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: v1TaskMatch[1] });
         return sendJson(res, 200, { data }, requestId);
       }


### PR DESCRIPTION
## Summary
- await async task-platform list/get handlers for the versioned task reads
- return resolved JSON payloads instead of unresolved Promise objects
- keep versioned route behavior aligned with the non-versioned API

## Testing
- npm run test:unit
- npm run build
