### PR TITLE
Fix Playwright color env conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test:ui:vitest": "vitest run src/app/*.test.tsx tests/unit/board-owner-card-rendering.test.js tests/unit/role-inbox-routing.test.js tests/unit/pm-overview-routing.test.js tests/integration/board-owner-filtering.integration.test.js tests/accessibility/task-assignment.a11y.spec.ts tests/visual/task-assignment.visual.spec.ts tests/performance/lighthouse-task-detail.spec.ts",
     "test:ui:coverage": "vitest run --coverage src/app/*.test.tsx tests/unit/board-owner-card-rendering.test.js tests/unit/role-inbox-routing.test.js tests/unit/pm-overview-routing.test.js tests/integration/board-owner-filtering.integration.test.js",
     "test:ui": "npm run test:ui:vitest && npm run test:integration:role-inbox && npm run test:integration:pm-overview",
-    "test:browser": "playwright test",
+    "test:browser": "node scripts/run-playwright.js",
     "test:integration:docker": "bash scripts/run-postgres-integration-docker.sh",
     "audit:rebuild": "node scripts/rebuild-audit-projections.js",
     "audit:project": "node scripts/process-audit-projection-queue.js",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
 
 const includeWebkit = process.env.PLAYWRIGHT_INCLUDE_WEBKIT === '1';
+const normalizedEnv = { ...process.env };
+
+if (normalizedEnv.NO_COLOR) {
+  delete normalizedEnv.NO_COLOR;
+  delete process.env.NO_COLOR;
+}
+
+// Keep the parent Playwright process and its child workers on the same env.
+Object.assign(process.env, normalizedEnv);
 
 export default defineConfig({
   testDir: './tests/browser',
@@ -13,7 +22,8 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'npm run dev -- --host 127.0.0.1 --port 4174',
+    command: 'env -u FORCE_COLOR npm run dev -- --host 127.0.0.1 --port 4174',
+    env: normalizedEnv,
     url: 'http://127.0.0.1:4174',
     reuseExistingServer: true,
     timeout: 30_000,

--- a/scripts/run-playwright.js
+++ b/scripts/run-playwright.js
@@ -1,0 +1,33 @@
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const env = { ...process.env };
+
+// Playwright forces worker color output internally, so browser-test child
+// processes must not inherit NO_COLOR or Node will warn about the conflict.
+if (Object.prototype.hasOwnProperty.call(env, 'NO_COLOR')) {
+  delete env.NO_COLOR;
+}
+
+const result = spawnSync(
+  process.execPath,
+  [
+    path.join(path.dirname(require.resolve('playwright/package.json')), 'cli.js'),
+    'test',
+    ...process.argv.slice(2),
+  ],
+  {
+    stdio: 'inherit',
+    env,
+  },
+);
+
+if (result.error) {
+  throw result.error;
+}
+
+if (result.signal) {
+  process.kill(process.pid, result.signal);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- route browser tests through a small Playwright launcher script
- normalize browser-test environment variables so Playwright runs without NO_COLOR/FORCE_COLOR warnings
- pass the normalized environment through the Playwright web server path as well

## Testing
- npm run test:browser
- npm test