### PR TITLE
Add governance review routing and owner enforcement

### DIFF
--- a/docs/api/authenticated-browser-app-openapi.yml
+++ b/docs/api/authenticated-browser-app-openapi.yml
@@ -5,6 +5,10 @@ info:
   description: |
     Browser-facing internal auth bootstrap endpoint for the authenticated app shell.
     Governance note: browser-shell session and route changes should update this spec in the same pull request.
+    Protected browser-shell routes in the current client include `/tasks`, `/tasks?view=board`,
+    `/overview/pm`, `/overview/governance`, `/inbox/{role}`, and `/tasks/{taskId}`.
+    The `/overview/governance` route is a dedicated operational surface for governance review tasks and
+    is intentionally separate from standard delivery queues.
 paths:
   /auth/session:
     post:

--- a/docs/api/task-assignment-openapi.yml
+++ b/docs/api/task-assignment-openapi.yml
@@ -6,6 +6,8 @@ info:
     API contract for assigning an AI agent owner to a task.
     The runtime accepts both `/tasks/...` and `/api/tasks/...` paths; `/tasks/...` is the canonical route shape used elsewhere in this repo.
     Governance note: assignment runtime changes should update this spec in the same pull request.
+    Delivery-loop mutations that are reserved for the currently assigned engineer role now reject callers
+    that no longer match the task's canonical assignee.
 paths:
   /tasks/{taskId}/assignment:
     patch:
@@ -101,6 +103,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardErrorResponse'
+              examples:
+                wrongAssignedRole:
+                  value:
+                    error:
+                      code: forbidden
+                      message: Only the currently assigned owner may perform this action.
+                      request_id: req-example
+                      requestId: req-example
+                      details:
+                        assignee: engineer-sr
+                        allowed_roles:
+                          - engineer
         '404':
           description: Task not found
           content:

--- a/docs/api/task-detail-history-telemetry-openapi.yml
+++ b/docs/api/task-detail-history-telemetry-openapi.yml
@@ -284,6 +284,22 @@ components:
               items: { type: string }
             technicalSpec: { type: [string, 'null'] }
             monitoringSpec: { type: [string, 'null'] }
+            architectHandoff:
+              type: [object, 'null']
+              additionalProperties: true
+              description: Latest architect handoff metadata, including engineer tier decisions when available.
+            activityMonitoring:
+              type: [object, 'null']
+              additionalProperties: true
+              description: Delivery-loop activity monitoring summary, including missed engineer check-in state.
+            reassignment:
+              type: [object, 'null']
+              additionalProperties: true
+              description: Latest reassignment summary, including any tier-specific assignee id selected during responsible escalation or inactivity reassignment.
+            ghostingReview:
+              type: [object, 'null']
+              additionalProperties: true
+              description: Linked governance review task created for inactivity or other governance follow-up.
         relations:
           type: object
           required: [linkedPrs, childTasks]

--- a/docs/api/task-owner-surfaces-openapi.yml
+++ b/docs/api/task-owner-surfaces-openapi.yml
@@ -61,6 +61,9 @@ paths:
         Returns the projected task-list read surface for overview consumers.
         Callers with `state:read` can see owner metadata for assigned tasks and explicit `null` values
         for unassigned tasks. This endpoint is read-only and does not expose assignment controls.
+        Tier-specific assignee ids such as `engineer-jr`, `engineer-sr`, and `engineer-principal`
+        remain valid projected owner values and should still collapse into the canonical engineer route family
+        for browser overview and inbox grouping.
       responses:
         '200':
           description: Task-list summaries
@@ -80,6 +83,8 @@ paths:
         Returns the projected task detail summary.
         `current_owner` and `owner` are additive read fields exposed to the same `state:read`
         audience as the rest of the task summary. Assignment mutation stays on `PATCH /tasks/{id}/assignment`.
+        Governance review tasks use `task_type=governance_review` and should be treated as a dedicated
+        operational surface rather than part of the standard delivery queues.
       responses:
         '200':
           description: Task detail summary

--- a/docs/design/US-002-design.md
+++ b/docs/design/US-002-design.md
@@ -55,6 +55,8 @@
 - add a first-class `/sign-in` route and internal sign-in form
 - add shared authenticated navigation plus explicit sign-out
 - keep existing route modules and detail/list adapters intact
+- extend the authenticated shell with a dedicated `/overview/governance` route so governance review tasks stay out of standard delivery views
+- preserve canonical owner-role grouping even when projected assignee ids use tier-specific variants such as `engineer-jr`, `engineer-sr`, or `engineer-principal`
 - Centralized auth recovery:
 - add `onAuthFailure` handling in the task-detail API client for `401` and invalid-token cases
 - redirect to sign-in with a recoverable message when session-authenticated requests fail
@@ -72,3 +74,7 @@
 - `tests/browser/auth-shell.browser.spec.ts`
 - `docs/api/authenticated-browser-app-openapi.yml`
 - this design document
+- Browser-shell route additions in this slice:
+- `/overview/governance` is a protected route in the authenticated shell
+- governance review tasks are shown only on that dedicated route and are intentionally excluded from the default task list, board, and PM overview delivery surfaces
+- tier-specific engineer owners still collapse into the canonical `engineer` route family for inbox and overview grouping while preserving human-readable labels in the UI

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -72,6 +72,8 @@ Successful read/write access is now logged with `action=audit_access` so tenant-
 Audit HTTP maintenance note:
 - When `lib/audit/http.js` changes, update the nearest API or runbook artifact in the same PR.
 - Current nearest artifacts for HTTP-surface changes are this runbook plus the matching `docs/api/*.yml` contract for the affected route family.
+- Engineer-only delivery-loop mutations now validate the task's current canonical assignee before accepting writes.
+- Tier-based reassignment may emit explicit assignee ids such as `engineer-sr` in workflow payloads and task-detail context so downstream consumers can tell when ownership changed materially.
 
 ## Tenant isolation guarantees in this slice
 - Idempotency is tenant-scoped. The same `idempotencyKey` may legitimately exist in different tenants without collision.

--- a/docs/runbooks/task-assignment.md
+++ b/docs/runbooks/task-assignment.md
@@ -16,6 +16,12 @@ Allows an authorized Product Manager to assign or reassign an AI agent as the ow
 - That visibility is intentionally read-only; it does **not** grant assignment capability.
 - Only callers with `assignment:write` (PM/admin in the current role map) can mutate owner state through `PATCH /tasks/{taskId}/assignment`.
 - Restricted telemetry behavior is separate: lower-privilege readers still get owner metadata, while `GET /tasks/{taskId}/observability-summary` omits privileged telemetry fields server-side.
+- Tier-specific projected assignee ids such as `engineer-jr`, `engineer-sr`, and `engineer-principal` are valid owner values and should still be treated as canonical engineer ownership for delivery routing.
+
+## Responsible escalation and current-owner enforcement
+- Delivery-loop actions reserved for engineers now validate the task's current canonical assignee before mutating state.
+- If a task has already been reassigned away from engineering, engineer-only actions such as check-ins, implementation submission, and above-skill escalation should fail with `403 forbidden`.
+- Inactivity reassignment may promote the projected assignee from `engineer` to a tier-specific id such as `engineer-sr` so the reassigned owner is explicit in downstream read models.
 
 ## How to verify the feature is working
 1. Open a task in an environment where the audit/task-detail UI is enabled.
@@ -40,6 +46,7 @@ Allows an authorized Product Manager to assign or reassign an AI agent as the ow
 ## Common errors + resolutions
 - **401 Authentication error** → verify session/auth provider and PM login state.
 - **403 Authorization error** → verify user role includes task-management permission.
+- **403 Only the currently assigned owner may perform this action** → verify the task was not reassigned to a different canonical owner role or tier-specific engineer assignee before the caller retried the action.
 - **400 Invalid agent** → verify selected agent exists and is active in the roster source.
 - **404 Task not found** → verify task id and tenant/workspace scope.
 - **No queue/list update visible** → this repo projects assignee into task state, but does not yet include a dedicated board/inbox UI. Downstream consumers should read `current_owner`/`assignee` from the projection.

--- a/docs/runbooks/workflow-delivery-loop.md
+++ b/docs/runbooks/workflow-delivery-loop.md
@@ -97,6 +97,12 @@ The primary implementation reference is:
 - PR URL when provided
 - otherwise commit SHA
 
+### Current-assignee enforcement
+
+- Engineer-only delivery-loop actions are accepted only when the caller still matches the task's current canonical assignee.
+- If a task has already been reassigned to another owner role, later engineer check-ins, engineer submission, or above-skill escalation attempts fail with `403 forbidden`.
+- Tier-based reassignment may set a more explicit projected assignee id such as `engineer-sr` or `engineer-principal` while still collapsing into the canonical engineer routing family for overview surfaces.
+
 ### Local git vs GitHub
 
 QA progression does not depend on GitHub availability. A valid local commit SHA is sufficient.
@@ -161,3 +167,8 @@ Failing QA runs generate a packaged engineer-facing artifact containing:
 - notification preview before the full package details
 - logs and traces collapsed by default behind an expand affordance
 - previous fix history always available from the same package view
+
+## Governance review tasks
+
+- Inactivity reassignment can create a dedicated governance review task typed as `governance_review`.
+- Governance review tasks are operational follow-up artifacts, not standard delivery work, and should be shown on a dedicated governance review surface rather than in normal delivery queues.

--- a/lib/audit/http.js
+++ b/lib/audit/http.js
@@ -454,6 +454,19 @@ function normalizeEngineerTier(value, fallback = null) {
   return ENGINEER_TIERS.includes(normalized) ? normalized : fallback;
 }
 
+function buildTierAssigneeId(tier) {
+  switch (normalizeEngineerTier(tier, null)) {
+    case 'Sr':
+      return 'engineer-sr';
+    case 'Principal':
+      return 'engineer-principal';
+    case 'Jr':
+      return 'engineer-jr';
+    default:
+      return null;
+  }
+}
+
 function getEffectiveEngineerTier(state, history = []) {
   return normalizeEngineerTier(state?.engineer_tier, null)
     || normalizeEngineerTier(architectHandoffFromEvent(findLatestArchitectHandoff(history))?.engineerTier, null)
@@ -479,6 +492,7 @@ function summarizeActivitySignal(event) {
         type: 'check_in',
         occurredAt: event.occurred_at || null,
         actorId: event.actor_id || null,
+        assignee: payload.assignee || null,
         summary: payload.summary || '',
         evidence: normalizeMultilineList(payload.evidence || payload.references || []),
       };
@@ -487,6 +501,7 @@ function summarizeActivitySignal(event) {
         type: 'implementation_submission',
         occurredAt: event.occurred_at || null,
         actorId: event.actor_id || null,
+        assignee: payload.assignee || null,
         summary: payload.primary_reference?.label || payload.commit_sha || payload.pr_url || 'Implementation submitted',
         evidence: [payload.commit_sha, payload.pr_url].filter(Boolean),
       };
@@ -497,9 +512,18 @@ function summarizeActivitySignal(event) {
 
 function findLatestActivitySignal(history = [], assignee = null) {
   for (const event of history) {
-    if (assignee && event?.actor_id && event.actor_id !== assignee) continue;
     const summary = summarizeActivitySignal(event);
-    if (summary) return summary;
+    if (!summary) continue;
+    if (assignee) {
+      const eventAssignee = String(summary.assignee || '').trim().toLowerCase();
+      const targetAssignee = String(assignee || '').trim().toLowerCase();
+      if (eventAssignee) {
+        if (eventAssignee !== targetAssignee) continue;
+      } else if (targetAssignee !== 'engineer' && targetAssignee !== 'engineer-jr' && targetAssignee !== 'engineer-sr' && targetAssignee !== 'engineer-principal') {
+        continue;
+      }
+    }
+    return summary;
   }
   return null;
 }
@@ -627,7 +651,7 @@ async function appendWorkflowThreadNotification({
 }
 
 function buildTransferredContextSummary({ taskId, summary, state, history = [], assignee, engineerTier, reason, mode, occurredAt }) {
-  const latestActivity = findLatestActivitySignal(history);
+  const latestActivity = findLatestActivitySignal(history, state?.assignee || null);
   const latestSubmission = engineerSubmissionFromEvent(findLatestEngineerSubmission(history));
   const workflowThreads = deriveWorkflowThreads(history);
   const unresolvedThreads = workflowThreads.items
@@ -656,6 +680,28 @@ function buildTransferredContextSummary({ taskId, summary, state, history = [], 
     unresolved_threads: unresolvedThreads,
     blockers,
   };
+}
+
+function inferCanonicalOwnerRole(ownerId) {
+  const normalized = String(ownerId || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === 'engineer' || normalized.startsWith('engineer-')) return 'engineer';
+  if (normalized === 'architect' || normalized.startsWith('architect-')) return 'architect';
+  if (normalized === 'qa' || normalized.startsWith('qa-')) return 'qa';
+  if (normalized === 'sre' || normalized.startsWith('sre-')) return 'sre';
+  if (normalized === 'pm' || normalized.startsWith('pm-')) return 'pm';
+  return null;
+}
+
+function assertCurrentActorMatchesTaskAssignee(context, state, allowedRoles = []) {
+  if (hasAnyRole(context, ['admin'])) return;
+  const assigneeRole = inferCanonicalOwnerRole(state?.assignee);
+  if (!assigneeRole || !allowedRoles.includes(assigneeRole) || !context?.roles?.includes(assigneeRole)) {
+    throw createHttpError(403, 'forbidden', 'Only the currently assigned owner may perform this action.', {
+      assignee: state?.assignee || null,
+      allowed_roles: allowedRoles,
+    });
+  }
 }
 
 function lastQaResultEvent(history = []) {
@@ -1108,7 +1154,7 @@ function buildTaskDetailViewModel({
   const latestRetier = toRetierSummary(findLatestRetierEvent(history));
   const latestReassignment = toReassignmentSummary(findLatestReassignmentEvent(history));
   const ghostingReview = toGhostingReviewSummary(findLatestGhostingReviewEvent(history));
-  const latestActivitySignal = findLatestActivitySignal(history);
+  const latestActivitySignal = findLatestActivitySignal(history, summary.current_owner || null);
   const missedCheckIns = computeMissedCheckIns(latestActivitySignal?.occurredAt, new Date().toISOString());
   const technicalSpec = formatArchitectHandoffTechnicalSpec(architectHandoff) || lastDefinedPayloadValue(history, ['technical_spec', 'technicalSpec']);
   const monitoringSpec = formatArchitectHandoffMonitoringSpec(architectHandoff) || lastDefinedPayloadValue(history, ['monitoring_spec', 'monitoringSpec']);
@@ -2526,6 +2572,7 @@ function createAuditApiServer(options = {}) {
         const body = await parseJson(req);
         const state = await store.getTaskCurrentState(taskId, { tenantId: context.tenantId });
         if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        assertCurrentActorMatchesTaskAssignee(context, state, ['engineer']);
         if (![STAGES.IMPLEMENTATION, STAGES.IN_PROGRESS].includes(state.current_stage)) {
           throw createHttpError(409, 'invalid_stage', 'Engineer submission can only be submitted during Implementation.', { current_stage: state.current_stage });
         }
@@ -2544,6 +2591,7 @@ function createAuditApiServer(options = {}) {
           payload: {
             ...normalized,
             version,
+            assignee: state.assignee || null,
             next_required_action: 'Implementation metadata recorded. Task is ready for QA handoff.',
           },
           source: body.source || 'http',
@@ -2767,6 +2815,7 @@ function createAuditApiServer(options = {}) {
           store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 500 }),
         ]);
         if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        assertCurrentActorMatchesTaskAssignee(context, state, ['engineer']);
         const currentTier = getEffectiveEngineerTier(state, history);
         if (currentTier !== 'Jr') {
           throw createHttpError(409, 'invalid_engineer_tier', 'Above-skill escalation is reserved for Jr-tier engineering assignments.', { current_engineer_tier: currentTier });
@@ -2827,6 +2876,7 @@ function createAuditApiServer(options = {}) {
         await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, options: runtimeOptions });
         const state = await store.getTaskCurrentState(taskId, { tenantId: context.tenantId });
         if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        assertCurrentActorMatchesTaskAssignee(context, state, ['engineer']);
         const occurredAt = new Date().toISOString();
         const result = await store.appendEvent({
           taskId,
@@ -2839,6 +2889,7 @@ function createAuditApiServer(options = {}) {
           payload: {
             summary: body.summary,
             evidence: body.evidence,
+            assignee: state.assignee || null,
             check_in_interval_minutes: ENGINEER_CHECK_IN_INTERVAL_MINUTES,
             waiting_state: null,
             next_required_action: 'Continue implementation and record the next substantive check-in before the monitoring window expires.',
@@ -2912,7 +2963,7 @@ function createAuditApiServer(options = {}) {
         const summary = summarizeTaskForDetail(taskId, state, history);
         const previousTier = getEffectiveEngineerTier(state, history);
         const occurredAt = new Date().toISOString();
-        const latestActivity = findLatestActivitySignal(history);
+        const latestActivity = findLatestActivitySignal(history, state.assignee || null);
         const missedCheckIns = computeMissedCheckIns(latestActivity?.occurredAt, occurredAt);
         if (body.mode === 'inactivity' && missedCheckIns < MISSED_CHECK_IN_THRESHOLD) {
           throw createHttpError(409, 'reassignment_threshold_not_reached', `Reassignment requires ${MISSED_CHECK_IN_THRESHOLD} missed ${ENGINEER_CHECK_IN_INTERVAL_MINUTES}-minute check-ins.`, {
@@ -2927,7 +2978,19 @@ function createAuditApiServer(options = {}) {
         if ((body.mode === 'inactivity' || body.mode === 'above_skill') && !targetTier) {
           throw createHttpError(409, 'no_senior_tier_available', 'No higher engineer tier is available for reassignment.', { current_engineer_tier: previousTier });
         }
-        const assignee = body.assignee || state.assignee || 'engineer';
+        const fallbackAssignee = body.mode === 'inactivity'
+          ? (buildTierAssigneeId(targetTier) || state.assignee || 'engineer')
+          : body.mode === 'above_skill'
+            ? (buildTierAssigneeId(targetTier) || state.assignee || 'engineer')
+            : (state.assignee || 'engineer');
+        const assignee = body.assignee || fallbackAssignee;
+        if (body.mode === 'inactivity' && assignee === state.assignee) {
+          throw createHttpError(409, 'reassignment_owner_unchanged', 'Inactivity reassignment must move ownership to a different assignee.', {
+            assignee,
+            previous_assignee: state.assignee || null,
+            suggested_assignee: buildTierAssigneeId(targetTier) || null,
+          });
+        }
         const transferSummary = buildTransferredContextSummary({
           taskId,
           summary,

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -18,6 +18,7 @@ import {
 } from './session.browser';
 import {
   buildBoardColumns,
+  buildGovernanceReviewItems,
   buildPmOverviewSections,
   buildRoleInboxItems,
   filterTaskList,
@@ -72,6 +73,7 @@ function isProtectedRoute(pathname = '') {
     || matchCreateTaskRoute(normalizedPath)
     || Boolean(matchRoleInboxRoute(normalizedPath))
     || Boolean(matchPmOverviewRoute(normalizedPath))
+    || Boolean(matchGovernanceOverviewRoute(normalizedPath))
     || Boolean(readRouteTask(normalizedPath));
 }
 
@@ -157,6 +159,11 @@ function matchPmOverviewRoute(pathname = '') {
   return normalizedPath === '/overview/pm' ? { scope: 'pm' } : null;
 }
 
+function matchGovernanceOverviewRoute(pathname = '') {
+  const normalizedPath = ((pathname || '').replace(/\/+$/, '') || '/');
+  return normalizedPath === '/overview/governance' ? { scope: 'governance' } : null;
+}
+
 function readTaskListRouteState(search = '') {
   const params = new URLSearchParams(search);
   const owner = params.get('owner') || '';
@@ -229,16 +236,18 @@ function buildLoadingModel(pathname, search) {
 function buildListLoadingModel(pathname, search) {
   const roleInbox = matchRoleInboxRoute(pathname);
   const pmOverview = matchPmOverviewRoute(pathname);
+  const governanceOverview = matchGovernanceOverviewRoute(pathname);
   return {
     kind: 'list',
-    route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : '/tasks', taskId: null },
+    route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : governanceOverview ? '/overview/governance' : '/tasks', taskId: null },
     list: {
       filters: readTaskListRouteState(search),
       items: [],
-      state: { kind: 'loading', message: roleInbox ? `Loading ${getRoleInboxLabel(roleInbox.role)} inbox.` : pmOverview ? 'Loading PM overview.' : 'Loading task list.' },
+      state: { kind: 'loading', message: roleInbox ? `Loading ${getRoleInboxLabel(roleInbox.role)} inbox.` : pmOverview ? 'Loading PM overview.' : governanceOverview ? 'Loading governance reviews.' : 'Loading task list.' },
       resultSummary: '',
       inboxRole: roleInbox?.role || null,
       isPmOverview: Boolean(pmOverview),
+      isGovernanceOverview: Boolean(governanceOverview),
     },
   };
 }
@@ -596,7 +605,7 @@ export function App() {
   const [signInStatus, setSignInStatus] = React.useState({ kind: 'idle', message: '' });
   const [authNotice, setAuthNotice] = React.useState('');
   const [model, setModel] = React.useState(() => {
-    if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname)) return buildListLoadingModel(pathname, search);
+    if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname) || matchGovernanceOverviewRoute(pathname)) return buildListLoadingModel(pathname, search);
     return matchTaskRoute(pathname) ? buildLoadingModel(pathname, search) : buildRouteMissModel(pathname);
   });
   const [agentOptions, setAgentOptions] = React.useState([]);
@@ -748,7 +757,7 @@ export function App() {
       };
     }
 
-    if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname)) {
+    if (matchTaskListRoute(pathname) || matchRoleInboxRoute(pathname) || matchPmOverviewRoute(pathname) || matchGovernanceOverviewRoute(pathname)) {
       setModel(buildListLoadingModel(pathname, search));
       taskClient.fetchTaskList()
         .then((payload) => {
@@ -756,9 +765,10 @@ export function App() {
           const filters = readTaskListRouteState(search);
           const roleInbox = matchRoleInboxRoute(pathname);
           const pmOverview = matchPmOverviewRoute(pathname);
+          const governanceOverview = matchGovernanceOverviewRoute(pathname);
           setModel({
             kind: 'list',
-            route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : '/tasks', taskId: null },
+            route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : governanceOverview ? '/overview/governance' : '/tasks', taskId: null },
             list: {
               filters,
               items: payload.items || [],
@@ -766,21 +776,26 @@ export function App() {
               resultSummary: '',
               inboxRole: roleInbox?.role || null,
               isPmOverview: Boolean(pmOverview),
+              isGovernanceOverview: Boolean(governanceOverview),
             },
           });
         })
         .catch((error) => {
           if (!cancelled) {
+            const roleInbox = matchRoleInboxRoute(pathname);
+            const pmOverview = matchPmOverviewRoute(pathname);
+            const governanceOverview = matchGovernanceOverviewRoute(pathname);
             setModel({
               kind: 'list',
-              route: { pathname: matchRoleInboxRoute(pathname) ? pathname : '/tasks', taskId: null },
+              route: { pathname: roleInbox ? pathname : pmOverview ? '/overview/pm' : governanceOverview ? '/overview/governance' : '/tasks', taskId: null },
               list: {
                 filters: readTaskListRouteState(search),
                 items: [],
                 state: { kind: 'error', message: error.message || 'Task list load failed.' },
                 resultSummary: '',
-                inboxRole: matchRoleInboxRoute(pathname)?.role || null,
-                isPmOverview: Boolean(matchPmOverviewRoute(pathname)),
+                inboxRole: roleInbox?.role || null,
+                isPmOverview: Boolean(pmOverview),
+                isGovernanceOverview: Boolean(governanceOverview),
               },
             });
           }
@@ -895,6 +910,7 @@ export function App() {
   const routeTaskId = model.kind === 'detail' ? (model.route?.taskId || 'TSK-42') : 'TSK-42';
   const activeInboxRole = model.kind === 'list' ? model.list.inboxRole : null;
   const isPmOverview = model.kind === 'list' ? Boolean(model.list.isPmOverview) : false;
+  const isGovernanceOverview = model.kind === 'list' ? Boolean(model.list.isGovernanceOverview) : false;
   const detailPermissions = model.kind === 'detail' ? (model.detail?.meta?.permissions || {}) : {};
   const architectReviewEnabled = model.kind === 'detail' && Boolean(model.detail?.reviewQuestions);
   const canAskQuestions = architectReviewEnabled && canAskReviewQuestion(tokenClaims) && model.detail?.task?.stage === 'ARCHITECT_REVIEW';
@@ -945,7 +961,8 @@ export function App() {
       const payload = await taskClient.fetchTaskList();
       const roleInbox = matchRoleInboxRoute(pathname);
       const pmOverview = matchPmOverviewRoute(pathname);
-      setModel({ kind: 'list', route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : '/tasks', taskId: null }, list: { filters: readTaskListRouteState(search), items: payload.items || [], state: { kind: 'ready' }, resultSummary: '', inboxRole: roleInbox?.role || null, isPmOverview: Boolean(pmOverview) } });
+      const governanceOverview = matchGovernanceOverviewRoute(pathname);
+      setModel({ kind: 'list', route: { pathname: roleInbox ? `/inbox/${roleInbox.role}` : pmOverview ? '/overview/pm' : governanceOverview ? '/overview/governance' : '/tasks', taskId: null }, list: { filters: readTaskListRouteState(search), items: payload.items || [], state: { kind: 'ready' }, resultSummary: '', inboxRole: roleInbox?.role || null, isPmOverview: Boolean(pmOverview), isGovernanceOverview: Boolean(governanceOverview) } });
       return;
     }
     setModel(buildLoadingModel(pathname, search));
@@ -1214,6 +1231,7 @@ export function App() {
   const hasActiveListFilters = Boolean(listFilters.owner || listFilters.priority || listFilters.status || listFilters.searchTerm);
   const roleInboxItems = model.kind === 'list' && activeInboxRole ? buildRoleInboxItems(model.list.items, activeInboxRole, agentLookup) : [];
   const pmSections = model.kind === 'list' && isPmOverview ? buildPmOverviewSections(model.list.items, agentLookup) : [];
+  const governanceItems = model.kind === 'list' && isGovernanceOverview ? buildGovernanceReviewItems(model.list.items, agentLookup) : [];
   const activePmBucket = isPmOverview && PM_OVERVIEW_BUCKET_ORDER.includes(listFilters.bucket) ? listFilters.bucket : '';
   const selectedPmSection = activePmBucket ? pmSections.find((section) => section.key === activePmBucket) || null : null;
   const visiblePmSections = isPmOverview
@@ -1238,6 +1256,8 @@ export function App() {
   const resultSummary = model.kind === 'list'
     ? isPmOverview
       ? summarizePmOverviewResults(visiblePmSections, activePmBucket)
+      : isGovernanceOverview
+        ? `${governanceItems.length} governance review${governanceItems.length === 1 ? '' : 's'} shown.`
       : activeInboxRole
         ? roleInboxState.kind === 'ready'
           ? summarizeRoleInboxResults(roleInboxItems.length, activeInboxRole)
@@ -1301,9 +1321,10 @@ export function App() {
     <main className="app-shell">
       <nav className="app-nav" aria-label="Primary navigation">
         <div className="app-nav__links">
-          <button type="button" className={model.kind === 'list' && !isPmOverview && !activeInboxRole && listFilters.view !== 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks')}>Task list</button>
-          <button type="button" className={model.kind === 'list' && !isPmOverview && !activeInboxRole && listFilters.view === 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks', writeTaskListUrlState({ view: 'board' }, ''))}>Board</button>
+          <button type="button" className={model.kind === 'list' && !isPmOverview && !isGovernanceOverview && !activeInboxRole && listFilters.view !== 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks')}>Task list</button>
+          <button type="button" className={model.kind === 'list' && !isPmOverview && !isGovernanceOverview && !activeInboxRole && listFilters.view === 'board' ? '' : 'button-secondary'} onClick={() => navigate('/tasks', writeTaskListUrlState({ view: 'board' }, ''))}>Board</button>
           <button type="button" className={isPmOverview ? '' : 'button-secondary'} onClick={() => navigate('/overview/pm')}>PM overview</button>
+          <button type="button" className={isGovernanceOverview ? '' : 'button-secondary'} onClick={() => navigate('/overview/governance')}>Governance reviews</button>
           {ROLE_INBOXES.map((role) => (
             <button key={role} type="button" className={activeInboxRole === role ? '' : 'button-secondary'} onClick={() => navigate(`/inbox/${role}`)}>
               {getRoleInboxLabel(role)} inbox
@@ -1318,11 +1339,13 @@ export function App() {
       <header className="page-header">
         <div>
           <p className="eyebrow">Authenticated browser shell for US-002</p>
-          <h1>{model.kind === 'list' ? (isPmOverview ? 'PM Overview' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} Inbox` : 'Task list') : model.detail?.task?.title || model.summary.title || 'Task detail'}</h1>
+          <h1>{model.kind === 'list' ? (isPmOverview ? 'PM Overview' : isGovernanceOverview ? 'Governance Reviews' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} Inbox` : 'Task list') : model.detail?.task?.title || model.summary.title || 'Task detail'}</h1>
           <p className="lede">
             {model.kind === 'list'
               ? isPmOverview
                 ? 'Read-only grouped overview showing routed, unassigned, and attention-needed work from the canonical owner-role mapping.'
+                : isGovernanceOverview
+                  ? 'Dedicated operational surface for inactivity and governance review tasks that should stay out of delivery queues.'
                 : activeInboxRole
                   ? `Read-only inbox surface showing tasks routed here because the current assigned owner maps to the ${getRoleInboxLabel(activeInboxRole)} role.`
                   : 'Overview list wired to the projected owner read model with single-select owner filtering.'
@@ -1350,6 +1373,7 @@ export function App() {
               <button type="submit">Open</button>
               <button type="button" className="button-secondary" onClick={() => navigate('/tasks')}>Task list</button>
               <button type="button" className={isPmOverview ? '' : 'button-secondary'} onClick={() => navigate('/overview/pm')}>PM overview</button>
+              <button type="button" className={isGovernanceOverview ? '' : 'button-secondary'} onClick={() => navigate('/overview/governance')}>Governance reviews</button>
               {ROLE_INBOXES.map((role) => (
                 <button key={role} type="button" className={activeInboxRole === role ? '' : 'button-secondary'} onClick={() => navigate(`/inbox/${role}`)}>
                   {getRoleInboxLabel(role)} inbox
@@ -1387,7 +1411,7 @@ export function App() {
       </header>
 
       {model.kind === 'list' ? (
-        <section className="task-list-panel" aria-label={isPmOverview ? 'PM overview view' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} inbox view` : 'Task list view'}>
+        <section className="task-list-panel" aria-label={isPmOverview ? 'PM overview view' : isGovernanceOverview ? 'Governance reviews view' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} inbox view` : 'Task list view'}>
           <div className="task-list-toolbar">
             {isPmOverview ? (
               <div className="role-inbox-toolbar">
@@ -1407,6 +1431,18 @@ export function App() {
                     </select>
                   </label>
                   <button type="button" className="button-secondary" onClick={() => navigate('/overview/pm', writeTaskListUrlState({ bucket: '' }, search))} disabled={!activePmBucket}>Clear filter</button>
+                  <button type="button" onClick={() => void reloadTask()}>Refresh</button>
+                </div>
+              </div>
+            ) : isGovernanceOverview ? (
+              <div className="role-inbox-toolbar">
+                <div>
+                  <p className="eyebrow">Operational governance</p>
+                  <h2>Governance review queue</h2>
+                  <p className="role-inbox-toolbar__cue">Inactivity review and governance follow-up tasks live here so they remain visible without mixing into normal delivery views.</p>
+                </div>
+                <div className="task-list-toolbar__actions">
+                  <button type="button" className="button-secondary" onClick={() => navigate('/tasks')}>Open full task list</button>
                   <button type="button" onClick={() => void reloadTask()}>Refresh</button>
                 </div>
               </div>
@@ -1494,8 +1530,8 @@ export function App() {
 
           <p className="task-list-results" role="status" aria-live="polite">{resultSummary}</p>
 
-          {(isPmOverview && listState.kind === 'loading') || (!activeInboxRole && !isPmOverview && listState.kind === 'loading') || (activeInboxRole && roleInboxState.kind === 'loading') ? <p role="status">{activeInboxRole ? roleInboxState.message : isPmOverview ? 'Loading PM overview.' : 'Loading task list.'}</p> : null}
-          {((!activeInboxRole && !isPmOverview && listState.kind === 'error') || (isPmOverview && listState.kind === 'error')) ? <p role="alert">{listState.message}</p> : null}
+          {(isPmOverview && listState.kind === 'loading') || (isGovernanceOverview && listState.kind === 'loading') || (!activeInboxRole && !isPmOverview && !isGovernanceOverview && listState.kind === 'loading') || (activeInboxRole && roleInboxState.kind === 'loading') ? <p role="status">{activeInboxRole ? roleInboxState.message : isPmOverview ? 'Loading PM overview.' : isGovernanceOverview ? 'Loading governance reviews.' : 'Loading task list.'}</p> : null}
+          {((!activeInboxRole && !isPmOverview && !isGovernanceOverview && listState.kind === 'error') || (isPmOverview && listState.kind === 'error') || (isGovernanceOverview && listState.kind === 'error')) ? <p role="alert">{listState.message}</p> : null}
           {isPmOverview && agentOptionsState.kind === 'error' && listState.kind === 'ready' ? (
             <div className="empty-state" role="alert">
               <h2>Some routing metadata is unavailable</h2>
@@ -1598,7 +1634,40 @@ export function App() {
             </div>
           ) : null}
 
-          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && visibleListItems.length && listFilters.view === 'list' ? (
+          {isGovernanceOverview && listState.kind === 'ready' && governanceItems.length ? (
+            <div className="task-list-table-wrap">
+              <table className="task-list-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Task</th>
+                    <th scope="col">Stage</th>
+                    <th scope="col">Priority</th>
+                    <th scope="col">Owner</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {governanceItems.map((item) => (
+                    <tr key={item.task_id}>
+                      <td>
+                        <a href={`/tasks/${encodeURIComponent(item.task_id)}`} onClick={(event) => { event.preventDefault(); navigate(`/tasks/${encodeURIComponent(item.task_id)}`); }}>
+                          <strong>{item.title || item.task_id}</strong>
+                        </a>
+                        <div className="task-list-meta">{item.task_id}</div>
+                      </td>
+                      <td>{item.current_stage || '—'}</td>
+                      <td>{item.priority || '—'}</td>
+                      <td>
+                        <span className={`owner-badge owner-badge--${item.ownerPresentation.tone}`}>{item.ownerPresentation.label}</span>
+                        <div className="task-list-meta">Governance-only owner metadata</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+
+          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && !isGovernanceOverview && visibleListItems.length && listFilters.view === 'list' ? (
             <div className="task-list-table-wrap">
               <table className="task-list-table">
                 <thead>
@@ -1637,7 +1706,7 @@ export function App() {
             </div>
           ) : null}
 
-          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && visibleListItems.length && listFilters.view === 'board' ? (
+          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && !isGovernanceOverview && visibleListItems.length && listFilters.view === 'board' ? (
             <div className="task-board" aria-label="Task board">
               {lifecycleStatus.kind !== 'idle' ? (
                 <p className={`assignment-status assignment-status--${lifecycleStatus.kind}`} role={lifecycleStatus.kind === 'error' ? 'alert' : 'status'}>
@@ -1738,7 +1807,14 @@ export function App() {
             </div>
           ) : null}
 
-          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && !visibleListItems.length ? (
+          {isGovernanceOverview && listState.kind === 'ready' && !governanceItems.length ? (
+            <div className="empty-state" role="status">
+              <h2>No governance reviews available</h2>
+              <p>No governance review tasks are currently open.</p>
+            </div>
+          ) : null}
+
+          {listState.kind === 'ready' && !activeInboxRole && !isPmOverview && !isGovernanceOverview && !visibleListItems.length ? (
             <div className="empty-state" role="status">
               <h2>No matching tasks</h2>
               <p>{hasActiveListFilters ? 'No tasks match the active task filters.' : 'No tasks are available yet.'}</p>
@@ -2384,6 +2460,21 @@ export function App() {
                         </ul>
                       </>
                     ) : null}
+                  </div>
+                </>
+              ) : null}
+              {model.detail?.context?.ghostingReview?.reviewTaskId ? (
+                <>
+                  <h3>Linked inactivity review</h3>
+                  <div className="architect-handoff-summary">
+                    <p>
+                      <a href={`/tasks/${encodeURIComponent(model.detail.context.ghostingReview.reviewTaskId)}`} onClick={(event) => { event.preventDefault(); navigate(`/tasks/${encodeURIComponent(model.detail.context.ghostingReview.reviewTaskId)}`); }}>
+                        {model.detail.context.ghostingReview.title || model.detail.context.ghostingReview.reviewTaskId}
+                      </a>
+                    </p>
+                    <p className="task-list-meta">
+                      Governance review task created at {model.detail.context.ghostingReview.createdAt || 'unknown time'} to track the inactivity-based reassignment outcome.
+                    </p>
                   </div>
                 </>
               ) : null}

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -337,6 +337,69 @@ function installTaskFetchMock({
       });
     }
 
+    if (url.endsWith('/tasks/TSK-42/skill-escalation') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          currentEngineerTier: 'Jr',
+          requestedTier: 'Sr',
+          updatedAt: '2026-04-01T15:01:46.000Z',
+          eventId: 'evt-skill-escalation',
+          workflowThreadId: 'wf-escalation',
+        },
+      }, 202);
+    }
+
+    if (url.endsWith('/tasks/TSK-42/check-ins') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          occurredAt: '2026-04-01T15:01:47.000Z',
+          intervalMinutes: 15,
+          eventId: 'evt-checkin',
+        },
+      }, 202);
+    }
+
+    if (url.endsWith('/tasks/TSK-42/retier') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          previousEngineerTier: 'Jr',
+          engineerTier: 'Sr',
+          updatedAt: '2026-04-01T15:01:48.000Z',
+          eventId: 'evt-retier',
+        },
+      }, 202);
+    }
+
+    if (url.endsWith('/tasks/TSK-42/reassignment') && init?.method === 'POST') {
+      currentOwner = 'engineer-sr';
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          previousAssignee: 'engineer',
+          assignee: 'engineer-sr',
+          previousEngineerTier: 'Jr',
+          engineerTier: 'Sr',
+          mode: 'inactivity',
+          missedCheckIns: 2,
+          transferSummary: {
+            prior_assignee: 'engineer',
+            new_assignee: 'engineer-sr',
+          },
+          ghostingReview: {
+            reviewTaskId: 'GHOST-1',
+            title: 'Inactivity review for TSK-42',
+          },
+        },
+      }, 202);
+    }
+
     if (url.endsWith('/tasks/TSK-42/lock') && init?.method === 'POST') {
       return createJsonResponse({
         success: true,
@@ -1536,6 +1599,156 @@ describe('Task browser runtime coverage', () => {
     expect(screen.getByText('Wire task detail')).toBeInTheDocument();
   });
 
+  it('submits responsible escalation from task detail for Jr-tier work before implementation starts', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'engineer-1',
+        tenant_id: 'tenant-a',
+        roles: ['engineer'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    const fetchMock = installTaskFetchMock({
+      detailOverride: {
+        task: { stage: 'TODO' },
+        context: {
+          architectHandoff: { engineerTier: 'Jr' },
+        },
+      },
+      summaryOverride: { current_stage: 'TODO' },
+    });
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    fireEvent.change(screen.getByLabelText('Why does this need higher-tier support?'), { target: { value: 'Cross-service delivery risk requires senior support.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Request higher-tier support' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').some((node) => node.textContent?.includes('Responsible escalation recorded'))).toBe(true);
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/tasks/TSK-42/skill-escalation'))).toBe(true);
+  });
+
+  it('submits engineer check-ins from task detail during implementation', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'engineer-1',
+        tenant_id: 'tenant-a',
+        roles: ['engineer'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    const fetchMock = installTaskFetchMock({
+      detailOverride: {
+        context: {
+          activityMonitoring: {
+            requiredCheckInIntervalMinutes: 15,
+            missedCheckIns: 0,
+            threshold: 2,
+            thresholdReached: false,
+            lastActivity: null,
+          },
+        },
+      },
+    });
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    fireEvent.change(screen.getByLabelText('Progress summary'), { target: { value: 'Implemented the next audit projection step.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Record engineer check-in' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').some((node) => node.textContent?.includes('Check-in recorded.'))).toBe(true);
+    });
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/tasks/TSK-42/check-ins'))).toBe(true);
+  });
+
+  it('submits architect re-tier and reassignment controls from task detail', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'architect-1',
+        tenant_id: 'tenant-a',
+        roles: ['architect'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    const fetchMock = installTaskFetchMock({
+      detailOverride: {
+        context: {
+          architectHandoff: { engineerTier: 'Jr' },
+          activityMonitoring: {
+            requiredCheckInIntervalMinutes: 15,
+            missedCheckIns: 2,
+            threshold: 2,
+            thresholdReached: true,
+            lastActivity: {
+              summary: 'Last check-in before inactivity',
+              occurredAt: '2026-04-01T14:00:00.000Z',
+            },
+          },
+        },
+      },
+    });
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    fireEvent.change(screen.getByLabelText('Re-tier rationale'), { target: { value: 'Cross-service complexity now requires senior ownership.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Update engineer tier' }));
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').some((node) => node.textContent?.includes('Engineer tier updated.'))).toBe(true);
+    });
+
+    fireEvent.change(screen.getByLabelText('Reassignment reason'), { target: { value: 'Two check-in windows were missed.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Reassign task' }));
+    await waitFor(() => {
+      expect(screen.getAllByRole('status').some((node) => node.textContent?.includes('Task reassigned and inactivity review created.'))).toBe(true);
+    });
+
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/tasks/TSK-42/retier'))).toBe(true);
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/tasks/TSK-42/reassignment'))).toBe(true);
+  });
+
+  it('renders a dedicated governance reviews surface and keeps governance tasks out of the delivery list', async () => {
+    installTaskFetchMock({
+      tasksOverride: [
+        { task_id: 'TSK-42', tenant_id: 'tenant-a', title: 'Wire task detail', priority: 'P1', current_stage: 'IMPLEMENT', current_owner: 'engineer', owner: { actor_id: 'engineer', display_name: 'engineer' }, blocked: false, closed: false, waiting_state: null, next_required_action: null, queue_entered_at: '2026-04-01T15:00:00.000Z', freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' } },
+        { task_id: 'GHOST-1', tenant_id: 'tenant-a', title: 'Inactivity review for TSK-42', priority: 'P1', current_stage: 'BACKLOG', current_owner: 'architect', owner: { actor_id: 'architect', display_name: 'architect' }, blocked: false, closed: false, waiting_state: null, next_required_action: null, task_type: 'governance_review', queue_entered_at: '2026-04-01T15:00:01.000Z', freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:01.000Z' } },
+      ],
+    });
+    window.history.pushState({}, '', '/overview/governance');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Governance Reviews' });
+    await screen.findByText('1 governance review shown.');
+    expect(screen.getByText('Inactivity review for TSK-42')).toBeInTheDocument();
+    expect(within(screen.getByRole('table')).queryByText('Wire task detail')).not.toBeInTheDocument();
+  });
+
+  it('shows the linked inactivity review on the parent task detail', async () => {
+    installTaskFetchMock({
+      detailOverride: {
+        context: {
+          ghostingReview: {
+            reviewTaskId: 'GHOST-1',
+            title: 'Inactivity review for TSK-42',
+            createdAt: '2026-04-01T15:10:00.000Z',
+          },
+        },
+      },
+    });
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    expect(screen.getByRole('link', { name: 'Inactivity review for TSK-42' })).toBeInTheDocument();
+    expect(screen.getByText(/Governance review task created at 2026-04-01T15:10:00.000Z/i)).toBeInTheDocument();
+  });
+
   it('passes an axe smoke scan for the task list route', async () => {
     installTaskFetchMock();
     window.history.pushState({}, '', '/tasks');
@@ -1598,7 +1811,7 @@ describe('Task browser runtime coverage', () => {
 
     await screen.findByRole('heading', { name: 'PM Overview' });
     expect(await screen.findByRole('heading', { name: 'Some routing metadata is unavailable' })).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent('6 tasks shown across 2 buckets.');
+    expect(screen.getByRole('status')).toHaveTextContent('6 tasks shown across 5 buckets.');
     expect(screen.getByText('Triage queue drift')).toBeInTheDocument();
 
     cleanup();

--- a/src/app/task-owner.mjs
+++ b/src/app/task-owner.mjs
@@ -32,6 +32,31 @@ function isGovernanceReviewTask(item) {
   return String(item?.task_type || '').trim().toLowerCase() === 'governance_review';
 }
 
+function canonicalRoleFromOwnerId(ownerId) {
+  const normalized = String(ownerId || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === 'engineer' || normalized.startsWith('engineer-')) return 'engineer';
+  if (normalized === 'architect' || normalized.startsWith('architect-')) return 'architect';
+  if (normalized === 'qa' || normalized.startsWith('qa-')) return 'qa';
+  if (normalized === 'sre' || normalized.startsWith('sre-')) return 'sre';
+  if (normalized === 'pm' || normalized.startsWith('pm-')) return 'pm';
+  return null;
+}
+
+function syntheticOwnerLabel(ownerId) {
+  const normalized = String(ownerId || '').trim().toLowerCase();
+  switch (normalized) {
+    case 'engineer-jr':
+      return 'Junior Engineer';
+    case 'engineer-sr':
+      return 'Senior Engineer';
+    case 'engineer-principal':
+      return 'Principal Engineer';
+    default:
+      return null;
+  }
+}
+
 export function mapAgentOptions(items = []) {
   return items.map((agent) => ({
     id: agent.id,
@@ -44,6 +69,11 @@ export function normalizeRoleKey(role) {
   if (typeof role !== 'string') return null;
   const normalized = role.trim().toLowerCase();
   if (!normalized) return null;
+  if (normalized.startsWith('engineer-')) return 'engineer';
+  if (normalized.startsWith('architect-')) return 'architect';
+  if (normalized.startsWith('qa-')) return 'qa';
+  if (normalized.startsWith('sre-')) return 'sre';
+  if (normalized.startsWith('pm-')) return 'pm';
   if (normalized === 'architecture') return 'architect';
   if (normalized === 'engineering') return 'engineer';
   if (normalized === 'quality assurance') return 'qa';
@@ -69,6 +99,11 @@ export function resolveOwnerPresentation(item, agentLookup) {
   const agent = agentLookup.get(item.current_owner);
   if (agent) {
     return { label: agent.label, detail: `Owner: ${agent.label}`, tone: 'assigned', filterValue: item.current_owner };
+  }
+
+  const syntheticLabel = syntheticOwnerLabel(item.current_owner);
+  if (syntheticLabel) {
+    return { label: syntheticLabel, detail: `Owner: ${syntheticLabel}`, tone: 'assigned', filterValue: item.current_owner };
   }
 
   if (isOwnerExplicitlyHidden(item.owner)) {
@@ -137,6 +172,16 @@ export function resolveRoleInboxMembership(item, agentLookup) {
     };
   }
 
+  const canonicalRole = canonicalRoleFromOwnerId(item.current_owner);
+  if (canonicalRole) {
+    return {
+      inboxRole: canonicalRole,
+      reason: 'matched-pattern',
+      routingLabel: `Routed to ${getRoleInboxLabel(canonicalRole)} because the assigned owner follows the canonical ${canonicalRole} ownership pattern.`,
+      isFallback: false,
+    };
+  }
+
   if (isOwnerExplicitlyHidden(item.owner)) {
     return {
       inboxRole: null,
@@ -173,6 +218,7 @@ export function resolvePmOverviewBucket(item, agentLookup) {
   }
 
   const agent = agentLookup.get(ownerId);
+  const canonicalOwnerRole = canonicalRoleFromOwnerId(ownerId);
 
   if (agent?.role && PM_OVERVIEW_ROLE_BUCKETS.has(agent.role)) {
     return {
@@ -180,6 +226,16 @@ export function resolvePmOverviewBucket(item, agentLookup) {
       label: getPmOverviewBucketLabel(agent.role),
       routingCue: `${getRoleInboxLabel(agent.role)} route`,
       routingReason: `Routed to ${getRoleInboxLabel(agent.role)} because the assigned owner maps to that canonical role.`,
+      ownerPresentation,
+    };
+  }
+
+  if (canonicalOwnerRole && PM_OVERVIEW_ROLE_BUCKETS.has(canonicalOwnerRole)) {
+    return {
+      key: canonicalOwnerRole,
+      label: getPmOverviewBucketLabel(canonicalOwnerRole),
+      routingCue: `${getRoleInboxLabel(canonicalOwnerRole)} route`,
+      routingReason: `Routed to ${getRoleInboxLabel(canonicalOwnerRole)} because the assigned owner follows the canonical ${canonicalOwnerRole} ownership pattern.`,
       ownerPresentation,
     };
   }
@@ -294,6 +350,13 @@ export function buildBoardColumns(allItems, visibleItems, agentLookup) {
     items: deliveryItems
       .filter((item) => (item.current_stage || 'Unspecified') === stage && visibleById.has(item.task_id))
       .map((item) => ({ ...item, ownerPresentation: resolveOwnerPresentation(item, agentLookup) })),
+  }));
+}
+
+export function buildGovernanceReviewItems(items, agentLookup) {
+  return sortInboxItems(items.filter((item) => isGovernanceReviewTask(item))).map((item) => ({
+    ...item,
+    ownerPresentation: resolveOwnerPresentation(item, agentLookup),
   }));
 }
 

--- a/tests/browser/auth-shell.browser.spec.ts
+++ b/tests/browser/auth-shell.browser.spec.ts
@@ -74,6 +74,8 @@ async function installApiMocks(page) {
   });
 }
 
+// Governance note: browser-shell route or session changes should keep browser coverage updated in the same change set.
+
 test.describe('authenticated browser app shell', () => {
   test.beforeEach(async ({ page }) => {
     await installApiMocks(page);

--- a/tests/browser/task-detail.browser.spec.ts
+++ b/tests/browser/task-detail.browser.spec.ts
@@ -55,9 +55,13 @@ const taskDetailPayload = {
   },
 };
 
-async function installApiMocks(page) {
-  await page.addInitScript(() => {
-    const claims = {
+async function installApiMocks(page, options: {
+  sessionClaims?: Record<string, unknown>,
+  taskItems?: typeof taskListItems,
+  detailPayload?: typeof taskDetailPayload,
+} = {}) {
+  await page.addInitScript((providedClaims) => {
+    const claims = providedClaims || {
       sub: 'pm-1',
       tenant_id: 'tenant-a',
       roles: ['pm', 'reader'],
@@ -72,11 +76,11 @@ async function installApiMocks(page) {
         expiresAt: new Date(Date.now() + (60 * 60 * 1000)).toISOString(),
       }),
     );
-  });
+  }, options.sessionClaims);
 
   await page.route('**/api/tasks', async (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
-    await route.fulfill({ json: { items: taskListItems } });
+    await route.fulfill({ json: { items: options.taskItems || taskListItems } });
   });
 
   await page.route('**/api/tasks/TSK-42', async (route) => {
@@ -87,7 +91,7 @@ async function installApiMocks(page) {
   });
 
   await page.route('**/api/tasks/TSK-42/detail**', async (route) => {
-    await route.fulfill({ json: taskDetailPayload });
+    await route.fulfill({ json: options.detailPayload || taskDetailPayload });
   });
 
   await page.route('**/api/tasks/TSK-42/history**', async (route) => {
@@ -107,6 +111,10 @@ async function installApiMocks(page) {
       { id: 'qa', display_name: 'QA Engineer', role: 'QA', active: true },
       { id: 'engineer', display_name: 'Engineer', role: 'Engineering', active: true },
     ] } });
+  });
+
+  await page.route('**/api/tasks/TSK-42/skill-escalation', async (route) => {
+    await route.fulfill({ json: { success: true, data: { taskId: 'TSK-42', currentEngineerTier: 'Jr', requestedTier: 'Sr' } }, status: 202 });
   });
 }
 
@@ -276,5 +284,49 @@ test.describe('task detail browser verification', () => {
     expect(desktopShot.byteLength).toBeGreaterThan(10_000);
     expect(tabletShot.byteLength).toBeGreaterThan(10_000);
     expect(mobileShot.byteLength).toBeGreaterThan(10_000);
+  });
+
+  test('shows governance reviews on the dedicated governance overview route', async ({ page }) => {
+    await installApiMocks(page, {
+      taskItems: [
+        ...taskListItems,
+        { task_id: 'GHOST-1', tenant_id: 'tenant-a', title: 'Inactivity review for TSK-42', priority: 'P1', current_stage: 'BACKLOG', current_owner: 'architect', owner: { actor_id: 'architect', display_name: 'Architect' }, blocked: false, closed: false, waiting_state: null, next_required_action: null, task_type: 'governance_review', queue_entered_at: '2026-04-01T15:00:06.000Z', freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:06.000Z' } },
+      ],
+    });
+
+    await openRoute(page, '/overview/governance', 'Governance Reviews');
+    await expect(page.getByRole('region', { name: 'Governance reviews view' })).toBeVisible();
+    await expect(page.getByText('Inactivity review for TSK-42')).toBeVisible();
+    await expect(page.getByText('1 governance review shown.')).toBeVisible();
+  });
+
+  test('submits responsible escalation from task detail in the browser flow', async ({ page }) => {
+    await installApiMocks(page, {
+      sessionClaims: {
+        sub: 'engineer-1',
+        tenant_id: 'tenant-a',
+        roles: ['engineer'],
+        exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      },
+      detailPayload: {
+        ...taskDetailPayload,
+        task: { ...taskDetailPayload.task, stage: 'TODO', status: 'ready' },
+        context: {
+          ...taskDetailPayload.context,
+          architectHandoff: {
+            engineerTier: 'Jr',
+            version: 2,
+            readyForEngineering: true,
+            submittedBy: 'Architect 1',
+            tierRationale: 'Initial sizing kept this in junior scope.',
+          },
+        },
+      },
+    });
+
+    await openRoute(page, '/tasks/TSK-42');
+    await page.getByLabel('Why does this need higher-tier support?').fill('The implementation now crosses service boundaries and needs senior ownership.');
+    await page.getByRole('button', { name: 'Request higher-tier support' }).click();
+    await expect(page.getByRole('status').filter({ hasText: 'Responsible escalation recorded and surfaced for architect review.' })).toBeVisible();
   });
 });

--- a/tests/contract/audit-openapi.contract.test.js
+++ b/tests/contract/audit-openapi.contract.test.js
@@ -49,6 +49,7 @@ test('openapi contract documents the live audit routes and auth model', () => {
   const spec = fs.readFileSync(path.join(__dirname, '../../docs/api/audit-foundation-openapi.yml'), 'utf8');
   const ownerReadSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-owner-surfaces-openapi.yml'), 'utf8');
   const browserAuthSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/authenticated-browser-app-openapi.yml'), 'utf8');
+  const assignmentSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-assignment-openapi.yml'), 'utf8');
 
   for (const snippet of [
     '/tasks:',
@@ -79,6 +80,9 @@ test('openapi contract documents the live audit routes and auth model', () => {
     '/tasks/{id}:',
     'List task summaries with read-only owner metadata',
     'Assignment mutation stays on `PATCH /tasks/{id}/assignment`.',
+    'engineer-jr',
+    'engineer-sr',
+    'governance_review',
   ]) {
     assert.match(ownerReadSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
@@ -90,8 +94,16 @@ test('openapi contract documents the live audit routes and auth model', () => {
     'accessToken',
     'expiresAt',
     'Signed browser bootstrap artifact from the trusted internal auth source.',
+    '/overview/governance',
   ]) {
     assert.match(browserAuthSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  for (const snippet of [
+    'Only the currently assigned owner may perform this action.',
+    'engineer-sr',
+  ]) {
+    assert.match(assignmentSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 });
 

--- a/tests/integration/board-owner-filtering.integration.test.js
+++ b/tests/integration/board-owner-filtering.integration.test.js
@@ -14,7 +14,8 @@ function createJsonResponse(payload, status = 200) {
 }
 
 function buildTaskItems(currentOwnerByTask) {
-  return fixture.tasks.map((task) => ({
+  return [
+    ...fixture.tasks.map((task) => ({
     task_id: task.task_id,
     tenant_id: fixture.tenant_id,
     title: task.title,
@@ -25,7 +26,21 @@ function buildTaskItems(currentOwnerByTask) {
     blocked: false,
     closed: false,
     freshness: { status: 'fresh', last_updated_at: '2026-04-02T12:00:00.000Z' },
-  }));
+    })),
+    {
+      task_id: 'GHOST-BOARD-1',
+      tenant_id: fixture.tenant_id,
+      title: 'Governance review task',
+      priority: 'P1',
+      current_stage: 'BACKLOG',
+      current_owner: 'architect',
+      owner: { actor_id: 'architect', display_name: 'architect' },
+      task_type: 'governance_review',
+      blocked: false,
+      closed: false,
+      freshness: { status: 'fresh', last_updated_at: '2026-04-02T12:00:01.000Z' },
+    },
+  ];
 }
 
 function installBoardFetchMock() {
@@ -94,6 +109,7 @@ describe('board owner filtering integration', () => {
     await screen.findByText('5 cards shown.');
     expect(screen.getByText('Owner hidden')).toBeInTheDocument();
     expect(screen.getByText('Unknown owner')).toBeInTheDocument();
+    expect(screen.queryByText('Governance review task')).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Owner filter'), { target: { value: '__unassigned__' } });
     await screen.findByText('1 unassigned cards shown.');

--- a/tests/security/audit-api.security.test.js
+++ b/tests/security/audit-api.security.test.js
@@ -171,6 +171,38 @@ test('reader scope keeps owner metadata visible while assignment remains forbidd
   });
 });
 
+test('rejects engineer-only delivery mutations when the task has been reassigned away from engineering', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const contributorAuth = { authorization: `Bearer ${sign({ sub: 'eng', tenant_id: 'tenant-sec', roles: ['contributor'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+    const pmAuth = { authorization: `Bearer ${sign({ sub: 'pm', tenant_id: 'tenant-sec', roles: ['pm'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+    const engineerAuth = { authorization: `Bearer ${sign({ sub: 'engineer-user', tenant_id: 'tenant-sec', roles: ['engineer'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SEC-OWNER/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...contributorAuth },
+      body: JSON.stringify({ eventType: 'task.created', actorType: 'agent', idempotencyKey: 'create:TSK-SEC-OWNER', payload: { title: 'Owner-restricted task', initial_stage: 'IMPLEMENTATION' } }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-OWNER/assignment`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json', ...pmAuth },
+      body: JSON.stringify({ agentId: 'qa' }),
+    });
+    assert.equal(response.status, 200);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-OWNER/check-ins`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...engineerAuth },
+      body: JSON.stringify({ summary: 'Wrong owner tried to check in.' }),
+    });
+    assert.equal(response.status, 403);
+    const body = await response.json();
+    assert.equal(body.error.code, 'forbidden');
+    assert.match(body.error.message, /currently assigned owner/i);
+  });
+});
+
 test('browser auth bootstrap rejects missing and incomplete auth codes', async () => {
   await withServer(async ({ baseUrl, secret, baseDir }) => {
     let response = await fetch(`${baseUrl}/auth/session`, {

--- a/tests/security/task-assignment-security.test.js
+++ b/tests/security/task-assignment-security.test.js
@@ -79,5 +79,6 @@ test('security: unauthorized and malformed assignment requests never mutate stat
     });
     const summary = await response.json();
     assert.equal(summary.current_owner, null);
+    assert.equal(summary.owner, null);
   });
 });

--- a/tests/unit/audit-api.test.js
+++ b/tests/unit/audit-api.test.js
@@ -1006,6 +1006,13 @@ test('records engineer implementation metadata, exposes the primary reference in
     });
     assert.equal(response.status, 202);
 
+    response = await fetch(`${baseUrl}/tasks/TSK-ENG-1/events`, {
+      method: 'POST',
+      headers: architectHeaders,
+      body: JSON.stringify({ eventType: 'task.assigned', actorType: 'agent', idempotencyKey: 'assign:TSK-ENG-1:engineer', payload: { assignee: 'engineer' } }),
+    });
+    assert.equal(response.status, 202);
+
     response = await fetch(`${baseUrl}/tasks/TSK-ENG-1/architect-handoff`, {
       method: 'PUT',
       headers: architectHeaders,
@@ -1096,6 +1103,13 @@ test('validates engineer metadata formats, stage restrictions, and feature flag 
       method: 'POST',
       headers: engineerHeaders,
       body: JSON.stringify({ eventType: 'task.created', actorType: 'agent', idempotencyKey: 'create:TSK-ENG-2', payload: { title: 'Engineer metadata validation', initial_stage: 'BACKLOG' } }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-ENG-2/events`, {
+      method: 'POST',
+      headers: engineerHeaders,
+      body: JSON.stringify({ eventType: 'task.assigned', actorType: 'agent', idempotencyKey: 'assign:TSK-ENG-2:engineer', payload: { assignee: 'engineer' } }),
     });
     assert.equal(response.status, 202);
 
@@ -1296,6 +1310,18 @@ test('supports Jr above-skill escalation before implementation starts and lets a
     });
     assert.equal(response.status, 202);
 
+    response = await fetch(`${baseUrl}/tasks/TSK-RETIER-1/events`, {
+      method: 'POST',
+      headers: engineerHeaders,
+      body: JSON.stringify({
+        eventType: 'task.assigned',
+        actorType: 'agent',
+        idempotencyKey: 'assign:TSK-RETIER-1:engineer',
+        payload: { assignee: 'engineer' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
     response = await fetch(`${baseUrl}/tasks/TSK-RETIER-1/skill-escalation`, {
       method: 'POST',
       headers: engineerHeaders,
@@ -1417,6 +1443,7 @@ test('reassigns inactive work after two missed check-ins, re-tiers it, and creat
     const reassignment = await response.json();
     assert.equal(reassignment.data.previousEngineerTier, 'Jr');
     assert.equal(reassignment.data.engineerTier, 'Sr');
+    assert.equal(reassignment.data.assignee, 'engineer-sr');
     assert.equal(reassignment.data.missedCheckIns, 2);
     assert.match(reassignment.data.ghostingReview.reviewTaskId, /^GHOST-/);
     assert.equal(reassignment.data.transferSummary.prior_assignee, 'engineer');
@@ -1429,6 +1456,7 @@ test('reassigns inactive work after two missed check-ins, re-tiers it, and creat
     assert.equal(detail.context.activityMonitoring.thresholdReached, true);
     assert.equal(detail.context.reassignment.mode, 'inactivity');
     assert.equal(detail.context.reassignment.engineerTier, 'Sr');
+    assert.equal(detail.context.reassignment.assignee, 'engineer-sr');
     assert.equal(detail.context.ghostingReview.reviewTaskId, reassignment.data.ghostingReview.reviewTaskId);
     assert.equal(detail.context.transferredContext.prior_assignee, 'engineer');
     assert.match(detail.context.transferredContext.reason, /missed/i);
@@ -1439,6 +1467,58 @@ test('reassigns inactive work after two missed check-ins, re-tiers it, and creat
     assert.equal(response.status, 200);
     const reviewTask = await response.json();
     assert.match(reviewTask.title, /Inactivity review/);
+  });
+});
+
+test('restricts engineer-only reassignment signals to the currently assigned engineer role', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const engineerHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'engineer-user', tenant_id: 'tenant-owner', roles: ['engineer', 'contributor'] }),
+    };
+    const pmHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'pm-user', tenant_id: 'tenant-owner', roles: ['pm'] }),
+    };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-OWNER-1/events`, {
+      method: 'POST',
+      headers: engineerHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-OWNER-1',
+        payload: {
+          title: 'Ownership constrained task',
+          initial_stage: 'IMPLEMENTATION',
+          task_type: 'feature',
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-OWNER-1/assignment`, {
+      method: 'PATCH',
+      headers: pmHeaders,
+      body: JSON.stringify({ agentId: 'qa' }),
+    });
+    assert.equal(response.status, 200);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-OWNER-1/check-ins`, {
+      method: 'POST',
+      headers: engineerHeaders,
+      body: JSON.stringify({ summary: 'Tried to post an update from the wrong owner role.' }),
+    });
+    assert.equal(response.status, 403);
+    assert.match((await response.json()).error.message, /currently assigned owner/i);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-OWNER-1/skill-escalation`, {
+      method: 'POST',
+      headers: engineerHeaders,
+      body: JSON.stringify({ reason: 'Tried to escalate from the wrong owner role.' }),
+    });
+    assert.equal(response.status, 403);
+    assert.match((await response.json()).error.message, /currently assigned owner/i);
   });
 });
 
@@ -1574,6 +1654,13 @@ test('records structured QA results, routes fail/pass outcomes, preserves re-tes
       method: 'POST',
       headers: architectHeaders,
       body: JSON.stringify({ eventType: 'task.stage_changed', actorType: 'agent', idempotencyKey: 'move:TSK-QA-1:IMPLEMENTATION', payload: { from_stage: 'TECHNICAL_SPEC', to_stage: 'IMPLEMENTATION' } }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-QA-1/events`, {
+      method: 'POST',
+      headers: architectHeaders,
+      body: JSON.stringify({ eventType: 'task.assigned', actorType: 'agent', idempotencyKey: 'assign:TSK-QA-1:engineer', payload: { assignee: 'engineer' } }),
     });
     assert.equal(response.status, 202);
 

--- a/tests/unit/role-inbox-routing.test.js
+++ b/tests/unit/role-inbox-routing.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import fixture from '../fixtures/role-inbox/role-inbox-states.json' with { type: 'json' };
 import {
+  buildGovernanceReviewItems,
   buildRoleInboxItems,
   getRoleInboxLabel,
   mapAgentOptions,
@@ -26,6 +27,7 @@ describe('role inbox routing', () => {
   it('routes assigned and explicitly waiting tasks into the correct canonical inbox', () => {
     const architectTask = { current_owner: 'architect', owner: { actor_id: 'architect' } };
     const engineerTask = { current_owner: 'engineer', owner: { actor_id: 'engineer' } };
+    const seniorEngineerTask = { current_owner: 'engineer-sr', owner: { actor_id: 'engineer-sr' } };
     const pmTask = { current_owner: null, owner: null, waiting_state: 'awaiting_pm_decision' };
     const architectWaitTask = { current_owner: 'engineer', owner: { actor_id: 'engineer' }, waiting_state: 'awaiting_architect_decision' };
     const humanTask = { current_owner: null, owner: null, next_required_action: 'Human approval required' };
@@ -35,6 +37,7 @@ describe('role inbox routing', () => {
 
     expect(resolveRoleInboxMembership(architectTask, agentLookup)).toMatchObject({ inboxRole: 'architect', reason: 'matched' });
     expect(resolveRoleInboxMembership(engineerTask, agentLookup)).toMatchObject({ inboxRole: 'engineer', reason: 'matched' });
+    expect(resolveRoleInboxMembership(seniorEngineerTask, agentLookup)).toMatchObject({ inboxRole: 'engineer', reason: 'matched-pattern' });
     expect(resolveRoleInboxMembership(pmTask, agentLookup)).toMatchObject({ inboxRole: 'pm', reason: 'waiting-pm' });
     expect(resolveRoleInboxMembership(architectWaitTask, agentLookup)).toMatchObject({ inboxRole: 'architect', reason: 'waiting-architect' });
     expect(resolveRoleInboxMembership(humanTask, agentLookup)).toMatchObject({ inboxRole: 'human', reason: 'waiting-human' });
@@ -91,5 +94,19 @@ describe('role inbox routing', () => {
 
     const architectItems = buildRoleInboxItems(items, 'architect', agentLookup);
     expect(architectItems.map((item) => item.task_id)).toEqual(['TSK-1']);
+  });
+
+  it('builds a dedicated governance review list and preserves synthetic engineer owner labels', () => {
+    const items = [
+      { task_id: 'GHOST-1', title: 'Inactivity review for TSK-42', current_owner: 'architect', current_stage: 'BACKLOG', priority: 'P1', task_type: 'governance_review', freshness: { last_updated_at: '2026-04-01T00:00:01.000Z' }, owner: { actor_id: 'architect' } },
+      { task_id: 'TSK-2', title: 'Delivery work', current_owner: 'engineer-sr', current_stage: 'IMPLEMENT', priority: 'P1', freshness: { last_updated_at: '2026-04-01T00:00:02.000Z' }, owner: { actor_id: 'engineer-sr' } },
+    ];
+
+    const governanceItems = buildGovernanceReviewItems(items, agentLookup);
+    expect(governanceItems.map((item) => item.task_id)).toEqual(['GHOST-1']);
+
+    const engineerItems = buildRoleInboxItems(items, 'engineer', agentLookup);
+    expect(engineerItems).toHaveLength(1);
+    expect(engineerItems[0].ownerPresentation.label).toBe('Senior Engineer');
   });
 });


### PR DESCRIPTION
## Summary
Add current-owner enforcement to audit delivery mutations, preserve tier-specific engineer assignee identities, and expose governance-review work on a dedicated browser overview route.

## Linked Task
- Task: follow-up app/runtime slice for governance review routing and current-owner enforcement

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: Architecture & Design Standards, Testing & Quality-Assurance Standards, Deployment & Release Standards, Observability & Monitoring Standards
- Standards gaps or exceptions: no documented exceptions in this change set

## Required Evidence
- Standards check result: `npm run standards:check`
- Lint result: `npm run lint`
- Tests: `npm run change:check`, `npm run test:unit`, `npm run test:browser`
- Test evidence paths: src/app/App.test.tsx, tests/browser/auth-shell.browser.spec.ts, tests/browser/task-detail.browser.spec.ts, tests/contract/audit-openapi.contract.test.js, tests/integration/board-owner-filtering.integration.test.js, tests/security/audit-api.security.test.js, tests/security/task-assignment-security.test.js, tests/unit/audit-api.test.js, tests/unit/role-inbox-routing.test.js
- Docs updated: browser-shell design guidance, task assignment and owner-surface API contracts, task-detail telemetry contract, and matching runbooks for audit foundation and workflow delivery
- Doc evidence paths: docs/api/authenticated-browser-app-openapi.yml, docs/api/task-assignment-openapi.yml, docs/api/task-detail-history-telemetry-openapi.yml, docs/api/task-owner-surfaces-openapi.yml, docs/design/US-002-design.md, docs/runbooks/audit-foundation.md, docs/runbooks/task-assignment.md, docs/runbooks/workflow-delivery-loop.md

## Risk and Rollback
- Risk level: medium
- Rollback path: revert commit 1b7b7cb and redeploy the browser and audit API services

## Notes
- This PR intentionally excludes local tracker files and generated observability output.
