### PR TITLE
Add validation workflow and issue audit report

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,47 @@
+name: Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  repo-validation:
+    name: Repo validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit, contract, integration, e2e, property, performance, security, and chaos suites
+        run: |
+          npm run test:unit
+          node --test tests/contract/*.test.js tests/integration/role-inbox-filtering.integration.test.js tests/integration/pm-overview-filtering.integration.test.js tests/integration/task-list-owner-filters.integration.test.js tests/integration/task-assignment-integration.test.js tests/e2e/*.test.js tests/property/*.test.js tests/performance/*.test.js tests/security/*.test.js chaos/*.test.js
+
+  browser-validation:
+    name: Browser validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
+
+      - name: Run Playwright browser suite
+        run: npm run test:browser

--- a/docs/reports/STATUS_2026-04-13_ISSUE_AUDIT.md
+++ b/docs/reports/STATUS_2026-04-13_ISSUE_AUDIT.md
@@ -1,0 +1,117 @@
+# Status Audit 2026-04-13
+
+## Scope
+
+This note records the repository-to-issue-tracker audit performed on 2026-04-13 against:
+
+- local `main`
+- `origin/main`
+- open GitHub issues in `wiinc1/engineering-team`
+
+## Repository state
+
+- `main` is in sync with `origin/main` (`git rev-list --left-right --count main...origin/main` returned `0 0`)
+- no open pull requests were present at audit time
+- local quality gates passed:
+  - `npm run lint`
+  - `npm run typecheck`
+  - `npm run test:unit`
+
+## Implemented but still open in GitHub
+
+The following issues were still open in GitHub even though the repository contains matching implementation, tests, and docs.
+
+### Issue #59 — `US-002: Authenticated browser app shell`
+
+Evidence:
+
+- browser session bootstrap route exists in [lib/audit/http.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/http.js:1393)
+- auth shell app tests cover protected-route redirect and post-sign-in restore in [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx:430)
+- dedicated auth shell coverage exists in [src/app/AuthAppShell.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/AuthAppShell.test.tsx:1)
+- browser verification exists in [tests/browser/auth-shell.browser.spec.ts](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/browser/auth-shell.browser.spec.ts:1)
+- contract/docs exist in [docs/api/authenticated-browser-app-openapi.yml](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/api/authenticated-browser-app-openapi.yml:7) and [docs/design/US-002-design.md](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/design/US-002-design.md:32)
+
+### Issue #29 — `[TSK-002] Assign AI agent to task`
+
+Evidence:
+
+- assignment writes exist on the legacy audit-backed path and are covered in [tests/unit/audit-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/audit-api.test.js:1166)
+- canonical task-platform owner mutation coverage exists in [tests/unit/task-platform-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/task-platform-api.test.js:37)
+- assignment security, accessibility, visual, integration, and browser coverage are present under `tests/`
+- API contract exists in [docs/api/task-assignment-openapi.yml](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/api/task-assignment-openapi.yml:1)
+
+### Issue #30 — `[ARCH] Redesign task persistence model and canonical AI agent ownership architecture`
+
+Evidence:
+
+- additive schema exists in [db/migrations/006_canonical_task_persistence.sql](/Users/wiinc2/.openclaw/workspace/engineering-team/db/migrations/006_canonical_task_persistence.sql:1)
+- runtime service implementation exists in [lib/task-platform/service.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/task-platform/service.js:1), [lib/task-platform/postgres.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/task-platform/postgres.js:1), and [lib/task-platform/backfill.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/task-platform/backfill.js:1)
+- versioned APIs exist under `/api/v1` and are covered in [tests/unit/task-platform-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/task-platform-api.test.js:37)
+- implementation summary is documented in [docs/reports/ISSUE_30_TASK_PLATFORM_REDESIGN.md](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/reports/ISSUE_30_TASK_PLATFORM_REDESIGN.md:5)
+
+### Issue #25 — `[SF-019] Browser-rendered task history and telemetry surfaces on Task Detail`
+
+Evidence:
+
+- canonical contract is documented in [docs/api/task-detail-history-telemetry-openapi.yml](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/api/task-detail-history-telemetry-openapi.yml:442)
+- the task detail UI renders history/telemetry states and pagination in [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx:1072)
+- browser verification exists in [tests/browser/task-detail.browser.spec.ts](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/browser/task-detail.browser.spec.ts:1)
+- contract/security/E2E coverage exists in [tests/contract/audit-openapi.contract.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/contract/audit-openapi.contract.test.js:58), [tests/security/audit-api.security.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/security/audit-api.security.test.js:98), and [tests/e2e/audit-foundation.e2e.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/e2e/audit-foundation.e2e.test.js:184)
+
+### Issue #26 — `[SF-019A] Frontend: Task Detail History/Telemetry tabs and UX states`
+
+Evidence:
+
+- history and telemetry tabs are exercised in [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx:1117)
+- responsive route/browser coverage exists in [tests/browser/task-detail.browser.spec.ts](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/browser/task-detail.browser.spec.ts:1)
+- route adapter coverage exists in [tests/unit/task-detail-adapter.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/task-detail-adapter.test.js:163)
+
+### Issue #27 — `[SF-019B] Backend/API: Task Detail read contracts for summary, history, and telemetry`
+
+Evidence:
+
+- summary, history, and telemetry route handling exists in [lib/audit/http.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/http.js:1645)
+- telemetry summary endpoint handling exists in [lib/audit/http.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/http.js:2410)
+- OpenAPI artifacts exist in [docs/api/task-detail-history-telemetry-openapi.yml](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/api/task-detail-history-telemetry-openapi.yml:442)
+
+### Issue #28 — `[SF-019C] QA/Test Matrix: Coverage for Task Detail history and telemetry surfaces`
+
+Evidence:
+
+- E2E coverage exists in [tests/e2e/audit-foundation.e2e.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/e2e/audit-foundation.e2e.test.js:184)
+- contract coverage exists in [tests/contract/audit-openapi.contract.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/contract/audit-openapi.contract.test.js:58)
+- accessibility coverage exists in [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx:1117) and supporting notes in [tests/accessibility/README.md](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/accessibility/README.md:10)
+- visual coverage is documented in [tests/visual/README.md](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/visual/README.md:3)
+
+### Issue #39 — `[TSK-007] Add PM cross-role overview for routed task visibility`
+
+Evidence:
+
+- PM overview routing helpers exist in [src/app/task-owner.mjs](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/task-owner.mjs:166)
+- PM overview UI states are exercised in [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx:1508)
+- PM overview unit and E2E coverage exist in [tests/unit/pm-overview-routing.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/pm-overview-routing.test.js:16) and [tests/e2e/pm-overview-routing.e2e.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/e2e/pm-overview-routing.e2e.test.js:30)
+- supporting workflow artifact exists in [docs/diagrams/workflow-TSK-007.mmd](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/diagrams/workflow-TSK-007.mmd:1)
+
+## Remaining likely-open roadmap items
+
+The following open issues still look like real pending work rather than tracker drift:
+
+- #18 `SF-013` GitHub webhook integration / PR sync / close gate
+- #19 `SF-014` SRE monitoring dashboard / countdown / approval actions
+- #20 `SF-015` child task creation from monitoring anomalies
+- #21 `SF-016` PM close review / cancellation flow / human decision inbox
+- #24 `SF-018` production identity provider integration
+
+These items are still represented mostly as roadmap/story documents rather than clearly landed runtime code.
+
+## Local-only follow-up not yet durable in repo history
+
+- #36 `TSK-006` may be addressed by `.github/workflows/validation.yml`, but that workflow is currently untracked in the local worktree rather than committed on `main`, so the issue should remain open until the CI automation is committed and visible in the remote repository.
+
+## Epic tracker note
+
+Issue #23 remains relevant as an umbrella tracker, but its child issue state had drifted. It should be updated to reflect:
+
+- implemented foundations already closed or closeable
+- implemented follow-on work that had remained open by mistake
+- remaining active roadmap centered on production integrations and final governance flows


### PR DESCRIPTION
## Summary
- add a GitHub Actions validation workflow
- add the 2026-04-13 issue audit status report

## Validation
- not run locally; this PR adds the validation workflow itself

## Notes
- isolated from the shipped SF-018 and SF-013 work so it can be reviewed separately