### PR TITLE
[SF-014] Complete SRE monitoring workflow and standards evidence

### DIFF
--- a/docs/api/audit-foundation-openapi.yml
+++ b/docs/api/audit-foundation-openapi.yml
@@ -2,6 +2,11 @@ openapi: 3.1.0
 info:
   title: Audit Foundation API
   version: 0.1.0
+  description: |
+    Canonical audit and workflow HTTP contract.
+    The task-list projection now also carries additive queue/WIP metadata and optional SRE monitoring preview data.
+    SRE monitoring runtime accepts both `ff_sre_monitoring` and `ff-sre-monitoring` as equivalent feature-flag names.
+    Expired monitoring escalations are materialized by background worker processing (`processExpiredSreMonitoring`) rather than read-side mutation.
 components:
   securitySchemes:
     BearerAuth:
@@ -41,11 +46,18 @@ components:
           $ref: '#/components/schemas/OwnerSummary'
         blocked: { type: boolean }
         closed: { type: boolean }
+        queue_entered_at: { type: [string, 'null'], format: date-time }
+        wip_owner: { type: [string, 'null'] }
+        wip_started_at: { type: [string, 'null'], format: date-time }
         freshness:
           type: object
           properties:
             status: { type: string }
             last_updated_at: { type: [string, 'null'], format: date-time }
+        monitoring:
+          type: [object, 'null']
+          additionalProperties: true
+          description: Optional SRE monitoring preview used by the `/inbox/sre` dashboard rows.
     TaskListResponse:
       type: object
       required: [items]
@@ -257,6 +269,69 @@ paths:
       responses:
         '200':
           description: Relationship response
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/FeatureDisabled'
+  /tasks/{id}/sre-monitoring/start:
+    post:
+      summary: Start the SRE monitoring window for a task already routed into `SRE_MONITORING`
+      description: |
+        Requires SRE or admin privileges and durable deployment confirmation inputs.
+        The runtime feature can be disabled by either `ff_sre_monitoring` or `ff-sre-monitoring`.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [deploymentEnvironment, deploymentUrl, deploymentVersion]
+              properties:
+                deploymentEnvironment: { type: string }
+                deploymentUrl: { type: string, format: uri }
+                deploymentVersion: { type: string }
+                evidence:
+                  type: array
+                  items: { type: string }
+      responses:
+        '201':
+          description: Monitoring window started
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/FeatureDisabled'
+  /tasks/{id}/sre-monitoring/approve:
+    post:
+      summary: Record early SRE approval for a stable monitoring window
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [reason]
+              properties:
+                reason: { type: string }
+                evidence:
+                  type: array
+                  items: { type: string }
+      responses:
+        '201':
+          description: Approval recorded and task advanced to close review
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/docs/api/authenticated-browser-app-openapi.yml
+++ b/docs/api/authenticated-browser-app-openapi.yml
@@ -9,6 +9,8 @@ info:
     `/overview/pm`, `/overview/governance`, `/inbox/{role}`, and `/tasks/{taskId}`.
     The `/overview/governance` route is a dedicated operational surface for governance review tasks and
     is intentionally separate from standard delivery queues.
+    `/inbox/sre` is the protected SRE monitoring dashboard route and consumes deployment-aware monitoring
+    preview data from the projected task-list response.
 paths:
   /auth/session:
     post:

--- a/docs/api/task-assignment-openapi.yml
+++ b/docs/api/task-assignment-openapi.yml
@@ -8,6 +8,7 @@ info:
     Governance note: assignment runtime changes should update this spec in the same pull request.
     Delivery-loop mutations that are reserved for the currently assigned engineer role now reject callers
     that no longer match the task's canonical assignee.
+    Shared browser surfaces such as `/inbox/sre` remain read-only unless a dedicated workflow endpoint is used.
 paths:
   /tasks/{taskId}/assignment:
     patch:

--- a/docs/api/task-detail-history-telemetry-openapi.yml
+++ b/docs/api/task-detail-history-telemetry-openapi.yml
@@ -300,6 +300,30 @@ components:
               type: [object, 'null']
               additionalProperties: true
               description: Linked governance review task created for inactivity or other governance follow-up.
+            sreMonitoring:
+              type: [object, 'null']
+              description: SRE monitoring workflow summary, including deployment evidence, countdown state, telemetry drilldowns, approval snapshot, and expiry escalation details when present.
+              properties:
+                state: { type: string }
+                windowStartedAt: { type: [string, 'null'], format: date-time }
+                windowEndsAt: { type: [string, 'null'], format: date-time }
+                timeRemainingLabel: { type: [string, 'null'] }
+                riskLevel: { type: [string, 'null'] }
+                deployment:
+                  type: [object, 'null']
+                  properties:
+                    environment: { type: [string, 'null'] }
+                    url: { type: [string, 'null'], format: uri }
+                    version: { type: [string, 'null'] }
+                telemetry:
+                  type: [object, 'null']
+                  additionalProperties: true
+                approval:
+                  type: [object, 'null']
+                  additionalProperties: true
+                escalation:
+                  type: [object, 'null']
+                  additionalProperties: true
         relations:
           type: object
           required: [linkedPrs, childTasks]

--- a/docs/api/task-owner-surfaces-openapi.yml
+++ b/docs/api/task-owner-surfaces-openapi.yml
@@ -64,6 +64,8 @@ paths:
         Tier-specific assignee ids such as `engineer-jr`, `engineer-sr`, and `engineer-principal`
         remain valid projected owner values and should still collapse into the canonical engineer route family
         for browser overview and inbox grouping.
+        Tasks in `SRE_MONITORING` route to the SRE inbox by workflow stage before owner-based routing;
+        explicit human waiting-state or approval escalation still takes precedence over SRE routing.
       responses:
         '200':
           description: Task-list summaries

--- a/docs/design/SF-014-design.md
+++ b/docs/design/SF-014-design.md
@@ -1,0 +1,69 @@
+# SF-014 Design
+
+## Research & Context
+## Evidence
+- Issue `#19` defines `SF-014` as an SRE monitoring dashboard with deployment-aware monitoring windows, telemetry drilldowns, early approval controls, and expiry escalation.
+- The requested workflow runner scripts are not present in this checkout: `npm run task:pull`, `npm run ag:workflow ...`, `npm run workflow:discover ...`, and `.agent/skills/test-coverage-gap-analysis/...` do not exist, so the workflow must be executed manually against the actual repo.
+- Existing workflow primitives already live in [lib/audit/http.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/http.js), [lib/audit/core.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/core.js), [lib/audit/store.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/store.js), and [lib/audit/workflow.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/workflow.js).
+- The current product already routes passing QA results into `SRE_MONITORING`, exposes task detail telemetry, links PR metadata, and has an SRE inbox surface in [src/app/App.jsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.jsx) and routing helpers in [src/app/task-owner.mjs](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/task-owner.mjs).
+- Existing acceptance-adjacent behavior already exists for PR sync and close gating in [tests/unit/audit-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/audit-api.test.js), but there is no deployment-gated monitoring window, no SRE approval mutation, and no expiry-based human escalation.
+
+## Coverage Gap Analysis
+## Evidence
+- The requested coverage-gap script is absent, so the gap analysis was performed from the repo’s real test surface.
+- Existing coverage already validates QA routing into `SRE_MONITORING`, task detail telemetry shaping, PR sync, and role inbox routing.
+- Missing coverage for this story:
+- backend tests for starting a monitoring window only after durable deployment confirmation inputs and merged PR evidence
+- backend tests for auditable early approval moving the task from `SRE_MONITORING` to `PM_CLOSE_REVIEW`
+- backend tests for automatic expiry escalation producing a human-routed escalation signal
+- adapter tests for new SRE monitoring start and approval endpoints
+- UI tests for the SRE inbox dashboard row/card treatment and the task-detail SRE monitoring controls
+- Planned gap closure:
+- extend [tests/unit/audit-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/audit-api.test.js) with SRE monitoring lifecycle tests
+- extend [tests/unit/task-detail-adapter.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/task-detail-adapter.test.js) for the new monitoring client methods
+- extend [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx) for SRE inbox and detail interaction
+- extend [tests/unit/role-inbox-routing.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/role-inbox-routing.test.js) so expired monitoring work routes to human stakeholders
+
+## User Story
+## Evidence
+- As an SRE, I want to monitor all deployed tasks with telemetry, timers, and decision controls, so that I can catch production issues before closing work.
+- Acceptance criteria to satisfy:
+- given a PR merge and successful deploy, when monitoring starts, then a 48-hour countdown is visible
+- given SRE opens the monitoring view, when tasks are listed, then PR, commit, metrics, logs, and time remaining are visible
+- given metrics are clearly stable, when SRE approves early, then the task advances to Close review
+- given 48 hours expires with no SRE action, when the threshold passes, then human stakeholder escalation is created
+- Architectural notes to preserve:
+- monitoring begins only after a durable deploy confirmation event or command, not merely after QA passes
+- the dashboard should read from a task-centric monitoring projection/view model rather than forcing the UI to compose raw observability queries itself
+- early approval must record an explicit reason plus an evidence snapshot
+- expiry escalation must be auditable and system-driven
+
+## Feasibility Check
+## Evidence
+- Backend feasibility is moderate but localized: the audit API already appends immutable events, computes detail view models, and exposes task/observability projections.
+- Frontend feasibility is moderate and low-risk: the SRE inbox route already exists, task detail already supports role-gated mutations, and telemetry/PR data already render in task detail.
+- Risk validation:
+- rather than inventing a separate monitoring subsystem, derive an SRE monitoring view model from existing task history, PR relationships, engineer submission metadata, and observability summary data
+- add two explicit SRE mutations, one to start the monitoring window after deploy confirmation and one to approve early with evidence
+- use the existing projection worker path to materialize expiry escalation when the monitoring deadline has passed and no approval exists; this keeps the path system-driven and idempotent without making reads mutate state
+- retain `PM_CLOSE_REVIEW` as the post-SRE close-review stage instead of introducing a new close-stage enum
+
+## Technical Plan
+## Evidence
+- Backend/API work in [lib/audit/http.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/http.js), [lib/audit/core.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/core.js), and [lib/audit/event-types.js](/Users/wiinc2/.openclaw/workspace/engineering-team/lib/audit/event-types.js):
+- add feature-flag support for `ff_sre_monitoring`
+- add explicit monitoring lifecycle events for monitoring start and SRE approval, while reusing `task.escalated` for expiry escalation
+- derive a task-centric `sreMonitoring` view model from task history, PR relationships, engineer submission metadata, architect monitoring spec, and observability summary data
+- expose new mutation routes for `POST /tasks/:id/sre-monitoring/start` and `POST /tasks/:id/sre-monitoring/approve`
+- process expired monitoring windows through the projection worker so an auditable expiry escalation event exists even when no read request touches the task
+- HTTP task-list enrichment:
+- augment `GET /tasks` responses with monitoring preview data needed by the SRE inbox so the UI can render countdown, risk, deployment, PR, commit, and drilldown links without fan-out fetches
+- Frontend work in [src/features/task-detail/adapter.js](/Users/wiinc2/.openclaw/workspace/engineering-team/src/features/task-detail/adapter.js), [src/features/task-detail/adapter.browser.js](/Users/wiinc2/.openclaw/workspace/engineering-team/src/features/task-detail/adapter.browser.js), [src/app/task-owner.mjs](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/task-owner.mjs), and [src/app/App.jsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.jsx):
+- add task-detail client methods for SRE monitoring start and approval
+- render a monitoring panel on task detail with deploy confirmation inputs, countdown, evidence snapshot, telemetry drilldowns, and early approval flow
+- specialize the existing SRE inbox into a monitoring dashboard treatment using the enriched task-list projection and stage-based routing
+- route expired monitoring items to human stakeholders via waiting-state / next-action semantics
+- Verification plan:
+- unit tests first for API lifecycle, adapter calls, routing, and UI
+- then run `npm run test:unit`
+- if time and environment permit, run broader verification commands available in this repo rather than the absent workflow wrappers

--- a/docs/design/US-002-design.md
+++ b/docs/design/US-002-design.md
@@ -78,3 +78,4 @@
 - `/overview/governance` is a protected route in the authenticated shell
 - governance review tasks are shown only on that dedicated route and are intentionally excluded from the default task list, board, and PM overview delivery surfaces
 - tier-specific engineer owners still collapse into the canonical `engineer` route family for inbox and overview grouping while preserving human-readable labels in the UI
+- `/inbox/sre` is a protected route in the authenticated shell and now renders a deployment-aware monitoring dashboard for tasks actively in the `SRE_MONITORING` stage

--- a/docs/reports/ISSUE_7_COMPLETION_AUDIT.md
+++ b/docs/reports/ISSUE_7_COMPLETION_AUDIT.md
@@ -134,6 +134,11 @@ Not required to satisfy issue #7, but worth later tightening:
 - add a first-class OpenAPI example payload for `/tasks/{id}/detail`
 - add explicit stale-window config if the project wants a runtime-tunable threshold later
 
+## Later task-detail additions now covered by the same contract discipline
+- Subsequent workflow slices may extend the detail `context` object with additive sections when the server remains the authoritative derivation layer.
+- Current additive example: `context.sreMonitoring`, which carries deployment evidence, countdown state, telemetry drilldowns, approval evidence, and expiry escalation status for tasks in the SRE monitoring flow.
+- These additions do not change the underlying task-detail rule that the client should consume the server-prepared `/tasks/{id}/detail` payload rather than reconstructing workflow state from multiple endpoints.
+
 ## Standards Alignment
 
 - Applicable standards areas: testing and quality assurance, observability and monitoring, team and process

--- a/docs/reports/SF-014-review.md
+++ b/docs/reports/SF-014-review.md
@@ -1,0 +1,28 @@
+# SF-014 Review
+
+## UAT Evidence
+- Internal UAT proxy completed against the acceptance criteria from issue `#19`.
+- Verified behaviors:
+- QA pass routes work into `SRE_MONITORING`.
+- Stage-based routing places active monitoring work in `/inbox/sre` even when the assigned owner remains an engineer.
+- The SRE inbox exposes countdown, deployment environment/version/link, PR, commit, and telemetry drilldowns from the task-list projection.
+- Early approval advances the task to `PM_CLOSE_REVIEW` with a recorded reason and evidence snapshot.
+- Expired monitoring windows create a human stakeholder escalation through worker processing rather than a read-side write.
+- Supporting artifacts:
+- [docs/design/SF-014-design.md](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/design/SF-014-design.md)
+- [tests/unit/audit-api.test.js](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/unit/audit-api.test.js)
+- [src/app/App.test.tsx](/Users/wiinc2/.openclaw/workspace/engineering-team/src/app/App.test.tsx)
+- [tests/browser/task-detail.browser.spec.ts](/Users/wiinc2/.openclaw/workspace/engineering-team/tests/browser/task-detail.browser.spec.ts)
+
+## Standards Alignment
+
+- Applicable standards areas: architecture and design, testing and quality assurance, deployment and release, observability and monitoring, team and process
+- Evidence in this report: implementation review tied to worker-driven expiry handling, contract-adjacent doc updates, automated validation, and user-visible monitoring workflow checks
+- Gap observed: this review uses an internal UAT proxy rather than a production-environment rollout validation. Documented rationale: progressive rollout and direct user-impact measurement remain separate release controls from repository review evidence (source https://sre.google/books/).
+
+## Required Evidence
+
+- Commands run: `npm run standards:check`, `npm run ownership:lint`, `npm run lint`, `npm run typecheck`, `npm run test:governance`, `npm run change:check`, `npm test`
+- Tests added or updated: contract, security, e2e, integration, browser, unit, and UI coverage adjacent to the monitoring workflow
+- Rollout or rollback notes: review artifact only; runtime rollback remains the existing feature-flag disablement path for `ff_sre_monitoring` / `ff-sre-monitoring`
+- Docs updated: SF-014 review report plus adjacent API/runbook/design artifacts referenced in this change

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -74,6 +74,7 @@ Audit HTTP maintenance note:
 - Current nearest artifacts for HTTP-surface changes are this runbook plus the matching `docs/api/*.yml` contract for the affected route family.
 - Engineer-only delivery-loop mutations now validate the task's current canonical assignee before accepting writes.
 - Tier-based reassignment may emit explicit assignee ids such as `engineer-sr` in workflow payloads and task-detail context so downstream consumers can tell when ownership changed materially.
+- SRE monitoring expiry is now worker-driven: reads reflect the current state but no longer append escalation events when the window has expired.
 
 ## Tenant isolation guarantees in this slice
 - Idempotency is tenant-scoped. The same `idempotencyKey` may legitimately exist in different tenants without collision.
@@ -158,6 +159,8 @@ npm run audit:rebuild -- /path/to/repo-root
 npm run audit:project -- /path/to/repo-root 100
 ```
 
+Projection-worker processing also evaluates expired SRE monitoring windows through `processExpiredSreMonitoring`, so bounded worker progress materializes any overdue human escalation events.
+
 ### Process queued outbox messages
 ```bash
 npm run audit:outbox -- /path/to/repo-root 100
@@ -195,6 +198,13 @@ Immediate action:
 1. Confirm whether the disable is intentional.
 2. Re-enable `FF_AUDIT_FOUNDATION` when safe.
 3. Replay queues if lag accumulated while disabled.
+
+### SRE monitoring window expired without escalation
+Symptom: a task remains in `SRE_MONITORING` past its deadline with no human escalation.
+Immediate action:
+1. Confirm the projection worker is running or invoke bounded worker processing locally.
+2. Verify the task has `sre_monitoring_window_ends_at` set and no `sre_approved_at`.
+3. Re-run projection worker processing; successful processing should append an auditable `task.escalated` event with `reason=sre_monitoring_window_expired`.
 
 ## Observability hooks
 Structured log fields emitted in this slice:

--- a/docs/runbooks/task-assignment.md
+++ b/docs/runbooks/task-assignment.md
@@ -17,6 +17,7 @@ Allows an authorized Product Manager to assign or reassign an AI agent as the ow
 - Only callers with `assignment:write` (PM/admin in the current role map) can mutate owner state through `PATCH /tasks/{taskId}/assignment`.
 - Restricted telemetry behavior is separate: lower-privilege readers still get owner metadata, while `GET /tasks/{taskId}/observability-summary` omits privileged telemetry fields server-side.
 - Tier-specific projected assignee ids such as `engineer-jr`, `engineer-sr`, and `engineer-principal` are valid owner values and should still be treated as canonical engineer ownership for delivery routing.
+- The SRE monitoring inbox is a separate workflow surface: tasks may appear in `/inbox/sre` by workflow stage even when `current_owner` still points at an engineer.
 
 ## Responsible escalation and current-owner enforcement
 - Delivery-loop actions reserved for engineers now validate the task's current canonical assignee before mutating state.

--- a/docs/runbooks/workflow-delivery-loop.md
+++ b/docs/runbooks/workflow-delivery-loop.md
@@ -172,3 +172,26 @@ Failing QA runs generate a packaged engineer-facing artifact containing:
 
 - Inactivity reassignment can create a dedicated governance review task typed as `governance_review`.
 - Governance review tasks are operational follow-up artifacts, not standard delivery work, and should be shown on a dedicated governance review surface rather than in normal delivery queues.
+
+## SRE monitoring workflow
+
+### Monitoring start requirements
+
+- A passing QA result routes work into `SRE_MONITORING`.
+- SRE or admin starts the monitoring window through the dedicated SRE monitoring route, not via assignment controls.
+- Start requires durable deployment confirmation fields:
+  - deployment environment
+  - deployment URL
+  - deployment version
+- The task-list projection exposes enough monitoring preview data for `/inbox/sre` to render countdown, deployment, PR, commit, and telemetry drilldowns without client fan-out.
+
+### Routing precedence
+
+- Active `SRE_MONITORING` work routes to the SRE inbox by stage, even when the assigned owner remains an engineer.
+- Explicit human waiting-state or stakeholder escalation routing takes precedence so expired monitoring work leaves the SRE inbox and appears in the human inbox.
+
+### Expiry handling
+
+- Expired windows are materialized by worker processing rather than task reads.
+- The worker appends an auditable `task.escalated` event with `reason=sre_monitoring_window_expired`.
+- Resulting state should carry `waiting_state=awaiting_human_stakeholder_escalation` and a human-focused next action.

--- a/lib/audit/core.js
+++ b/lib/audit/core.js
@@ -153,6 +153,10 @@ function summarizeEvent(event) {
       return `Rollback recorded${payload.reason ? `: ${payload.reason}` : ''}`;
     case 'task.ghosting_review_created':
       return `Inactivity review created: ${payload.review_task_id || 'review task'}`;
+    case 'task.sre_monitoring_started':
+      return `SRE monitoring started${payload.deployment_environment ? ` for ${payload.deployment_environment}` : ''}`;
+    case 'task.sre_approval_recorded':
+      return `SRE approved early${payload.reason ? `: ${payload.reason}` : ''}`;
     case 'task.closed':
       return 'Task closed';
     case 'task.github_pr_synced':
@@ -194,6 +198,12 @@ function buildCurrentState(previous = {}, event) {
     latest_qa_retest_scope: previous.latest_qa_retest_scope || [],
     latest_qa_submission_version: previous.latest_qa_submission_version || 0,
     latest_qa_routed_stage: previous.latest_qa_routed_stage || null,
+    sre_monitoring_started_at: previous.sre_monitoring_started_at || null,
+    sre_monitoring_started_by: previous.sre_monitoring_started_by || null,
+    sre_monitoring_window_ends_at: previous.sre_monitoring_window_ends_at || null,
+    sre_approved_at: previous.sre_approved_at || null,
+    sre_approved_by: previous.sre_approved_by || null,
+    sre_expiry_escalated_at: previous.sre_expiry_escalated_at || null,
     blocked: previous.blocked || false,
     closed: previous.closed || false,
     waiting_state: previous.waiting_state || null,
@@ -286,6 +296,10 @@ function buildCurrentState(previous = {}, event) {
       next.blocked = false;
       break;
     case 'task.escalated':
+      if (event.payload.reason === 'sre_monitoring_window_expired') {
+        next.sre_expiry_escalated_at = event.occurred_at;
+      }
+    // fall through
     case 'task.decision_recorded':
     case 'task.decision_revised':
     case 'task.skill_escalation_requested':
@@ -320,6 +334,24 @@ function buildCurrentState(previous = {}, event) {
       next.next_required_action = event.payload.outcome === 'fail'
         ? 'Address QA findings and resubmit implementation metadata.'
         : 'SRE monitoring handoff is ready.';
+      next.queue_entered_at = event.occurred_at;
+      break;
+    case 'task.sre_monitoring_started':
+      next.sre_monitoring_started_at = event.occurred_at;
+      next.sre_monitoring_started_by = event.actor_id || null;
+      next.sre_monitoring_window_ends_at = event.payload.window_ends_at || null;
+      next.sre_approved_at = null;
+      next.sre_approved_by = null;
+      next.sre_expiry_escalated_at = null;
+      next.waiting_state = event.payload.waiting_state || null;
+      next.next_required_action = event.payload.next_required_action || next.next_required_action;
+      next.queue_entered_at = event.occurred_at;
+      break;
+    case 'task.sre_approval_recorded':
+      next.sre_approved_at = event.occurred_at;
+      next.sre_approved_by = event.actor_id || null;
+      next.waiting_state = event.payload.waiting_state || null;
+      next.next_required_action = event.payload.next_required_action || next.next_required_action;
       next.queue_entered_at = event.occurred_at;
       break;
     case 'task.closed':

--- a/lib/audit/event-types.js
+++ b/lib/audit/event-types.js
@@ -33,6 +33,8 @@ const WORKFLOW_AUDIT_EVENT_TYPES = Object.freeze([
   'task.review_question_reopened',
   'task.rollback_recorded',
   'task.ghosting_review_created',
+  'task.sre_monitoring_started',
+  'task.sre_approval_recorded',
   'task.github_pr_synced',
   'task.github_pr_comment_recorded',
   'task.closed'

--- a/lib/audit/feature-flags.js
+++ b/lib/audit/feature-flags.js
@@ -175,6 +175,26 @@ function assertQaContextRoutingEnabled(options = {}) {
   }
 }
 
+function isSreMonitoringEnabled(options = {}) {
+  if (typeof options.sreMonitoringEnabled === 'boolean') return options.sreMonitoringEnabled;
+  const raw = options.ffSreMonitoring
+    ?? options.ff_sre_monitoring
+    ?? options['ff-sre-monitoring']
+    ?? process.env.FF_SRE_MONITORING;
+  if (raw === undefined || raw === null || raw === '') return true;
+  return !['0', 'false', 'off', 'disabled', 'no'].includes(String(raw).trim().toLowerCase());
+}
+
+function assertSreMonitoringEnabled(options = {}) {
+  if (!isSreMonitoringEnabled(options)) {
+    const error = new Error('SRE monitoring is disabled by ff_sre_monitoring');
+    error.code = 'feature_disabled';
+    error.statusCode = 503;
+    error.details = { feature: 'ff_sre_monitoring' };
+    throw error;
+  }
+}
+
 function isReassignmentGhostingEnabled(options = {}) {
   if (typeof options.reassignmentGhostingEnabled === 'boolean') return options.reassignmentGhostingEnabled;
   const raw = options.ffReassignmentGhosting ?? process.env.FF_REASSIGNMENT_GHOSTING;
@@ -259,6 +279,8 @@ module.exports = {
   assertQaStageEnabled,
   isQaContextRoutingEnabled,
   assertQaContextRoutingEnabled,
+  isSreMonitoringEnabled,
+  assertSreMonitoringEnabled,
   isReassignmentGhostingEnabled,
   assertReassignmentGhostingEnabled,
   isSpecialistDelegationEnabled,

--- a/lib/audit/http.js
+++ b/lib/audit/http.js
@@ -21,6 +21,7 @@ const {
   assertStructuredCommentsEnabled,
   assertQaStageEnabled,
   assertQaContextRoutingEnabled,
+  assertSreMonitoringEnabled,
   assertReassignmentGhostingEnabled,
 } = require('./feature-flags');
 const { isWorkflowAuditEventType } = require('./event-types');
@@ -44,6 +45,8 @@ const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 const GITHUB_PR_URL_PATTERN = /^https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+(?:\/?\S*)?$/i;
 const BROWSER_SESSION_TTL_SECONDS = 60 * 60;
 const GITHUB_SYNC_STALE_MS = 5 * 60 * 1000;
+const SRE_MONITORING_WINDOW_HOURS = 48;
+const SRE_MONITORING_WINDOW_MS = SRE_MONITORING_WINDOW_HOURS * 60 * 60 * 1000;
 
 function parseJson(req) {
   return new Promise((resolve, reject) => {
@@ -1022,6 +1025,202 @@ function validateArchitectHandoffBody(body = {}) {
   };
 }
 
+function canManageSreMonitoring(context) {
+  return hasAnyRole(context, ['sre', 'admin']);
+}
+
+function validateSreMonitoringStartBody(body = {}) {
+  const deploymentEnvironment = String(body.deploymentEnvironment || '').trim();
+  const deploymentUrl = String(body.deploymentUrl || '').trim();
+  const deploymentVersion = String(body.deploymentVersion || '').trim();
+  const deploymentStatus = String(body.deploymentStatus || 'success').trim().toLowerCase();
+  const evidence = normalizeMultilineList(body.evidence);
+
+  const missingFields = [];
+  if (!deploymentEnvironment) missingFields.push('deploymentEnvironment');
+  if (!deploymentUrl) missingFields.push('deploymentUrl');
+  if (!deploymentVersion) missingFields.push('deploymentVersion');
+  if (missingFields.length) {
+    throw createHttpError(400, 'missing_required_sre_monitoring_fields', 'Starting SRE monitoring requires deployment environment, deployment URL, and deployment version.', { missing_fields: missingFields });
+  }
+  if (!['success', 'healthy', 'stable'].includes(deploymentStatus)) {
+    throw createHttpError(400, 'invalid_deployment_status', 'Deployment status must confirm a successful or stable deploy.');
+  }
+
+  return {
+    deployment_environment: deploymentEnvironment,
+    deployment_url: deploymentUrl,
+    deployment_version: deploymentVersion,
+    deployment_status: deploymentStatus,
+    evidence,
+  };
+}
+
+function validateSreApprovalBody(body = {}) {
+  const reason = String(body.reason || '').trim();
+  const evidence = normalizeMultilineList(body.evidence);
+  if (!reason) {
+    throw createHttpError(400, 'missing_sre_approval_reason', 'SRE approval requires an explicit reason.');
+  }
+  return { reason, evidence };
+}
+
+function findLatestSreMonitoringStart(history = []) {
+  return history.find((event) => event?.event_type === 'task.sre_monitoring_started') || null;
+}
+
+function findLatestSreApproval(history = []) {
+  return history.find((event) => event?.event_type === 'task.sre_approval_recorded') || null;
+}
+
+function findLatestSreExpiryEscalation(history = []) {
+  return history.find((event) => event?.event_type === 'task.escalated' && event?.payload?.reason === 'sre_monitoring_window_expired') || null;
+}
+
+function formatDurationFromNow(targetIso) {
+  if (!targetIso) return 'Not started';
+  const diffMs = Date.parse(targetIso) - Date.now();
+  const absMs = Math.abs(diffMs);
+  const hours = Math.floor(absMs / (60 * 60 * 1000));
+  const minutes = Math.floor((absMs % (60 * 60 * 1000)) / (60 * 1000));
+  const label = `${hours}h ${minutes}m`;
+  return diffMs < 0 ? `${label} overdue` : label;
+}
+
+function buildTelemetryDrilldowns(telemetry = {}, architectHandoff = null) {
+  const links = Array.isArray(telemetry?.links) ? telemetry.links : [];
+  const dashboardUrls = Array.isArray(architectHandoff?.monitoringSpec?.dashboardUrls)
+    ? architectHandoff.monitoringSpec.dashboardUrls
+    : [];
+  const alertPolicies = Array.isArray(architectHandoff?.monitoringSpec?.alertPolicies)
+    ? architectHandoff.monitoringSpec.alertPolicies
+    : [];
+  const metricsLink = links.find((entry) => /metric/i.test(entry?.label || entry?.type || ''))?.url || dashboardUrls[0] || null;
+  const logsLink = links.find((entry) => /log/i.test(entry?.label || entry?.type || ''))?.url || null;
+  const tracesLink = links.find((entry) => /trace/i.test(entry?.label || entry?.type || ''))?.url || null;
+  return {
+    metrics: metricsLink,
+    logs: logsLink,
+    traces: tracesLink,
+    dashboards: dashboardUrls,
+    alertPolicies,
+    runbook: architectHandoff?.monitoringSpec?.runbook || null,
+  };
+}
+
+function buildSreEvidenceSnapshot({ telemetry = {}, linkedPrs = [], engineerSubmission = null, startPayload = null }) {
+  return {
+    deployment: startPayload ? {
+      environment: startPayload.deployment_environment || null,
+      url: startPayload.deployment_url || null,
+      version: startPayload.deployment_version || null,
+      status: startPayload.deployment_status || null,
+    } : null,
+    telemetry: {
+      freshness: telemetry?.freshness?.status || 'unknown',
+      degraded: Boolean(telemetry?.degraded),
+      eventCount: Number(telemetry?.event_count || 0),
+      keySignals: telemetry?.key_signals || {},
+    },
+    engineerSubmission: engineerSubmission ? {
+      version: engineerSubmission.version || null,
+      commitSha: engineerSubmission.commitSha || null,
+      prUrl: engineerSubmission.prUrl || null,
+      primaryReference: engineerSubmission.primaryReference || null,
+    } : null,
+    linkedPullRequests: linkedPrs.map((pr) => ({
+      number: pr.number,
+      title: pr.title,
+      repository: pr.repository,
+      merged: pr.merged,
+      updatedAt: pr.updatedAt,
+      url: pr.url,
+    })),
+  };
+}
+
+function deriveSreMonitoringProjection({
+  taskId,
+  summary,
+  history = [],
+  relationships = {},
+  telemetry = null,
+}) {
+  const architectHandoff = architectHandoffFromEvent(findLatestArchitectHandoff(history));
+  const engineerSubmission = engineerSubmissionFromEvent(findLatestEngineerSubmission(history));
+  const linkedPrs = collectLinkedPrs(history, relationships, taskId);
+  const startEvent = findLatestSreMonitoringStart(history);
+  const approvalEvent = findLatestSreApproval(history);
+  const expiryEvent = findLatestSreExpiryEscalation(history);
+  const startPayload = startEvent?.payload || null;
+  const windowStartedAt = startEvent?.occurred_at || null;
+  const windowEndsAt = startPayload?.window_ends_at || (windowStartedAt ? new Date(Date.parse(windowStartedAt) + SRE_MONITORING_WINDOW_MS).toISOString() : null);
+  const mergedPrs = linkedPrs.filter((pr) => pr.merged);
+  const timeRemainingMs = windowEndsAt ? Date.parse(windowEndsAt) - Date.now() : null;
+  const expired = Number.isFinite(timeRemainingMs) ? timeRemainingMs <= 0 : false;
+  const drilldowns = buildTelemetryDrilldowns(telemetry, architectHandoff);
+  const telemetryFresh = telemetry?.freshness?.status === 'fresh' && !telemetry?.degraded;
+  const canStart = summary?.current_stage === STAGES.SRE_MONITORING && !startEvent && mergedPrs.length > 0;
+  const canApprove = summary?.current_stage === STAGES.SRE_MONITORING && Boolean(startEvent) && !approvalEvent && !expiryEvent && telemetryFresh;
+  const riskLevel = expiryEvent || expired || telemetry?.degraded
+    ? 'high'
+    : timeRemainingMs != null && timeRemainingMs <= 12 * 60 * 60 * 1000
+      ? 'medium'
+      : 'low';
+
+  return {
+    active: summary?.current_stage === STAGES.SRE_MONITORING || Boolean(startEvent) || Boolean(approvalEvent) || Boolean(expiryEvent),
+    state: approvalEvent ? 'approved' : expiryEvent ? 'escalated' : startEvent ? (expired ? 'expired' : 'active') : 'pending_start',
+    canStart,
+    canApprove,
+    windowHours: SRE_MONITORING_WINDOW_HOURS,
+    windowStartedAt,
+    windowEndsAt,
+    timeRemainingMs: timeRemainingMs != null ? Math.max(0, timeRemainingMs) : null,
+    timeRemainingLabel: formatDurationFromNow(windowEndsAt),
+    expired,
+    riskLevel,
+    approval: approvalEvent ? {
+      approvedAt: approvalEvent.occurred_at,
+      approvedBy: approvalEvent.actor_id || null,
+      reason: approvalEvent.payload?.reason || null,
+      evidence: approvalEvent.payload?.evidence || [],
+      snapshot: approvalEvent.payload?.evidence_snapshot || null,
+    } : null,
+    escalation: expiryEvent ? {
+      escalatedAt: expiryEvent.occurred_at,
+      severity: expiryEvent.payload?.severity || 'warning',
+      reason: expiryEvent.payload?.reason || null,
+    } : null,
+    deployment: startPayload ? {
+      environment: startPayload.deployment_environment || null,
+      url: startPayload.deployment_url || null,
+      version: startPayload.deployment_version || null,
+      status: startPayload.deployment_status || null,
+      evidence: startPayload.evidence || [],
+      startedBy: startEvent.actor_id || null,
+    } : null,
+    linkedPrs,
+    commitSha: engineerSubmission?.commitSha || null,
+    prUrl: engineerSubmission?.prUrl || null,
+    engineerSubmission,
+    telemetry: telemetry ? {
+      freshness: telemetry.freshness?.status || 'unknown',
+      degraded: Boolean(telemetry.degraded),
+      eventCount: Number(telemetry.event_count || 0),
+      keySignals: telemetry.key_signals || {},
+      drilldowns,
+    } : {
+      freshness: 'unknown',
+      degraded: false,
+      eventCount: 0,
+      keySignals: {},
+      drilldowns,
+    },
+    architectMonitoringSpec: architectHandoff?.monitoringSpec || null,
+  };
+}
+
 function summarizeTaskForDetail(taskId, state, history = []) {
   const createdEvent = history.find(event => event.event_type === 'task.created');
   const newestEvent = history[0] || null;
@@ -1070,6 +1269,9 @@ function summarizeTaskForDetail(taskId, state, history = []) {
     acceptance_criteria: createdEvent?.payload?.acceptance_criteria || null,
     definition_of_done: createdEvent?.payload?.definition_of_done || null,
     task_type: createdEvent?.payload?.task_type || null,
+    queue_entered_at: state.queue_entered_at || null,
+    wip_owner: state.wip_owner || null,
+    wip_started_at: state.wip_started_at || null,
     lock: getActiveTaskLock(state),
     latest_qa_outcome: state.latest_qa_outcome || null,
   };
@@ -1150,6 +1352,7 @@ function buildTaskDetailViewModel({
   const implementationHistory = deriveImplementationHistory(history);
   const engineerSubmission = engineerSubmissionFromEvent(findLatestEngineerSubmission(history));
   const qaResults = deriveQaResults(history);
+  const sreMonitoring = deriveSreMonitoringProjection({ taskId, summary, history, relationships, telemetry });
   const skillEscalation = toSkillEscalationSummary(findLatestSkillEscalation(history));
   const latestRetier = toRetierSummary(findLatestRetierEvent(history));
   const latestReassignment = toReassignmentSummary(findLatestReassignmentEvent(history));
@@ -1233,6 +1436,7 @@ function buildTaskDetailViewModel({
         queueAgeLabel: queueStartedAt ? formatDurationFromMs(Math.max(0, Date.now() - Date.parse(queueStartedAt))) : 'Not started',
         lastUpdatedAt: summary.freshness?.last_updated_at || null,
         freshness: summary.freshness?.status || 'unknown',
+        sreWindowLabel: sreMonitoring.windowEndsAt ? sreMonitoring.timeRemainingLabel : 'Not started',
       },
       blockedState: {
         isBlocked: status === 'blocked' || workflowThreads.summary.unresolvedBlockingCount > 0,
@@ -1289,6 +1493,7 @@ function buildTaskDetailViewModel({
       engineerSubmission,
       implementationHistory,
       qaResults,
+      sreMonitoring,
       skillEscalation,
       retiering: latestRetier,
       reassignment: latestReassignment,
@@ -1345,6 +1550,7 @@ function buildTaskDetailViewModel({
             availability: telemetry.access?.restricted ? 'restricted' : telemetry.degraded ? 'stale' : telemetry.event_count ? 'available' : 'empty',
             lastUpdatedAt: telemetry.last_updated_at || null,
             summary: telemetry.key_signals || {},
+            links: telemetry.links || [],
             emptyStateReason: telemetry.event_count ? null : 'No telemetry signals are linked to this task yet.',
             access: telemetry.access,
           }
@@ -2045,8 +2251,28 @@ function createAuditApiServer(options = {}) {
           throw createHttpError(501, 'not_supported', 'Task list summaries are not supported by this store');
         }
         const items = await store.listTaskSummaries({ tenantId: context.tenantId });
+        const enrichedItems = await Promise.all(items.map(async (item) => {
+          const [state, relationships, telemetry, initialHistory] = await Promise.all([
+            store.getTaskCurrentState(item.task_id, { tenantId: context.tenantId }),
+            typeof store.getTaskRelationships === 'function' ? store.getTaskRelationships(item.task_id, { tenantId: context.tenantId }) : Promise.resolve({}),
+            typeof store.getTaskObservabilitySummary === 'function' ? store.getTaskObservabilitySummary(item.task_id, { tenantId: context.tenantId }) : Promise.resolve(null),
+            typeof store.getTaskHistory === 'function' ? store.getTaskHistory(item.task_id, { tenantId: context.tenantId, limit: 500 }) : Promise.resolve([]),
+          ]);
+          const finalSummary = summarizeTaskForDetail(item.task_id, state || item, initialHistory);
+          const monitoring = deriveSreMonitoringProjection({
+            taskId: item.task_id,
+            summary: finalSummary,
+            history: initialHistory,
+            relationships,
+            telemetry,
+          });
+          return {
+            ...summarizeTaskForList(finalSummary),
+            monitoring,
+          };
+        }));
         logger.info({ feature: 'ff_audit_foundation', action: 'audit_access', outcome: 'success', request_id: requestId, method: req.method, path: url.pathname, tenant_id: context.tenantId, actor_id: context.actorId, resource: 'task_list', result_count: items.length, duration_ms: Date.now() - startedAt });
-        return sendJson(res, 200, { items: items.map(summarizeTaskForList) }, requestId);
+        return sendJson(res, 200, { items: enrichedItems }, requestId);
       }
 
       const summaryMatch = routePath.match(/^\/tasks\/([^/]+)$/);
@@ -2056,6 +2282,7 @@ function createAuditApiServer(options = {}) {
       const checkInsMatch = routePath.match(/^\/tasks\/([^/]+)\/check-ins$/);
       const retierMatch = routePath.match(/^\/tasks\/([^/]+)\/retier$/);
       const reassignmentMatch = routePath.match(/^\/tasks\/([^/]+)\/reassignment$/);
+      const sreMonitoringMatch = routePath.match(/^\/tasks\/([^/]+)\/sre-monitoring\/(start|approve)$/);
       const architectHandoffMatch = routePath.match(/^\/tasks\/([^/]+)\/architect-handoff$/);
       const engineerSubmissionMatch = routePath.match(/^\/tasks\/([^/]+)\/engineer-submission$/);
       const workflowThreadsMatch = routePath.match(/^\/tasks\/([^/]+)\/workflow-threads$/);
@@ -2064,8 +2291,8 @@ function createAuditApiServer(options = {}) {
       const reviewQuestionsMatch = routePath.match(/^\/tasks\/([^/]+)\/review-questions$/);
       const reviewQuestionActionMatch = routePath.match(/^\/tasks\/([^/]+)\/review-questions\/([^/]+)\/(answers|resolve|reopen)$/);
       const resourceMatch = routePath.match(/^\/tasks\/([^/]+)\/(detail|events|history|state|relationships|observability-summary)$/);
-      if (!summaryMatch && !resourceMatch && !assignmentMatch && !lockMatch && !skillEscalationMatch && !checkInsMatch && !retierMatch && !reassignmentMatch && !architectHandoffMatch && !engineerSubmissionMatch && !workflowThreadsMatch && !workflowThreadActionMatch && !qaResultsMatch && !reviewQuestionsMatch && !reviewQuestionActionMatch) throw createHttpError(404, 'not_found', 'Route not found');
-      const taskId = (summaryMatch || resourceMatch || assignmentMatch || lockMatch || skillEscalationMatch || checkInsMatch || retierMatch || reassignmentMatch || architectHandoffMatch || engineerSubmissionMatch || workflowThreadsMatch || workflowThreadActionMatch || qaResultsMatch || reviewQuestionsMatch || reviewQuestionActionMatch)[1];
+      if (!summaryMatch && !resourceMatch && !assignmentMatch && !lockMatch && !skillEscalationMatch && !checkInsMatch && !retierMatch && !reassignmentMatch && !sreMonitoringMatch && !architectHandoffMatch && !engineerSubmissionMatch && !workflowThreadsMatch && !workflowThreadActionMatch && !qaResultsMatch && !reviewQuestionsMatch && !reviewQuestionActionMatch) throw createHttpError(404, 'not_found', 'Route not found');
+      const taskId = (summaryMatch || resourceMatch || assignmentMatch || lockMatch || skillEscalationMatch || checkInsMatch || retierMatch || reassignmentMatch || sreMonitoringMatch || architectHandoffMatch || engineerSubmissionMatch || workflowThreadsMatch || workflowThreadActionMatch || qaResultsMatch || reviewQuestionsMatch || reviewQuestionActionMatch)[1];
       const resource = assignmentMatch
         ? 'assignment'
         : lockMatch
@@ -2078,8 +2305,10 @@ function createAuditApiServer(options = {}) {
           ? 'retier'
         : reassignmentMatch
           ? 'reassignment'
-        : architectHandoffMatch
-          ? 'architect-handoff'
+          : sreMonitoringMatch
+            ? `sre-monitoring:${sreMonitoringMatch[2]}`
+          : architectHandoffMatch
+            ? 'architect-handoff'
         : engineerSubmissionMatch
           ? 'engineer-submission'
         : workflowThreadsMatch
@@ -2412,6 +2641,148 @@ function createAuditApiServer(options = {}) {
           },
         }, requestId);
       }
+      if (resource === 'sre-monitoring:start' && req.method === 'POST') {
+        assertSreMonitoringEnabled(runtimeOptions);
+        if (!canManageSreMonitoring(context)) throw createHttpError(403, 'forbidden', 'Only SRE/admin may start the monitoring window.');
+        await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, options: runtimeOptions });
+        const body = validateSreMonitoringStartBody(await parseJson(req));
+        const [state, history, relationships, telemetry] = await Promise.all([
+          store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
+          store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 500 }),
+          typeof store.getTaskRelationships === 'function' ? store.getTaskRelationships(taskId, { tenantId: context.tenantId }) : Promise.resolve({}),
+          typeof store.getTaskObservabilitySummary === 'function' ? store.getTaskObservabilitySummary(taskId, { tenantId: context.tenantId }) : Promise.resolve(null),
+        ]);
+        if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        if (state.current_stage !== STAGES.SRE_MONITORING) {
+          throw createHttpError(409, 'invalid_stage', 'SRE monitoring can only start while the task is in SRE monitoring.', { current_stage: state.current_stage });
+        }
+        const summary = summarizeTaskForDetail(taskId, state, history);
+        const monitoring = deriveSreMonitoringProjection({ taskId, summary, history, relationships, telemetry });
+        if (monitoring.windowStartedAt) {
+          throw createHttpError(409, 'sre_monitoring_already_started', 'SRE monitoring has already started for this task.', { started_at: monitoring.windowStartedAt });
+        }
+        if (!monitoring.linkedPrs.some((pr) => pr.merged)) {
+          throw createHttpError(409, 'merged_pr_required', 'SRE monitoring requires at least one merged linked pull request before the monitoring window can start.');
+        }
+
+        const windowEndsAt = new Date(Date.now() + SRE_MONITORING_WINDOW_MS).toISOString();
+        const result = await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.sre_monitoring_started',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `sre-monitoring-start:${taskId}:${windowEndsAt}`,
+          payload: {
+            ...body,
+            window_hours: SRE_MONITORING_WINDOW_HOURS,
+            window_ends_at: windowEndsAt,
+            waiting_state: null,
+            next_required_action: 'Observe production telemetry and approve early only if the rollout is stable.',
+            evidence_snapshot: buildSreEvidenceSnapshot({
+              telemetry,
+              linkedPrs: monitoring.linkedPrs,
+              engineerSubmission: monitoring.engineerSubmission,
+              startPayload: body,
+            }),
+          },
+          source: 'http',
+        });
+
+        return sendJson(res, 201, {
+          success: true,
+          data: {
+            taskId,
+            windowStartedAt: result.event.occurred_at,
+            windowEndsAt,
+            deploymentEnvironment: body.deployment_environment,
+            deploymentUrl: body.deployment_url,
+            deploymentVersion: body.deployment_version,
+          },
+        }, requestId);
+      }
+      if (resource === 'sre-monitoring:approve' && req.method === 'POST') {
+        assertSreMonitoringEnabled(runtimeOptions);
+        if (!canManageSreMonitoring(context)) throw createHttpError(403, 'forbidden', 'Only SRE/admin may approve SRE monitoring.');
+        await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, options: runtimeOptions });
+        const body = validateSreApprovalBody(await parseJson(req));
+        const [state, history, relationships, telemetry] = await Promise.all([
+          store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
+          store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 500 }),
+          typeof store.getTaskRelationships === 'function' ? store.getTaskRelationships(taskId, { tenantId: context.tenantId }) : Promise.resolve({}),
+          typeof store.getTaskObservabilitySummary === 'function' ? store.getTaskObservabilitySummary(taskId, { tenantId: context.tenantId }) : Promise.resolve(null),
+        ]);
+        if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        if (state.current_stage !== STAGES.SRE_MONITORING) {
+          throw createHttpError(409, 'invalid_stage', 'SRE approval can only happen while the task is in SRE monitoring.', { current_stage: state.current_stage });
+        }
+        const summary = summarizeTaskForDetail(taskId, state, history);
+        const monitoring = deriveSreMonitoringProjection({ taskId, summary, history, relationships, telemetry });
+        if (!monitoring.windowStartedAt) {
+          throw createHttpError(409, 'sre_monitoring_not_started', 'SRE monitoring must be started before early approval is available.');
+        }
+        if (monitoring.expired || monitoring.escalation) {
+          throw createHttpError(409, 'sre_monitoring_window_expired', 'The SRE monitoring window has already expired and escalated.');
+        }
+        if (monitoring.approval) {
+          throw createHttpError(409, 'sre_monitoring_already_approved', 'This task already has an SRE approval.');
+        }
+        if (telemetry?.degraded || telemetry?.freshness?.status !== 'fresh') {
+          throw createHttpError(409, 'telemetry_not_stable', 'Early approval requires fresh, stable telemetry.');
+        }
+
+        const approval = await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.sre_approval_recorded',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `sre-monitoring-approve:${taskId}:${state.last_event_id || 'initial'}`,
+          payload: {
+            reason: body.reason,
+            evidence: body.evidence,
+            evidence_snapshot: buildSreEvidenceSnapshot({
+              telemetry,
+              linkedPrs: monitoring.linkedPrs,
+              engineerSubmission: monitoring.engineerSubmission,
+              startPayload: monitoring.deployment ? {
+                deployment_environment: monitoring.deployment.environment,
+                deployment_url: monitoring.deployment.url,
+                deployment_version: monitoring.deployment.version,
+                deployment_status: monitoring.deployment.status,
+              } : null,
+            }),
+            waiting_state: 'awaiting_human_close_review',
+            next_required_action: 'Human close review is required before final closure.',
+          },
+          source: 'http',
+        });
+        await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.stage_changed',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `sre-monitoring-stage-route:${taskId}:${approval.event.event_id}`,
+          payload: {
+            from_stage: STAGES.SRE_MONITORING,
+            to_stage: STAGES.PM_CLOSE_REVIEW,
+            waiting_state: 'awaiting_human_close_review',
+            next_required_action: 'Human close review is required before final closure.',
+          },
+          source: 'http',
+        });
+
+        return sendJson(res, 201, {
+          success: true,
+          data: {
+            taskId,
+            approvedAt: approval.event.occurred_at,
+            approvedBy: context.actorId,
+            nextStage: STAGES.PM_CLOSE_REVIEW,
+          },
+        }, requestId);
+      }
 
       if (resource === 'review-questions' && req.method === 'GET') {
         requirePermission(context, 'history:read');
@@ -2612,12 +2983,14 @@ function createAuditApiServer(options = {}) {
       }
       if (resource === 'summary' && req.method === 'GET') {
         requirePermission(context, 'state:read');
-        const [state, history] = await Promise.all([
+        const [state, initialHistory, relationships, telemetry] = await Promise.all([
           store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
           store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 25 }),
+          typeof store.getTaskRelationships === 'function' ? store.getTaskRelationships(taskId, { tenantId: context.tenantId }) : Promise.resolve({}),
+          typeof store.getTaskObservabilitySummary === 'function' ? store.getTaskObservabilitySummary(taskId, { tenantId: context.tenantId }) : Promise.resolve(null),
         ]);
         if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
-        const result = summarizeTaskForDetail(taskId, state, history);
+        const result = summarizeTaskForDetail(taskId, state, initialHistory);
         logger.info({ feature: 'ff_audit_foundation', action: 'audit_access', outcome: 'success', request_id: requestId, method: req.method, path: url.pathname, tenant_id: context.tenantId, actor_id: context.actorId, task_id: taskId, resource: 'task_summary', duration_ms: Date.now() - startedAt });
         return sendJson(res, 200, result, requestId);
       }
@@ -2641,7 +3014,7 @@ function createAuditApiServer(options = {}) {
           limit,
           cursor,
         };
-        const [state, history, timelineHistory, relationships, telemetry, taskSummaries] = await Promise.all([
+        const [state, initialHistory, timelineHistory, relationships, telemetry, taskSummaries] = await Promise.all([
           store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
           authorize(context, 'history:read') ? store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 200 }) : Promise.resolve([]),
           authorize(context, 'history:read') ? store.getTaskHistory(taskId, historyFilters) : Promise.resolve([]),
@@ -2650,7 +3023,7 @@ function createAuditApiServer(options = {}) {
           authorize(context, 'relationships:read') ? store.listTaskSummaries({ tenantId: context.tenantId }) : Promise.resolve([]),
         ]);
         if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
-        const summary = summarizeTaskForDetail(taskId, state, history);
+        const summary = summarizeTaskForDetail(taskId, state, initialHistory);
         const childTaskIds = Array.isArray(relationships?.child_task_ids) ? relationships.child_task_ids : [];
         const taskSummaryById = new Map((taskSummaries || []).map((item) => [item.task_id, item]));
         const childTaskSummaries = childTaskIds.map((childTaskId) => taskSummaryById.get(childTaskId) || {
@@ -2665,7 +3038,7 @@ function createAuditApiServer(options = {}) {
           taskId,
           summary,
           relationships: relationships || { child_task_ids: [], escalations: [], decisions: [] },
-          history: history.map(normalizeHistoryItem),
+          history: initialHistory.map(normalizeHistoryItem),
           timelineHistory: timelineHistory.map(normalizeHistoryItem),
           timelinePageInfo: buildPaginatedHistoryResponse(timelineHistory, limit).page_info,
           telemetry: telemetry ? toTelemetryResponse(telemetry, context) : null,

--- a/lib/audit/store.js
+++ b/lib/audit/store.js
@@ -649,6 +649,53 @@ function createAuditStore(options = {}) {
     };
   }
 
+  if (typeof store.processExpiredSreMonitoring !== 'function') {
+    store.processExpiredSreMonitoring = async function(limit = 100) {
+      assertAuditFoundationEnabled(options);
+      const nowMs = Date.now();
+      const items = await Promise.resolve(store.listTaskSummaries({}));
+      const candidates = items
+        .filter((item) => String(item?.current_stage || '').toUpperCase() === STAGES.SRE_MONITORING)
+        .slice(0, Math.max(0, Number(limit) || 0) || undefined);
+
+      let processed = 0;
+      let failed = 0;
+      for (const item of candidates) {
+        try {
+          const state = await Promise.resolve(store.getTaskCurrentState(item.task_id, { tenantId: item.tenant_id }));
+          if (!state) continue;
+          const windowEndsAt = state.sre_monitoring_window_ends_at || null;
+          const expiredAt = windowEndsAt ? Date.parse(windowEndsAt) : NaN;
+          if (!windowEndsAt || !Number.isFinite(expiredAt) || expiredAt > nowMs) continue;
+          if (state.sre_approved_at || state.sre_expiry_escalated_at) continue;
+
+          const result = await Promise.resolve(store.appendEvent({
+            taskId: item.task_id,
+            tenantId: item.tenant_id,
+            eventType: 'task.escalated',
+            actorId: 'system:sre-monitoring-expiry',
+            actorType: 'system',
+            idempotencyKey: `sre-monitoring-expiry:${item.task_id}:${windowEndsAt}`,
+            payload: {
+              severity: 'warning',
+              reason: 'sre_monitoring_window_expired',
+              summary: 'SRE monitoring window expired without approval.',
+              waiting_state: 'awaiting_human_stakeholder_escalation',
+              next_required_action: 'Human stakeholder escalation required after monitoring window expiry.',
+              monitoring_window_started_at: state.sre_monitoring_started_at || null,
+              monitoring_window_ends_at: windowEndsAt,
+            },
+            source: 'system',
+          }));
+          if (!result?.duplicate) processed += 1;
+        } catch (error) {
+          failed += 1;
+        }
+      }
+      return { processed, failed };
+    };
+  }
+
   return store;
 }
 

--- a/lib/audit/workers.js
+++ b/lib/audit/workers.js
@@ -9,7 +9,16 @@ function createProjectionWorker(store, options = {}) {
   return {
     async runOnce() {
       if (!store.processProjectionQueue) throw new Error('store does not support async projection queue processing');
-      return store.processProjectionQueue(batchSize);
+      const result = await store.processProjectionQueue(batchSize);
+      if (typeof store.processExpiredSreMonitoring === 'function') {
+        const expiryResult = await store.processExpiredSreMonitoring(batchSize);
+        return {
+          processed: (result.processed || 0) + (expiryResult.processed || 0),
+          failed: (result.failed || 0) + (expiryResult.failed || 0),
+          expiredProcessed: expiryResult.processed || 0,
+        };
+      }
+      return result;
     },
   };
 }

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -448,6 +448,22 @@ function normalizeQaResultDraft(result = {}) {
   };
 }
 
+function normalizeSreMonitoringStartDraft(monitoring = {}) {
+  return {
+    deploymentEnvironment: monitoring.deployment?.environment || 'production',
+    deploymentUrl: monitoring.deployment?.url || '',
+    deploymentVersion: monitoring.deployment?.version || '',
+    evidence: Array.isArray(monitoring.deployment?.evidence) ? monitoring.deployment.evidence.join('\n') : '',
+  };
+}
+
+function normalizeSreApprovalDraft(monitoring = {}) {
+  return {
+    reason: monitoring.approval?.reason || '',
+    evidence: Array.isArray(monitoring.approval?.evidence) ? monitoring.approval.evidence.join('\n') : '',
+  };
+}
+
 function splitTextareaLines(value) {
   return String(value || '')
     .split(/\n+/)
@@ -535,6 +551,10 @@ function canRequestSkillEscalation(tokenClaims) {
 
 function canManageReassignmentGhosting(tokenClaims) {
   return hasAnyRole(tokenClaims, ['architect', 'admin']);
+}
+
+function canManageSreMonitoring(tokenClaims) {
+  return hasAnyRole(tokenClaims, ['sre', 'admin']);
 }
 
 function canAnswerReviewQuestion(tokenClaims) {
@@ -637,6 +657,10 @@ export function App() {
   const [expandedQaPackages, setExpandedQaPackages] = React.useState({});
   const [qaResultDraft, setQaResultDraft] = React.useState(() => normalizeQaResultDraft());
   const [qaResultStatus, setQaResultStatus] = React.useState({ kind: 'idle', message: '' });
+  const [sreMonitoringStartDraft, setSreMonitoringStartDraft] = React.useState(() => normalizeSreMonitoringStartDraft());
+  const [sreMonitoringStartStatus, setSreMonitoringStartStatus] = React.useState({ kind: 'idle', message: '' });
+  const [sreApprovalDraft, setSreApprovalDraft] = React.useState(() => normalizeSreApprovalDraft());
+  const [sreApprovalStatus, setSreApprovalStatus] = React.useState({ kind: 'idle', message: '' });
   const [lifecycleStatus, setLifecycleStatus] = React.useState({ kind: 'idle', message: '', taskId: null });
   const [sreFindingDraft, setSreFindingDraft] = React.useState('');
   const [dragState, setDragState] = React.useState({ taskId: null, overStage: '' });
@@ -727,6 +751,8 @@ export function App() {
       setExpandedWorkflowThreads({});
       setExpandedQaPackages({});
       setQaResultDraft(normalizeQaResultDraft(model.detail?.context?.qaResults?.latest));
+      setSreMonitoringStartDraft(normalizeSreMonitoringStartDraft(model.detail?.context?.sreMonitoring));
+      setSreApprovalDraft(normalizeSreApprovalDraft(model.detail?.context?.sreMonitoring));
       setSreFindingDraft('');
       setHistoryLoadMoreState({ kind: 'idle', message: '' });
 
@@ -743,6 +769,8 @@ export function App() {
         setTaskLockStatus({ kind: 'idle', message: '' });
         setWorkflowThreadStatus({ kind: 'idle', message: '', threadId: null, action: null });
         setQaResultStatus({ kind: 'idle', message: '' });
+        setSreMonitoringStartStatus({ kind: 'idle', message: '' });
+        setSreApprovalStatus({ kind: 'idle', message: '' });
         setLifecycleStatus({ kind: 'idle', message: '', taskId: null });
       }
     }
@@ -930,6 +958,8 @@ export function App() {
   const canManageWorkflowThreads = model.kind === 'detail' && hasAnyRole(tokenClaims, ['architect', 'engineer', 'qa', 'pm', 'contributor', 'admin']);
   const qaStageEnabled = model.kind === 'detail' && model.detail?.task?.stage === 'QA_TESTING';
   const canSubmitQaResult = qaStageEnabled && hasAnyRole(tokenClaims, ['qa', 'admin', 'contributor']);
+  const sreMonitoring = model.kind === 'detail' ? (model.detail?.context?.sreMonitoring || null) : null;
+  const sreMonitoringEnabled = model.kind === 'detail' && model.detail?.task?.stage === 'SRE_MONITORING' && canManageSreMonitoring(tokenClaims);
   const workflowThreadNotificationTargets = defaultWorkflowNotificationTargets(workflowThreadDraft.commentType, workflowThreadDraft.blocking);
   const latestQaResult = model.kind === 'detail' ? (model.detail?.context?.qaResults?.latest || null) : null;
   const latestFailedQa = model.kind === 'detail' ? (model.detail?.context?.qaResults?.items || []).find((item) => item.outcome === 'fail') || null : null;
@@ -1173,6 +1203,40 @@ export function App() {
     }
   }, [qaResultDraft, reloadTask, routeTaskId, taskClient]);
 
+  const submitSreMonitoringStart = React.useCallback(async (event) => {
+    event.preventDefault();
+    if (!routeTaskId) return;
+    setSreMonitoringStartStatus({ kind: 'loading', message: 'Starting monitoring window…' });
+    try {
+      await taskClient.startSreMonitoring(routeTaskId, {
+        deploymentEnvironment: sreMonitoringStartDraft.deploymentEnvironment,
+        deploymentUrl: sreMonitoringStartDraft.deploymentUrl,
+        deploymentVersion: sreMonitoringStartDraft.deploymentVersion,
+        evidence: splitTextareaLines(sreMonitoringStartDraft.evidence),
+      });
+      await reloadTask();
+      setSreMonitoringStartStatus({ kind: 'success', message: 'SRE monitoring window started.' });
+    } catch (error) {
+      setSreMonitoringStartStatus({ kind: 'error', message: error?.message || 'SRE monitoring could not be started.' });
+    }
+  }, [reloadTask, routeTaskId, sreMonitoringStartDraft, taskClient]);
+
+  const submitSreApproval = React.useCallback(async (event) => {
+    event.preventDefault();
+    if (!routeTaskId) return;
+    setSreApprovalStatus({ kind: 'loading', message: 'Recording early approval…' });
+    try {
+      await taskClient.approveSreMonitoring(routeTaskId, {
+        reason: sreApprovalDraft.reason,
+        evidence: splitTextareaLines(sreApprovalDraft.evidence),
+      });
+      await reloadTask();
+      setSreApprovalStatus({ kind: 'success', message: 'SRE early approval recorded.' });
+    } catch (error) {
+      setSreApprovalStatus({ kind: 'error', message: error?.message || 'SRE approval failed.' });
+    }
+  }, [reloadTask, routeTaskId, sreApprovalDraft, taskClient]);
+
   const handleSignIn = React.useCallback(async (event) => {
     event.preventDefault();
     const apiBaseUrl = String(signInDraft.apiBaseUrl || '').trim().replace(/\/+$/, '');
@@ -1341,15 +1405,17 @@ export function App() {
           <p className="eyebrow">Authenticated browser shell for US-002</p>
           <h1>{model.kind === 'list' ? (isPmOverview ? 'PM Overview' : isGovernanceOverview ? 'Governance Reviews' : activeInboxRole ? `${getRoleInboxLabel(activeInboxRole)} Inbox` : 'Task list') : model.detail?.task?.title || model.summary.title || 'Task detail'}</h1>
           <p className="lede">
-            {model.kind === 'list'
-              ? isPmOverview
-                ? 'Read-only grouped overview showing routed, unassigned, and attention-needed work from the canonical owner-role mapping.'
-                : isGovernanceOverview
-                  ? 'Dedicated operational surface for inactivity and governance review tasks that should stay out of delivery queues.'
-                : activeInboxRole
-                  ? `Read-only inbox surface showing tasks routed here because the current assigned owner maps to the ${getRoleInboxLabel(activeInboxRole)} role.`
-                  : 'Overview list wired to the projected owner read model with single-select owner filtering.'
-              : 'Route-mounted task detail screen using the existing adapter and page module contract.'}
+	            {model.kind === 'list'
+	              ? isPmOverview
+	                ? 'Read-only grouped overview showing routed, unassigned, and attention-needed work from the canonical owner-role mapping.'
+	                : isGovernanceOverview
+	                  ? 'Dedicated operational surface for inactivity and governance review tasks that should stay out of delivery queues.'
+	                : activeInboxRole
+	                  ? activeInboxRole === 'sre'
+	                    ? 'Read-only monitoring inbox showing tasks routed here because they are in the SRE monitoring stage or explicitly assigned to SRE-owned work.'
+	                    : `Read-only inbox surface showing tasks routed here because the current assigned owner maps to the ${getRoleInboxLabel(activeInboxRole)} role.`
+	                  : 'Overview list wired to the projected owner read model with single-select owner filtering.'
+	              : 'Route-mounted task detail screen using the existing adapter and page module contract.'}
           </p>
         </div>
 
@@ -1446,13 +1512,17 @@ export function App() {
                   <button type="button" onClick={() => void reloadTask()}>Refresh</button>
                 </div>
               </div>
-            ) : activeInboxRole ? (
-              <div className="role-inbox-toolbar">
-                <div>
-                  <p className="eyebrow">Role inbox</p>
-                  <h2>{getRoleInboxLabel(activeInboxRole)} inbox routing</h2>
-                  <p className="role-inbox-toolbar__cue">Tasks appear here only when their current assigned owner resolves to the {getRoleInboxLabel(activeInboxRole)} canonical role. Unassigned tasks appear in no role inbox.</p>
-                </div>
+	            ) : activeInboxRole ? (
+	              <div className="role-inbox-toolbar">
+	                <div>
+	                  <p className="eyebrow">Role inbox</p>
+	                  <h2>{getRoleInboxLabel(activeInboxRole)} inbox routing</h2>
+	                  <p className="role-inbox-toolbar__cue">
+	                    {activeInboxRole === 'sre'
+	                      ? 'Tasks appear here when they are actively in the SRE monitoring stage or when routing metadata explicitly points to SRE ownership.'
+	                      : `Tasks appear here only when their current assigned owner resolves to the ${getRoleInboxLabel(activeInboxRole)} canonical role. Unassigned tasks appear in no role inbox.`}
+	                  </p>
+	                </div>
                 <div className="task-list-toolbar__actions">
                   <button type="button" className="button-secondary" onClick={() => navigate('/tasks')}>Open full task list</button>
                   <button type="button" onClick={() => void reloadTask()}>Refresh</button>
@@ -1591,7 +1661,69 @@ export function App() {
             </div>
           ) : null}
 
-          {roleInboxState.kind === 'ready' && activeInboxRole && roleInboxItems.length ? (
+          {roleInboxState.kind === 'ready' && activeInboxRole === 'sre' && roleInboxItems.length ? (
+            <div className="task-list-table-wrap">
+              <table className="task-list-table" aria-label="SRE monitoring dashboard">
+                <thead>
+                  <tr>
+                    <th scope="col">Task</th>
+                    <th scope="col">Risk</th>
+                    <th scope="col">Time remaining</th>
+                    <th scope="col">Deployment</th>
+                    <th scope="col">PR / Commit</th>
+                    <th scope="col">Telemetry</th>
+                    <th scope="col">Drilldowns</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {roleInboxItems.map((item) => (
+                    <tr key={item.task_id}>
+                      <td>
+                        <a href={`/tasks/${encodeURIComponent(item.task_id)}`} onClick={(event) => { event.preventDefault(); navigate(`/tasks/${encodeURIComponent(item.task_id)}`); }}>
+                          <strong>{item.title || item.task_id}</strong>
+                        </a>
+                        <div className="task-list-meta">{item.task_id} · {item.current_stage || '—'}</div>
+                      </td>
+                      <td>
+                        <span className="routing-badge">{String(item.monitoring?.riskLevel || 'unknown').toUpperCase()}</span>
+                        <div className="task-list-meta">{item.queueReason.label}</div>
+                      </td>
+                      <td>
+                        <strong>{item.monitoring?.timeRemainingLabel || 'Not started'}</strong>
+                        <div className="task-list-meta">{item.monitoring?.windowEndsAt || 'No deadline yet'}</div>
+                      </td>
+                      <td>
+                        <div>{item.monitoring?.deployment?.environment || 'No deploy recorded'}</div>
+                        <div className="task-list-meta">
+                          {item.monitoring?.deployment?.version || 'No version'}
+                          {item.monitoring?.deployment?.url ? ` · ${item.monitoring.deployment.url}` : ''}
+                        </div>
+                      </td>
+                      <td>
+                        <div>{item.monitoring?.linkedPrs?.[0]?.number ? `PR #${item.monitoring.linkedPrs[0].number}` : 'No merged PR'}</div>
+                        <div className="task-list-meta">{item.monitoring?.commitSha || 'No commit snapshot'}</div>
+                      </td>
+                      <td>
+                        <div>Freshness: {item.monitoring?.telemetry?.freshness || 'unknown'}</div>
+                        <div className="task-list-meta">Events: {item.monitoring?.telemetry?.eventCount ?? 0}</div>
+                      </td>
+                      <td>
+                        <div className="task-list-meta">
+                          {item.monitoring?.telemetry?.drilldowns?.metrics ? <a href={item.monitoring.telemetry.drilldowns.metrics} target="_blank" rel="noreferrer">Metrics</a> : 'Metrics unavailable'}
+                          {' · '}
+                          {item.monitoring?.telemetry?.drilldowns?.logs ? <a href={item.monitoring.telemetry.drilldowns.logs} target="_blank" rel="noreferrer">Logs</a> : 'Logs unavailable'}
+                          {' · '}
+                          {item.monitoring?.telemetry?.drilldowns?.traces ? <a href={item.monitoring.telemetry.drilldowns.traces} target="_blank" rel="noreferrer">Traces</a> : 'Traces unavailable'}
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+
+          {roleInboxState.kind === 'ready' && activeInboxRole && activeInboxRole !== 'sre' && roleInboxItems.length ? (
             <div className="task-list-table-wrap">
               <table className="task-list-table">
                 <thead>
@@ -3296,6 +3428,126 @@ export function App() {
                   ))}
                 </ul>
               ) : null}
+            </section>
+
+            <section className="detail-card">
+              <h2>SRE Monitoring</h2>
+              {sreMonitoring ? (
+                <>
+                  <div className="summary-grid review-question-summary-grid">
+                    <article>
+                      <span>State</span>
+                      <strong>{sreMonitoring.state}</strong>
+                    </article>
+                    <article>
+                      <span>Risk</span>
+                      <strong>{sreMonitoring.riskLevel || 'unknown'}</strong>
+                    </article>
+                    <article>
+                      <span>Time remaining</span>
+                      <strong>{sreMonitoring.timeRemainingLabel || 'Not started'}</strong>
+                    </article>
+                    <article>
+                      <span>Telemetry freshness</span>
+                      <strong>{sreMonitoring.telemetry?.freshness || 'unknown'}</strong>
+                    </article>
+                  </div>
+
+                  <div className="review-question-note">
+                    <span>Deployment snapshot</span>
+                    <p>{sreMonitoring.deployment?.environment ? `${sreMonitoring.deployment.environment} · ${sreMonitoring.deployment.version || 'version unknown'}` : 'Monitoring has not started yet.'}</p>
+                    <p className="task-list-meta">
+                      PR: {sreMonitoring.linkedPrs?.[0]?.number ? `#${sreMonitoring.linkedPrs[0].number}` : 'None'}
+                      {` · Commit: ${sreMonitoring.commitSha || 'None'}`}
+                      {sreMonitoring.windowEndsAt ? ` · Window ends: ${sreMonitoring.windowEndsAt}` : ''}
+                    </p>
+                    <p className="task-list-meta">
+                      {sreMonitoring.telemetry?.drilldowns?.metrics ? <a href={sreMonitoring.telemetry.drilldowns.metrics} target="_blank" rel="noreferrer">Metrics</a> : 'Metrics unavailable'}
+                      {' · '}
+                      {sreMonitoring.telemetry?.drilldowns?.logs ? <a href={sreMonitoring.telemetry.drilldowns.logs} target="_blank" rel="noreferrer">Logs</a> : 'Logs unavailable'}
+                      {' · '}
+                      {sreMonitoring.telemetry?.drilldowns?.traces ? <a href={sreMonitoring.telemetry.drilldowns.traces} target="_blank" rel="noreferrer">Traces</a> : 'Traces unavailable'}
+                    </p>
+                  </div>
+
+                  {sreMonitoring.approval ? (
+                    <div className="review-question-note">
+                      <span>Recorded approval</span>
+                      <p>{sreMonitoring.approval.reason}</p>
+                      <p className="task-list-meta">{sreMonitoring.approval.approvedBy || 'Unknown approver'} · {sreMonitoring.approval.approvedAt || 'No timestamp'}</p>
+                      {renderList(sreMonitoring.approval.evidence, 'No evidence notes captured.')}
+                    </div>
+                  ) : null}
+
+                  {sreMonitoring.escalation ? (
+                    <div className="review-question-note">
+                      <span>Expiry escalation</span>
+                      <p>Human stakeholder escalation was created because the monitoring window expired without approval.</p>
+                      <p className="task-list-meta">{sreMonitoring.escalation.escalatedAt || 'No timestamp'}</p>
+                    </div>
+                  ) : null}
+
+                  {sreMonitoringEnabled && sreMonitoring.canStart ? (
+                    <form className="architect-handoff-form" onSubmit={submitSreMonitoringStart}>
+                      <div className="summary-grid architect-handoff-grid">
+                        <label>
+                          Deployment environment
+                          <input value={sreMonitoringStartDraft.deploymentEnvironment} onChange={(event) => setSreMonitoringStartDraft((current) => ({ ...current, deploymentEnvironment: event.target.value }))} />
+                        </label>
+                        <label>
+                          Deployment URL
+                          <input value={sreMonitoringStartDraft.deploymentUrl} onChange={(event) => setSreMonitoringStartDraft((current) => ({ ...current, deploymentUrl: event.target.value }))} placeholder="https://deploy.example/releases/123" />
+                        </label>
+                        <label>
+                          Deployment version
+                          <input value={sreMonitoringStartDraft.deploymentVersion} onChange={(event) => setSreMonitoringStartDraft((current) => ({ ...current, deploymentVersion: event.target.value }))} placeholder="2026.04.14-1" />
+                        </label>
+                        <label className="architect-handoff-grid__full">
+                          Deployment evidence
+                          <textarea value={sreMonitoringStartDraft.evidence} onChange={(event) => setSreMonitoringStartDraft((current) => ({ ...current, evidence: event.target.value }))} placeholder="One confirmation per line" />
+                        </label>
+                      </div>
+                      <div className="assignment-form__actions">
+                        <button type="submit" disabled={sreMonitoringStartStatus.kind === 'loading'}>
+                          {sreMonitoringStartStatus.kind === 'loading' ? 'Starting…' : 'Start monitoring window'}
+                        </button>
+                      </div>
+                      {sreMonitoringStartStatus.kind !== 'idle' ? (
+                        <p className={`assignment-status assignment-status--${sreMonitoringStartStatus.kind}`} role={sreMonitoringStartStatus.kind === 'error' ? 'alert' : 'status'}>
+                          {sreMonitoringStartStatus.message}
+                        </p>
+                      ) : null}
+                    </form>
+                  ) : null}
+
+                  {sreMonitoringEnabled && sreMonitoring.canApprove ? (
+                    <form className="architect-handoff-form" onSubmit={submitSreApproval}>
+                      <div className="summary-grid architect-handoff-grid">
+                        <label className="architect-handoff-grid__full">
+                          Approval reason
+                          <textarea value={sreApprovalDraft.reason} onChange={(event) => setSreApprovalDraft((current) => ({ ...current, reason: event.target.value }))} placeholder="Explain why the rollout is stable enough to leave SRE monitoring early." />
+                        </label>
+                        <label className="architect-handoff-grid__full">
+                          Evidence notes
+                          <textarea value={sreApprovalDraft.evidence} onChange={(event) => setSreApprovalDraft((current) => ({ ...current, evidence: event.target.value }))} placeholder="One evidence note per line" />
+                        </label>
+                      </div>
+                      <div className="assignment-form__actions">
+                        <button type="submit" disabled={sreApprovalStatus.kind === 'loading'}>
+                          {sreApprovalStatus.kind === 'loading' ? 'Approving…' : 'Approve early'}
+                        </button>
+                      </div>
+                      {sreApprovalStatus.kind !== 'idle' ? (
+                        <p className={`assignment-status assignment-status--${sreApprovalStatus.kind}`} role={sreApprovalStatus.kind === 'error' ? 'alert' : 'status'}>
+                          {sreApprovalStatus.message}
+                        </p>
+                      ) : null}
+                    </form>
+                  ) : null}
+                </>
+              ) : (
+                <p>No SRE monitoring context yet.</p>
+              )}
             </section>
 
             <section className="detail-card">

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -181,6 +181,28 @@ function installTaskFetchMock({
       }, 202);
     }
 
+    if (url.endsWith('/tasks/TSK-42/sre-monitoring/start') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          windowStartedAt: '2026-04-01T16:00:00.000Z',
+          windowEndsAt: '2026-04-03T16:00:00.000Z',
+        },
+      }, 201);
+    }
+
+    if (url.endsWith('/tasks/TSK-42/sre-monitoring/approve') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          approvedAt: '2026-04-01T18:00:00.000Z',
+          nextStage: 'PM_CLOSE_REVIEW',
+        },
+      }, 201);
+    }
+
     if (url.includes('/tasks/TSK-42/detail')) {
       if (detailStatus !== 200) {
         return createJsonResponse({
@@ -1562,6 +1584,61 @@ describe('Task browser runtime coverage', () => {
     await screen.findByText('0 tasks routed to SRE.');
     expect(screen.getByRole('heading', { name: 'No tasks routed to SRE' })).toBeInTheDocument();
     expect(screen.getByText(/This is not a loading state/i)).toBeInTheDocument();
+  });
+
+  it('routes SRE monitoring work into the SRE inbox by stage and shows deployment visibility', async () => {
+    installTaskFetchMock({
+      tasksOverride: [
+        {
+          task_id: 'TSK-SRE-1',
+          tenant_id: 'tenant-a',
+          title: 'Monitor rollout',
+          priority: 'P1',
+          current_stage: 'SRE_MONITORING',
+          current_owner: 'engineer',
+          owner: { actor_id: 'engineer', display_name: 'engineer' },
+          blocked: false,
+          closed: false,
+          waiting_state: null,
+          next_required_action: 'Observe production telemetry and approve early only if the rollout is stable.',
+          queue_entered_at: '2026-04-01T15:00:00.000Z',
+          freshness: { status: 'fresh', last_updated_at: '2026-04-01T15:00:00.000Z' },
+          monitoring: {
+            state: 'active',
+            riskLevel: 'medium',
+            timeRemainingMs: 3_600_000,
+            timeRemainingLabel: '1h 0m',
+            windowEndsAt: '2026-04-03T16:00:00.000Z',
+            deployment: {
+              environment: 'production',
+              version: '2026.04.14-1',
+              url: 'https://deploy.example/releases/501',
+            },
+            linkedPrs: [{ number: 501 }],
+            commitSha: 'abc1234def5678',
+            telemetry: {
+              freshness: 'fresh',
+              eventCount: 12,
+              drilldowns: {
+                metrics: 'https://metrics.example/task/TSK-SRE-1',
+                logs: 'https://logs.example/task/TSK-SRE-1',
+                traces: 'https://traces.example/task/TSK-SRE-1',
+              },
+            },
+          },
+        },
+      ],
+    });
+    window.history.pushState({}, '', '/inbox/sre');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'SRE Inbox' });
+    await screen.findByText('1 task routed to SRE.');
+    expect(screen.getByText('Monitor rollout')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Deployment' })).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+    expect(screen.getByText(/2026\.04\.14-1 · https:\/\/deploy\.example\/releases\/501/)).toBeInTheDocument();
+    expect(screen.getByText(/actively in the SRE monitoring stage/i)).toBeInTheDocument();
   });
 
   it('keeps role inbox counts hidden and shows a degraded state when canonical roster loading fails', async () => {

--- a/src/app/task-owner.mjs
+++ b/src/app/task-owner.mjs
@@ -153,6 +153,15 @@ export function resolveRoleInboxMembership(item, agentLookup) {
     };
   }
 
+  if (String(item?.current_stage || '').trim().toUpperCase() === 'SRE_MONITORING') {
+    return {
+      inboxRole: 'sre',
+      reason: 'stage-sre-monitoring',
+      routingLabel: 'Routed to SRE because the task is actively in the SRE monitoring stage.',
+      isFallback: false,
+    };
+  }
+
   if (!item?.current_owner) {
     return {
       inboxRole: null,
@@ -378,8 +387,23 @@ function compareStableTaskId(left, right) {
   return String(left?.task_id || '').localeCompare(String(right?.task_id || ''));
 }
 
-export function sortInboxItems(items = []) {
-  return [...items].sort((left, right) => comparePriority(left, right) || compareFreshnessTimestamp(left, right) || compareStableTaskId(left, right));
+function compareMonitoringDeadline(left, right) {
+  const leftMs = Number(left?.monitoring?.timeRemainingMs);
+  const rightMs = Number(right?.monitoring?.timeRemainingMs);
+  const safeLeft = Number.isFinite(leftMs) ? leftMs : Number.MAX_SAFE_INTEGER;
+  const safeRight = Number.isFinite(rightMs) ? rightMs : Number.MAX_SAFE_INTEGER;
+  if (safeLeft !== safeRight) return safeLeft - safeRight;
+  return 0;
+}
+
+export function sortInboxItems(items = [], roleKey = null) {
+  const normalizedRole = normalizeRoleKey(roleKey);
+  return [...items].sort((left, right) => {
+    if (normalizedRole === 'sre') {
+      return comparePriority(left, right) || compareMonitoringDeadline(left, right) || compareFreshnessTimestamp(left, right) || compareStableTaskId(left, right);
+    }
+    return comparePriority(left, right) || compareFreshnessTimestamp(left, right) || compareStableTaskId(left, right);
+  });
 }
 
 export function resolveQueueReason(item, roleKey) {
@@ -393,6 +417,13 @@ export function resolveQueueReason(item, roleKey) {
     return {
       label: actionNeeded,
       detail: `Action needed from ${getRoleInboxLabel(normalizedRole)}. Ordered by priority first, then queue age (${queueEnteredAt || 'unknown'}), then task ID for stable tie-breaking.`,
+    };
+  }
+
+  if (normalizedRole === 'sre' && item?.monitoring?.windowEndsAt) {
+    return {
+      label: item.monitoring.state === 'approved' ? 'Monitoring approved' : item.monitoring.state === 'escalated' ? 'Escalated to human review' : `Monitoring window: ${item.monitoring.timeRemainingLabel || 'unknown'}`,
+      detail: `Operational review is ordered by priority first, then remaining monitoring time (${item.monitoring.windowEndsAt}), then freshness, then task ID.`,
     };
   }
 
@@ -410,7 +441,7 @@ export function resolveQueueReason(item, roleKey) {
 }
 
 export function buildRoleInboxItems(items, roleKey, agentLookup) {
-  return sortInboxItems(filterTasksForRoleInbox(items, roleKey, agentLookup)).map((item) => ({
+  return sortInboxItems(filterTasksForRoleInbox(items, roleKey, agentLookup), roleKey).map((item) => ({
     ...item,
     ownerPresentation: resolveOwnerPresentation(item, agentLookup),
     routing: resolveRoleInboxMembership(item, agentLookup),

--- a/src/features/task-detail/adapter.browser.js
+++ b/src/features/task-detail/adapter.browser.js
@@ -341,6 +341,20 @@ export function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, get
         body: JSON.stringify(payload),
       });
     },
+    startSreMonitoring(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/start`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
+    approveSreMonitoring(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/approve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
     fetchAssignableAgents() { return request('/ai-agents'); },
     assignTaskOwner(taskId, agentId) {
       return request(`/tasks/${encodeURIComponent(taskId)}/assignment`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agentId }) });

--- a/src/features/task-detail/adapter.js
+++ b/src/features/task-detail/adapter.js
@@ -343,6 +343,20 @@ function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders
         body: JSON.stringify(payload),
       });
     },
+    startSreMonitoring(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/start`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
+    approveSreMonitoring(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/approve`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
     fetchAssignableAgents() { return request('/ai-agents'); },
     assignTaskOwner(taskId, agentId) {
       return request(`/tasks/${encodeURIComponent(taskId)}/assignment`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agentId }) });

--- a/tests/accessibility/task-assignment.a11y.spec.ts
+++ b/tests/accessibility/task-assignment.a11y.spec.ts
@@ -18,6 +18,7 @@ describe('task assignment accessibility', () => {
 
     await screen.findByRole('heading', { name: /wire task detail/i });
     await waitFor(() => expect(screen.getByRole('button', { name: /save owner/i })).toBeInTheDocument());
+    expect(screen.getByLabelText(/owner/i)).toBeInTheDocument();
 
     const results = await axe.run(container, {
       rules: {

--- a/tests/browser/auth-shell.browser.spec.ts
+++ b/tests/browser/auth-shell.browser.spec.ts
@@ -119,4 +119,17 @@ test.describe('authenticated browser app shell', () => {
     await expect(page.getByRole('heading', { name: 'Sign in to the workflow app' })).toBeVisible();
     await expect(page.getByRole('status')).toContainText('Your session expired. Sign in again to continue.');
   });
+
+  test('restores a protected SRE inbox route after sign-in', async ({ page }) => {
+    await page.goto('/inbox/sre', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: 'Sign in to the workflow app' })).toBeVisible();
+
+    await page.getByLabel('Trusted auth code').fill('signed-browser-auth-code');
+    await page.getByLabel('API base URL').fill('/api');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+
+    await expect(page.getByRole('heading', { name: 'SRE Inbox', exact: true })).toBeVisible();
+    await expect(page).toHaveURL(/\/inbox\/sre/);
+    await expect(page.locator('.lede')).toContainText('Read-only monitoring inbox');
+  });
 });

--- a/tests/browser/task-detail.browser.spec.ts
+++ b/tests/browser/task-detail.browser.spec.ts
@@ -121,7 +121,7 @@ async function installApiMocks(page, options: {
 async function openRoute(page, route: string, expectedHeading: string | null = 'Wire task detail') {
   await page.goto(route, { waitUntil: 'domcontentloaded' });
   if (expectedHeading) {
-    await expect(page.getByRole('heading', { name: expectedHeading })).toBeVisible();
+    await expect(page.getByRole('heading', { name: expectedHeading, exact: true })).toBeVisible();
   }
 }
 
@@ -328,5 +328,62 @@ test.describe('task detail browser verification', () => {
     await page.getByLabel('Why does this need higher-tier support?').fill('The implementation now crosses service boundaries and needs senior ownership.');
     await page.getByRole('button', { name: 'Request higher-tier support' }).click();
     await expect(page.getByRole('status').filter({ hasText: 'Responsible escalation recorded and surfaced for architect review.' })).toBeVisible();
+  });
+
+  test('shows deployment-aware SRE monitoring rows in the browser inbox flow', async ({ page }) => {
+    await installApiMocks(page, {
+      sessionClaims: {
+        sub: 'sre-1',
+        tenant_id: 'tenant-a',
+        roles: ['sre', 'reader'],
+        exp: Math.floor(Date.now() / 1000) + (60 * 60),
+      },
+      taskItems: [
+        {
+          task_id: 'TSK-SRE-BROWSER-1',
+          tenant_id: 'tenant-a',
+          title: 'Observe production telemetry',
+          priority: 'P1',
+          current_stage: 'SRE_MONITORING',
+          current_owner: 'engineer',
+          owner: { actor_id: 'engineer', display_name: 'Engineer' },
+          blocked: false,
+          closed: false,
+          waiting_state: null,
+          next_required_action: 'SRE monitoring validation is required.',
+          queue_entered_at: '2026-04-15T12:00:00.000Z',
+          freshness: { status: 'fresh', last_updated_at: '2026-04-15T12:00:00.000Z' },
+          monitoring: {
+            riskLevel: 'low',
+            timeRemainingLabel: '47h remaining',
+            windowEndsAt: '2026-04-17T12:00:00.000Z',
+            deployment: {
+              environment: 'production',
+              version: '2026.04.15-1',
+              url: 'https://deploy.example/releases/901',
+            },
+            linkedPrs: [{ number: 901 }],
+            commitSha: 'abc1234def5678',
+            telemetry: {
+              freshness: 'fresh',
+              eventCount: 3,
+              drilldowns: {
+                metrics: 'https://metrics.example/sre-901',
+                logs: 'https://logs.example/sre-901',
+                traces: 'https://traces.example/sre-901',
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    await openRoute(page, '/inbox/sre', 'SRE Inbox');
+    await expect(page.getByLabel('SRE monitoring dashboard')).toBeVisible();
+    await expect(page.getByText('Observe production telemetry')).toBeVisible();
+    await expect(page.getByText('production', { exact: true })).toBeVisible();
+    await expect(page.getByText(/2026\.04\.15-1/)).toBeVisible();
+    await expect(page.getByText('PR #901')).toBeVisible();
+    await expect(page.getByText('abc1234def5678')).toBeVisible();
   });
 });

--- a/tests/contract/audit-openapi.contract.test.js
+++ b/tests/contract/audit-openapi.contract.test.js
@@ -50,6 +50,7 @@ test('openapi contract documents the live audit routes and auth model', () => {
   const ownerReadSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-owner-surfaces-openapi.yml'), 'utf8');
   const browserAuthSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/authenticated-browser-app-openapi.yml'), 'utf8');
   const assignmentSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-assignment-openapi.yml'), 'utf8');
+  const taskDetailSpec = fs.readFileSync(path.join(__dirname, '../../docs/api/task-detail-history-telemetry-openapi.yml'), 'utf8');
 
   for (const snippet of [
     '/tasks:',
@@ -59,6 +60,8 @@ test('openapi contract documents the live audit routes and auth model', () => {
     '/tasks/{id}/state:',
     '/tasks/{id}/relationships:',
     '/tasks/{id}/observability-summary:',
+    '/tasks/{id}/sre-monitoring/start:',
+    '/tasks/{id}/sre-monitoring/approve:',
     '/metrics:',
     '/projections/process:',
     'BearerAuth:',
@@ -68,6 +71,10 @@ test('openapi contract documents the live audit routes and auth model', () => {
     'limit',
     'dateFrom',
     'dateTo',
+    'queue_entered_at',
+    'wip_owner',
+    'ff-sre-monitoring',
+    'processExpiredSreMonitoring',
     'approved_correlation_ids',
     'current_owner',
     'List projected task summaries with additive owner metadata',
@@ -102,8 +109,20 @@ test('openapi contract documents the live audit routes and auth model', () => {
   for (const snippet of [
     'Only the currently assigned owner may perform this action.',
     'engineer-sr',
+    'Shared browser surfaces such as `/inbox/sre` remain read-only unless a dedicated workflow endpoint is used.',
   ]) {
     assert.match(assignmentSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  for (const snippet of [
+    'sreMonitoring',
+    'deployment',
+    'windowEndsAt',
+    'telemetry',
+    'approval',
+    'escalation',
+  ]) {
+    assert.match(taskDetailSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 });
 

--- a/tests/e2e/audit-foundation.e2e.test.js
+++ b/tests/e2e/audit-foundation.e2e.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const crypto = require('crypto');
 const { createAuditApiServer } = require('../../lib/audit');
+const { createProjectionWorker } = require('../../lib/audit/workers');
 
 function sign(payload, secret) {
   const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64url');
@@ -22,12 +23,12 @@ function authHeaders(secret, roles, overrides = {}) {
 async function withServer(run, options = {}) {
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-e2e-'));
   const secret = 'e2e-secret';
-  const { server } = createAuditApiServer({ baseDir, jwtSecret: secret, ...options });
+  const { server, store } = createAuditApiServer({ baseDir, jwtSecret: secret, ...options });
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   const { port } = server.address();
 
   try {
-    await run({ baseUrl: `http://127.0.0.1:${port}`, secret, baseDir });
+    await run({ baseUrl: `http://127.0.0.1:${port}`, secret, baseDir, store });
   } finally {
     await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
   }
@@ -283,6 +284,72 @@ test('must-have: unauthorized callers are blocked by tenant-scoped RBAC and cann
       }),
     });
     assert.equal(response.status, 403);
+  });
+});
+
+test('must-have: worker processing materializes expired SRE monitoring escalation without a read-side write', async () => {
+  await withServer(async ({ baseUrl, secret, store }) => {
+    const contributorHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, ['contributor']),
+    };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-E2E-SRE-001/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-E2E-SRE-001',
+        payload: {
+          title: 'Expired SRE monitoring task',
+          initial_stage: 'SRE_MONITORING',
+          linked_prs: [{
+            id: 'pr-e2e-sre-1',
+            number: 901,
+            title: 'feat: sre monitoring e2e',
+            repository: 'wiinc1/engineering-team',
+            merged: true,
+            state: 'closed',
+            merged_at: '2026-04-14T12:00:00.000Z',
+          }],
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-SRE-001/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.sre_monitoring_started',
+        actorType: 'user',
+        idempotencyKey: 'start:TSK-E2E-SRE-001',
+        payload: {
+          deployment_environment: 'production',
+          deployment_url: 'https://deploy.example/releases/901',
+          deployment_version: '2026.04.15-1',
+          deployment_status: 'success',
+          window_hours: 48,
+          window_ends_at: '2026-04-14T00:00:00.000Z',
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-SRE-001/state`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    let state = await response.json();
+    assert.equal(state.waiting_state, null);
+
+    const worker = createProjectionWorker(store, { batchSize: 25 });
+    const result = await worker.runOnce();
+    assert.equal(result.expiredProcessed, 1);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-SRE-001/state`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    state = await response.json();
+    assert.equal(state.waiting_state, 'awaiting_human_stakeholder_escalation');
   });
 });
 

--- a/tests/integration/board-owner-filtering.integration.test.js
+++ b/tests/integration/board-owner-filtering.integration.test.js
@@ -130,4 +130,56 @@ describe('board owner filtering integration', () => {
     await screen.findByText('5 cards shown.');
     expect(screen.getAllByText('QA Engineer · QA').length).toBeGreaterThan(0);
   });
+
+  it('routes SRE monitoring work to the SRE inbox by stage even when an engineer remains assigned', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: 'header.eyJzdWIiOiJzcmUtMSIsInRlbmFudF9pZCI6InRlbmFudC1ib2FyZC1vd25lciIsInJvbGVzIjpbInNyZSIsInJlYWRlciJdfQ.signature',
+    });
+
+    const fetchMock = vi.fn(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith('/ai-agents')) return createJsonResponse({ items: fixture.agents });
+      if (url.endsWith('/tasks') && (!init || !init.method || init.method === 'GET')) {
+        return createJsonResponse({
+          items: [
+            {
+              task_id: 'TSK-SRE-STAGE-1',
+              tenant_id: fixture.tenant_id,
+              title: 'Stage-routed SRE task',
+              priority: 'P1',
+              current_stage: 'SRE_MONITORING',
+              current_owner: 'engineer',
+              owner: { actor_id: 'engineer', display_name: 'Engineer' },
+              blocked: false,
+              closed: false,
+              waiting_state: null,
+              next_required_action: 'SRE monitoring validation is required.',
+              freshness: { status: 'fresh', last_updated_at: '2026-04-15T12:00:00.000Z' },
+              monitoring: {
+                riskLevel: 'low',
+                timeRemainingLabel: '47h remaining',
+                windowEndsAt: '2026-04-17T12:00:00.000Z',
+                deployment: { environment: 'production', version: '2026.04.15-1', url: 'https://deploy.example/releases/901' },
+                linkedPrs: [{ number: 901 }],
+                commitSha: 'abc1234def5678',
+                telemetry: { freshness: 'fresh', eventCount: 3, drilldowns: {} },
+              },
+            },
+          ],
+        });
+      }
+
+      throw new Error(`Unhandled fetch URL in integration test: ${url}`);
+    });
+
+    vi.stubGlobal('fetch', fetchMock);
+    window.history.pushState({}, '', '/inbox/sre');
+    render(React.createElement(App));
+
+    await screen.findByRole('heading', { name: 'SRE Inbox' });
+    expect(screen.getByText('Stage-routed SRE task')).toBeInTheDocument();
+    expect(screen.getByText(/actively in the SRE monitoring stage/i)).toBeInTheDocument();
+    expect(screen.getByText('production')).toBeInTheDocument();
+  });
 });

--- a/tests/security/audit-api.security.test.js
+++ b/tests/security/audit-api.security.test.js
@@ -203,6 +203,35 @@ test('rejects engineer-only delivery mutations when the task has been reassigned
   });
 });
 
+test('rejects SRE monitoring mutations for callers without SRE or admin privileges', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const readerAuth = { authorization: `Bearer ${sign({ sub: 'reader', tenant_id: 'tenant-sec', roles: ['reader'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/sre-monitoring/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...readerAuth },
+      body: JSON.stringify({
+        deploymentEnvironment: 'production',
+        deploymentUrl: 'https://deploy.example/releases/sec-1',
+        deploymentVersion: '2026.04.15-1',
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error.code, 'forbidden');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/sre-monitoring/approve`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...readerAuth },
+      body: JSON.stringify({
+        reason: 'No authority',
+        evidence: ['reader attempted approval'],
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error.code, 'forbidden');
+  });
+});
+
 test('browser auth bootstrap rejects missing and incomplete auth codes', async () => {
   await withServer(async ({ baseUrl, secret, baseDir }) => {
     let response = await fetch(`${baseUrl}/auth/session`, {

--- a/tests/unit/audit-api.test.js
+++ b/tests/unit/audit-api.test.js
@@ -36,14 +36,14 @@ function githubSignature(secret, body) {
 async function withServer(run, options = {}) {
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-api-'));
   const secret = 'test-secret';
-  const { server } = createAuditApiServer({ baseDir, jwtSecret: secret, ...options });
+  const { server, store } = createAuditApiServer({ baseDir, jwtSecret: secret, ...options });
 
   await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
   const address = server.address();
   const baseUrl = `http://127.0.0.1:${address.port}`;
 
   try {
-    await run({ baseDir, baseUrl, secret });
+    await run({ baseDir, baseUrl, secret, store });
   } finally {
     await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
   }
@@ -1756,6 +1756,272 @@ test('records structured QA results, routes fail/pass outcomes, preserves re-tes
     state = await response.json();
     assert.equal(state.current_stage, 'SRE_MONITORING');
   });
+});
+
+test('starts SRE monitoring after deploy confirmation and allows early approval into close review', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const contributorHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['contributor'] }),
+    };
+    const sreHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    };
+    const engineerHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'engineer-1', tenant_id: 'tenant-sre', roles: ['engineer', 'contributor'] }),
+    };
+    const qaHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'qa-1', tenant_id: 'tenant-sre', roles: ['qa', 'contributor'] }),
+    };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-SRE-1',
+        payload: {
+          title: 'Monitor production rollout',
+          initial_stage: 'IMPLEMENTATION',
+          linked_prs: [{
+            id: 'pr-sre-1',
+            number: 501,
+            title: 'feat: sre monitoring',
+            repository: 'wiinc1/engineering-team',
+            merged: true,
+            state: 'closed',
+            merged_at: '2026-04-14T12:00:00.000Z',
+          }],
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.assigned',
+        actorType: 'user',
+        idempotencyKey: 'assign:TSK-SRE-1:engineer-1',
+        payload: { assignee: 'engineer-1' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/engineer-submission`, {
+      method: 'PUT',
+      headers: engineerHeaders,
+      body: JSON.stringify({ commitSha: 'abc1234def5678', prUrl: 'https://github.com/wiinc1/engineering-team/pull/501' }),
+    });
+    assert.equal(response.status, 200);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'user',
+        idempotencyKey: 'move:TSK-SRE-1:QA_TESTING',
+        payload: {
+          from_stage: 'IMPLEMENTATION',
+          to_stage: 'QA_TESTING',
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/qa-results`, {
+      method: 'POST',
+      headers: qaHeaders,
+      body: JSON.stringify({
+        outcome: 'pass',
+        summary: 'Deployment validation stayed stable.',
+        scenarios: ['smoke'],
+        findings: [],
+        reproductionSteps: [],
+        stackTraces: [],
+        envLogs: [],
+        retestScope: ['smoke'],
+      }),
+    });
+    assert.equal(response.status, 201);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/sre-monitoring/start`, {
+      method: 'POST',
+      headers: sreHeaders,
+      body: JSON.stringify({
+        deploymentEnvironment: 'production',
+        deploymentUrl: 'https://deploy.example/releases/501',
+        deploymentVersion: '2026.04.14-1',
+      }),
+    });
+    assert.equal(response.status, 201);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/detail`, {
+      headers: authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    });
+    assert.equal(response.status, 200);
+    let detail = await response.json();
+    assert.equal(detail.context.sreMonitoring.state, 'active');
+    assert.equal(detail.context.sreMonitoring.deployment.environment, 'production');
+    assert.equal(detail.context.sreMonitoring.deployment.version, '2026.04.14-1');
+    assert.equal(detail.context.sreMonitoring.commitSha, 'abc1234def5678');
+
+    response = await fetch(`${baseUrl}/tasks`, {
+      headers: authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    });
+    assert.equal(response.status, 200);
+    const list = await response.json();
+    const monitoringRow = list.items.find((item) => item.task_id === 'TSK-SRE-1');
+    assert.equal(monitoringRow.monitoring.deployment.environment, 'production');
+    assert.equal(monitoringRow.monitoring.deployment.version, '2026.04.14-1');
+    assert.equal(monitoringRow.monitoring.deployment.url, 'https://deploy.example/releases/501');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/sre-monitoring/approve`, {
+      method: 'POST',
+      headers: sreHeaders,
+      body: JSON.stringify({
+        reason: 'Stable metrics, logs, and traces after deployment.',
+        evidence: ['latency steady', 'error budget unchanged'],
+      }),
+    });
+    assert.equal(response.status, 201);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/state`, {
+      headers: authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['reader'] }),
+    });
+    const state = await response.json();
+    assert.equal(state.current_stage, 'PM_CLOSE_REVIEW');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-1/detail`, {
+      headers: authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    });
+    detail = await response.json();
+    assert.equal(detail.context.sreMonitoring.state, 'approved');
+    assert.equal(detail.context.sreMonitoring.approval.reason, 'Stable metrics, logs, and traces after deployment.');
+  });
+});
+
+test('auto-escalates expired SRE monitoring windows into human stakeholder review without read side effects', async () => {
+  await withServer(async ({ baseUrl, secret, store }) => {
+    const contributorHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['contributor'] }),
+    };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SRE-2/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-SRE-2',
+        payload: {
+          title: 'Expired monitoring task',
+          initial_stage: 'SRE_MONITORING',
+          linked_prs: [{
+            id: 'pr-sre-2',
+            number: 502,
+            title: 'feat: expired sre monitoring',
+            repository: 'wiinc1/engineering-team',
+            merged: true,
+            state: 'closed',
+            merged_at: '2026-04-13T12:00:00.000Z',
+          }],
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    let stateResponse = await fetch(`${baseUrl}/tasks/TSK-SRE-2/state`, {
+      headers: authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['reader'] }),
+    });
+    assert.equal(stateResponse.status, 200);
+    let state = await stateResponse.json();
+    assert.equal(state.waiting_state, null);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-2/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.sre_monitoring_started',
+        actorType: 'user',
+        idempotencyKey: 'start:TSK-SRE-2',
+        payload: {
+          deployment_environment: 'production',
+          deployment_url: 'https://deploy.example/releases/502',
+          deployment_version: '2026.04.12-1',
+          deployment_status: 'success',
+          window_hours: 48,
+          window_ends_at: '2026-04-13T00:00:00.000Z',
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    const expiryProcessing = await store.processExpiredSreMonitoring();
+    assert.equal(expiryProcessing.processed, 1);
+
+    response = await fetch(`${baseUrl}/tasks`, {
+      headers: authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['reader'] }),
+    });
+    assert.equal(response.status, 200);
+    const list = await response.json();
+    const expiredItem = list.items.find((item) => item.task_id === 'TSK-SRE-2');
+    assert.equal(expiredItem.monitoring.state, 'escalated');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-2/detail`, {
+      headers: authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    });
+    const detail = await response.json();
+    assert.equal(detail.context.sreMonitoring.state, 'escalated');
+    assert.equal(detail.summary.nextAction.label, 'Human stakeholder escalation required after monitoring window expiry.');
+
+    stateResponse = await fetch(`${baseUrl}/tasks/TSK-SRE-2/state`, {
+      headers: authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['reader'] }),
+    });
+    state = await stateResponse.json();
+    assert.equal(state.waiting_state, 'awaiting_human_stakeholder_escalation');
+  });
+});
+
+test('supports all documented SRE monitoring feature-flag aliases', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    let response = await fetch(`${baseUrl}/tasks/TSK-SRE-FLAG/sre-monitoring/start`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['sre'] }),
+      },
+      body: JSON.stringify({
+        deploymentEnvironment: 'production',
+        deploymentUrl: 'https://deploy.example/releases/900',
+        deploymentVersion: '2026.04.15-1',
+      }),
+    });
+    assert.equal(response.status, 503);
+  }, { 'ff-sre-monitoring': false });
+
+  await withServer(async ({ baseUrl, secret }) => {
+    let response = await fetch(`${baseUrl}/tasks/TSK-SRE-FLAG/sre-monitoring/start`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['sre'] }),
+      },
+      body: JSON.stringify({
+        deploymentEnvironment: 'production',
+        deploymentUrl: 'https://deploy.example/releases/900',
+        deploymentVersion: '2026.04.15-1',
+      }),
+    });
+    assert.equal(response.status, 503);
+  }, { ff_sre_monitoring: false });
 });
 
 test('supports AI-agent registry reads and assignment writes on the audit API path', async () => {

--- a/tests/unit/role-inbox-routing.test.js
+++ b/tests/unit/role-inbox-routing.test.js
@@ -30,7 +30,9 @@ describe('role inbox routing', () => {
     const seniorEngineerTask = { current_owner: 'engineer-sr', owner: { actor_id: 'engineer-sr' } };
     const pmTask = { current_owner: null, owner: null, waiting_state: 'awaiting_pm_decision' };
     const architectWaitTask = { current_owner: 'engineer', owner: { actor_id: 'engineer' }, waiting_state: 'awaiting_architect_decision' };
+    const sreMonitoringTask = { current_owner: 'engineer', owner: { actor_id: 'engineer' }, current_stage: 'SRE_MONITORING' };
     const humanTask = { current_owner: null, owner: null, next_required_action: 'Human approval required' };
+    const escalatedSreTask = { current_owner: 'engineer', owner: { actor_id: 'engineer' }, current_stage: 'SRE_MONITORING', waiting_state: 'awaiting_human_stakeholder_escalation' };
     const unassignedTask = { current_owner: null, owner: null };
     const staleTask = { current_owner: 'ghost', owner: { actor_id: 'ghost' } };
     const governanceTask = { current_owner: 'architect', owner: { actor_id: 'architect' }, task_type: 'governance_review' };
@@ -40,7 +42,9 @@ describe('role inbox routing', () => {
     expect(resolveRoleInboxMembership(seniorEngineerTask, agentLookup)).toMatchObject({ inboxRole: 'engineer', reason: 'matched-pattern' });
     expect(resolveRoleInboxMembership(pmTask, agentLookup)).toMatchObject({ inboxRole: 'pm', reason: 'waiting-pm' });
     expect(resolveRoleInboxMembership(architectWaitTask, agentLookup)).toMatchObject({ inboxRole: 'architect', reason: 'waiting-architect' });
+    expect(resolveRoleInboxMembership(sreMonitoringTask, agentLookup)).toMatchObject({ inboxRole: 'sre', reason: 'stage-sre-monitoring' });
     expect(resolveRoleInboxMembership(humanTask, agentLookup)).toMatchObject({ inboxRole: 'human', reason: 'waiting-human' });
+    expect(resolveRoleInboxMembership(escalatedSreTask, agentLookup)).toMatchObject({ inboxRole: 'human', reason: 'waiting-human' });
     expect(resolveRoleInboxMembership(unassignedTask, agentLookup)).toMatchObject({ inboxRole: null, reason: 'unassigned' });
     expect(resolveRoleInboxMembership(staleTask, agentLookup)).toMatchObject({ inboxRole: null, reason: 'unknown-owner', isFallback: true });
     expect(resolveRoleInboxMembership(governanceTask, agentLookup)).toMatchObject({ inboxRole: null, reason: 'governance-review' });
@@ -78,6 +82,16 @@ describe('role inbox routing', () => {
     ]);
 
     expect(ordered.map((item) => item.task_id)).toEqual(['TSK-1', 'TSK-2', 'TSK-4', 'TSK-3']);
+  });
+
+  it('sorts SRE inbox rows by remaining monitoring time after priority', () => {
+    const ordered = sortInboxItems([
+      { task_id: 'TSK-3', priority: 'P1', monitoring: { timeRemainingMs: 6_000 }, freshness: { last_updated_at: '2026-04-01T00:00:03.000Z' } },
+      { task_id: 'TSK-1', priority: 'P1', monitoring: { timeRemainingMs: 1_000 }, freshness: { last_updated_at: '2026-04-01T00:00:01.000Z' } },
+      { task_id: 'TSK-2', priority: 'P1', monitoring: { timeRemainingMs: 3_000 }, freshness: { last_updated_at: '2026-04-01T00:00:02.000Z' } },
+    ], 'sre');
+
+    expect(ordered.map((item) => item.task_id)).toEqual(['TSK-1', 'TSK-2', 'TSK-3']);
   });
 
   it('marks active work as non-preemptive in the queue reason', () => {

--- a/tests/unit/task-detail-adapter.test.js
+++ b/tests/unit/task-detail-adapter.test.js
@@ -279,6 +279,33 @@ test('task detail client submits reassignment workflow actions to dedicated endp
   assert.ok(calls.every((entry) => entry.init.method === 'POST'));
 });
 
+test('task detail client submits SRE monitoring workflow actions to dedicated endpoints', async () => {
+  const calls = [];
+  const client = createTaskDetailApiClient({
+    baseUrl: 'http://audit.local',
+    fetchImpl: async (url, init) => {
+      calls.push({ url, init });
+      return { ok: true, json: async () => ({ success: true }) };
+    },
+  });
+
+  await client.startSreMonitoring('TSK-91', {
+    deploymentEnvironment: 'production',
+    deploymentUrl: 'https://deploy.example/releases/42',
+    deploymentVersion: '2026.04.14-1',
+  });
+  await client.approveSreMonitoring('TSK-91', {
+    reason: 'Telemetry stayed stable across the first hour.',
+    evidence: ['metrics steady', 'error budget unchanged'],
+  });
+
+  assert.deepEqual(calls.map((entry) => entry.url), [
+    'http://audit.local/tasks/TSK-91/sre-monitoring/start',
+    'http://audit.local/tasks/TSK-91/sre-monitoring/approve',
+  ]);
+  assert.ok(calls.every((entry) => entry.init.method === 'POST'));
+});
+
 test('deriveTelemetryFreshness promotes fresh and stale signals from freshness metadata', () => {
   assert.deepEqual(
     deriveTelemetryFreshness({ freshness: { status: 'fresh', last_updated_at: '2026-04-01T12:00:00.000Z' } }),


### PR DESCRIPTION
## Summary
- implement the SRE monitoring start and approval workflow for SF-014
- route active SRE monitoring work into the SRE inbox by stage and show deployment-aware monitoring rows
- move monitoring expiry escalation to worker-driven processing and add the required standards-adjacent docs/tests

## Linked Task
- Task: #19

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: architecture and design, coding and code quality, testing and quality assurance, deployment and release, observability and monitoring, team and process
- Standards gaps or exceptions: Gap observed: this PR uses an internal UAT proxy rather than a production-environment rollout validation. Documented rationale: progressive rollout and direct user-impact measurement remain separate release controls from repository review evidence (source https://sre.google/books/).

## Required Evidence
- Standards check result: `npm run standards:check`
- Lint result: `npm run lint`
- Tests: `npm run ownership:lint`, `npm run typecheck`, `npm run test:governance`, `npm run change:check`, `npm test`
- Test evidence paths: docs/reports/SF-014-review.md, docs/design/SF-014-design.md
- Docs updated: yes
- Doc evidence paths: docs/design/SF-014-design.md, docs/reports/SF-014-review.md, docs/api/audit-foundation-openapi.yml, docs/runbooks/audit-foundation.md

## Risk and Rollback
- Risk level: medium
- Rollback path: disable `ff_sre_monitoring` / `ff-sre-monitoring` and revert this branch if needed

## Notes
- Closes #19