### PR TITLE
Close SF-015 anomaly child workflow gaps

### DIFF
--- a/docs/api/audit-foundation-openapi.yml
+++ b/docs/api/audit-foundation-openapi.yml
@@ -338,6 +338,81 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '503':
           $ref: '#/components/responses/FeatureDisabled'
+  /tasks/{id}/sre-monitoring/anomaly-child-task:
+    post:
+      summary: Create a linked P0 child task from a live monitoring anomaly
+      description: |
+        Requires SRE or admin privileges while the parent task is in `SRE_MONITORING`.
+        The runtime feature can be disabled by `ff_child_task_creation`.
+        Successful creation links the child back to the parent, records a P0 audit reason, and blocks the parent
+        while leaving it viewable/commentable for follow-up coordination.
+        The parent block is released automatically when the linked anomaly child reaches a resolved terminal state.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [service, anomalySummary, metrics, logs, errorSamples]
+              properties:
+                title: { type: string }
+                service: { type: string }
+                anomalySummary: { type: string }
+                metrics:
+                  type: array
+                  items: { type: string }
+                logs:
+                  type: array
+                  items: { type: string }
+                errorSamples:
+                  type: array
+                  items: { type: string }
+      responses:
+        '201':
+          description: Child task created and linked to the parent monitoring task
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/FeatureDisabled'
+  /tasks/{id}/pm-business-context:
+    post:
+      summary: Finalize machine-generated PM business context for an anomaly child task
+      description: |
+        Requires PM or admin privileges while the anomaly child task remains in `BACKLOG`
+        with `waiting_state=pm_business_context_required`.
+        Successful completion records a dedicated `task.pm_business_context_completed` audit event,
+        clears the PM gate, and marks the anomaly context as finalized by PM.
+        Generic event injection is not a supported completion path for this workflow.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [businessContext]
+              properties:
+                businessContext: { type: string }
+      responses:
+        '200':
+          description: PM business context finalized and architect work unblocked
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '503':
+          $ref: '#/components/responses/FeatureDisabled'
   /tasks/{id}/observability-summary:
     get:
       summary: Return non-authoritative observability summary and approved_correlation_ids / correlation pointers

--- a/docs/api/authenticated-browser-app-openapi.yml
+++ b/docs/api/authenticated-browser-app-openapi.yml
@@ -11,6 +11,8 @@ info:
     is intentionally separate from standard delivery queues.
     `/inbox/sre` is the protected SRE monitoring dashboard route and consumes deployment-aware monitoring
     preview data from the projected task-list response.
+    Authenticated SRE sessions may also create anomaly child tasks from the protected `/tasks/{taskId}`
+    detail route by calling the dedicated monitoring workflow endpoint after bootstrap succeeds.
 paths:
   /auth/session:
     post:

--- a/docs/api/task-assignment-openapi.yml
+++ b/docs/api/task-assignment-openapi.yml
@@ -9,6 +9,7 @@ info:
     Delivery-loop mutations that are reserved for the currently assigned engineer role now reject callers
     that no longer match the task's canonical assignee.
     Shared browser surfaces such as `/inbox/sre` remain read-only unless a dedicated workflow endpoint is used.
+    SRE anomaly-to-child-task creation is a separate dedicated workflow endpoint and does not mutate assignment state directly.
 paths:
   /tasks/{taskId}/assignment:
     patch:

--- a/docs/api/task-detail-history-telemetry-openapi.yml
+++ b/docs/api/task-detail-history-telemetry-openapi.yml
@@ -261,7 +261,7 @@ components:
           type: array
           items:
             type: object
-            required: [id, type, label, source, owner, ageLabel, occurredAt]
+            required: [id, type, label, source, owner, ageLabel, occurredAt, reason, childTaskId, freezeScope, viewable, commentable, nextRequiredAction, childTask]
             properties:
               id: { type: string }
               type: { type: string }
@@ -271,9 +271,27 @@ components:
                 $ref: '#/components/schemas/TaskDetailActor'
               ageLabel: { type: string }
               occurredAt: { type: [string, 'null'], format: date-time }
+              reason: { type: [string, 'null'] }
+              childTaskId: { type: [string, 'null'] }
+              freezeScope:
+                type: array
+                items: { type: string }
+              viewable: { type: boolean }
+              commentable: { type: boolean }
+              nextRequiredAction: { type: [string, 'null'] }
+              childTask:
+                type: [object, 'null']
+                properties:
+                  id: { type: string }
+                  title: { type: string }
+                  stage: { type: [string, 'null'] }
+                  status: { type: string, enum: [active, waiting, blocked, done] }
+                  owner:
+                    $ref: '#/components/schemas/TaskDetailActor'
+                  waitingState: { type: [string, 'null'] }
         context:
           type: object
-          required: [businessContext, acceptanceCriteria, definitionOfDone, technicalSpec, monitoringSpec]
+          required: [businessContext, acceptanceCriteria, definitionOfDone, technicalSpec, monitoringSpec, pmBusinessContextReview]
           properties:
             businessContext: { type: [string, 'null'] }
             acceptanceCriteria:
@@ -300,6 +318,47 @@ components:
               type: [object, 'null']
               additionalProperties: true
               description: Linked governance review task created for inactivity or other governance follow-up.
+            anomalyChildTask:
+              type: [object, 'null']
+              description: Machine-generated anomaly context used when a child task is created directly from SRE monitoring telemetry.
+              properties:
+                machineGenerated: { type: boolean }
+                sourceTaskId: { type: [string, 'null'] }
+                service: { type: [string, 'null'] }
+                summary: { type: [string, 'null'] }
+                metrics:
+                  type: array
+                  items: { type: string }
+                logs:
+                  type: array
+                  items: { type: string }
+                errorSamples:
+                  type: array
+                  items: { type: string }
+                prefill:
+                  type: [object, 'null']
+                  properties:
+                    service: { type: [string, 'null'] }
+                    anomalySummary: { type: [string, 'null'] }
+                    metrics:
+                      type: array
+                      items: { type: string }
+                    logs:
+                      type: array
+                      items: { type: string }
+                    errorSamples:
+                      type: array
+                      items: { type: string }
+                finalizedByPm: { type: boolean }
+                finalizedAt: { type: [string, 'null'], format: date-time }
+                finalizedBy: { type: [string, 'null'] }
+            pmBusinessContextReview:
+              type: object
+              required: [completedAt, completedBy, finalized]
+              properties:
+                completedAt: { type: [string, 'null'], format: date-time }
+                completedBy: { type: [string, 'null'] }
+                finalized: { type: boolean }
             sreMonitoring:
               type: [object, 'null']
               description: SRE monitoring workflow summary, including deployment evidence, countdown state, telemetry drilldowns, approval snapshot, and expiry escalation details when present.
@@ -326,18 +385,29 @@ components:
                   additionalProperties: true
         relations:
           type: object
-          required: [linkedPrs, childTasks]
+          required: [linkedPrs, childTasks, parentTask]
           properties:
             linkedPrs:
               type: array
               items:
                 type: object
                 additionalProperties: true
+            parentTask:
+              type: [object, 'null']
+              properties:
+                id: { type: string }
+                title: { type: string }
+                stage: { type: [string, 'null'] }
+                status: { type: string, enum: [active, waiting, blocked, done] }
+                owner:
+                  $ref: '#/components/schemas/TaskDetailActor'
+                blocked: { type: boolean }
+                waitingState: { type: [string, 'null'] }
             childTasks:
               type: array
               items:
                 type: object
-                required: [id, title, stage, status, owner, blocked]
+                required: [id, title, stage, status, owner, blocked, waitingState]
                 properties:
                   id: { type: string }
                   title: { type: string }
@@ -346,6 +416,7 @@ components:
                   owner:
                     $ref: '#/components/schemas/TaskDetailActor'
                   blocked: { type: boolean }
+                  waitingState: { type: [string, 'null'] }
         activity:
           type: object
           required: [comments, auditLog]

--- a/docs/design/US-002-design.md
+++ b/docs/design/US-002-design.md
@@ -79,3 +79,4 @@
 - governance review tasks are shown only on that dedicated route and are intentionally excluded from the default task list, board, and PM overview delivery surfaces
 - tier-specific engineer owners still collapse into the canonical `engineer` route family for inbox and overview grouping while preserving human-readable labels in the UI
 - `/inbox/sre` is a protected route in the authenticated shell and now renders a deployment-aware monitoring dashboard for tasks actively in the `SRE_MONITORING` stage
+- protected `/tasks/{taskId}` sessions can now surface the SRE-only anomaly-child-task form on task detail, so browser-shell auth coverage must continue to protect that route restoration path as detail capabilities expand

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -75,6 +75,9 @@ Audit HTTP maintenance note:
 - Engineer-only delivery-loop mutations now validate the task's current canonical assignee before accepting writes.
 - Tier-based reassignment may emit explicit assignee ids such as `engineer-sr` in workflow payloads and task-detail context so downstream consumers can tell when ownership changed materially.
 - SRE monitoring expiry is now worker-driven: reads reflect the current state but no longer append escalation events when the window has expired.
+- SRE monitoring also exposes `POST /tasks/{id}/sre-monitoring/anomaly-child-task`, which creates a linked child task with machine-generated telemetry context, records the auto-`P0` rationale, and blocks the parent while leaving it readable/commentable.
+- The anomaly-child parent block is cleared automatically when the linked child reaches a resolved terminal state; generic `task.unblocked` event injection is not the supported path for this workflow.
+- PM anomaly follow-up now also exposes `POST /tasks/{id}/pm-business-context`, which records `task.pm_business_context_completed`, clears `pm_business_context_required`, and marks the anomaly context as finalized by PM for task detail consumers. Generic event injection is not a supported completion path for this workflow.
 
 ## Tenant isolation guarantees in this slice
 - Idempotency is tenant-scoped. The same `idempotencyKey` may legitimately exist in different tenants without collision.
@@ -205,6 +208,15 @@ Immediate action:
 1. Confirm the projection worker is running or invoke bounded worker processing locally.
 2. Verify the task has `sre_monitoring_window_ends_at` set and no `sre_approved_at`.
 3. Re-run projection worker processing; successful processing should append an auditable `task.escalated` event with `reason=sre_monitoring_window_expired`.
+
+### Monitoring anomaly requires tracked child work
+Symptom: SRE identifies a production anomaly that should become first-class tracked work.
+Immediate action:
+1. Use `POST /tasks/{id}/sre-monitoring/anomaly-child-task` with service, anomaly summary, metrics, logs, and error samples.
+2. Confirm the parent task gains a `task.child_link_added` event and a blocking `task.blocked` event referencing the new child id.
+3. Confirm the child task is created as `P0`, linked back to the parent, and routed with `waiting_state=pm_business_context_required`.
+4. Use `POST /tasks/{childId}/pm-business-context` to finalize the machine-generated business context before architect work begins.
+5. Confirm the parent task is automatically unblocked when the linked child reaches its normal resolved terminal state.
 
 ## Observability hooks
 Structured log fields emitted in this slice:

--- a/docs/runbooks/task-assignment.md
+++ b/docs/runbooks/task-assignment.md
@@ -18,6 +18,7 @@ Allows an authorized Product Manager to assign or reassign an AI agent as the ow
 - Restricted telemetry behavior is separate: lower-privilege readers still get owner metadata, while `GET /tasks/{taskId}/observability-summary` omits privileged telemetry fields server-side.
 - Tier-specific projected assignee ids such as `engineer-jr`, `engineer-sr`, and `engineer-principal` are valid owner values and should still be treated as canonical engineer ownership for delivery routing.
 - The SRE monitoring inbox is a separate workflow surface: tasks may appear in `/inbox/sre` by workflow stage even when `current_owner` still points at an engineer.
+- If SRE creates a monitoring-anomaly child task from task detail, the new child is intentionally assigned to `pm`; that route is distinct from `PATCH /tasks/{taskId}/assignment`.
 
 ## Responsible escalation and current-owner enforcement
 - Delivery-loop actions reserved for engineers now validate the task's current canonical assignee before mutating state.
@@ -58,6 +59,7 @@ Allows an authorized Product Manager to assign or reassign an AI agent as the ow
 
 ## Change Ownership Notes
 - Changes to the assignment mutation path in `lib/audit/http.js` or the assignment controls in `src/app/App.jsx` should update this runbook or the matching assignment API contract in the same PR.
+- SRE anomaly child-task creation should continue to bypass assignment mutation and remain on its dedicated monitoring workflow endpoint.
 - Nearest verification artifacts for that surface are:
 - `tests/unit/task-assignment.test.js`
 - `tests/unit/audit-api.test.js`

--- a/lib/audit/core.js
+++ b/lib/audit/core.js
@@ -157,6 +157,8 @@ function summarizeEvent(event) {
       return `SRE monitoring started${payload.deployment_environment ? ` for ${payload.deployment_environment}` : ''}`;
     case 'task.sre_approval_recorded':
       return `SRE approved early${payload.reason ? `: ${payload.reason}` : ''}`;
+    case 'task.pm_business_context_completed':
+      return `PM business context completed${payload.completed_by ? ` by ${payload.completed_by}` : ''}`;
     case 'task.closed':
       return 'Task closed';
     case 'task.github_pr_synced':
@@ -294,6 +296,8 @@ function buildCurrentState(previous = {}, event) {
       break;
     case 'task.unblocked':
       next.blocked = false;
+      next.waiting_state = event.payload.waiting_state || null;
+      next.next_required_action = event.payload.next_required_action || null;
       break;
     case 'task.escalated':
       if (event.payload.reason === 'sre_monitoring_window_expired') {
@@ -306,6 +310,7 @@ function buildCurrentState(previous = {}, event) {
     case 'task.check_in_recorded':
     case 'task.ghosting_review_created':
     case 'task.comment_workflow_recorded':
+    case 'task.pm_business_context_completed':
       next.waiting_state = event.payload.waiting_state || next.waiting_state;
       next.next_required_action = event.payload.next_required_action || next.next_required_action;
       next.queue_entered_at = event.occurred_at;

--- a/lib/audit/event-types.js
+++ b/lib/audit/event-types.js
@@ -37,6 +37,7 @@ const WORKFLOW_AUDIT_EVENT_TYPES = Object.freeze([
   'task.sre_approval_recorded',
   'task.github_pr_synced',
   'task.github_pr_comment_recorded',
+  'task.pm_business_context_completed',
   'task.closed'
 ]);
 

--- a/lib/audit/feature-flags.js
+++ b/lib/audit/feature-flags.js
@@ -195,6 +195,26 @@ function assertSreMonitoringEnabled(options = {}) {
   }
 }
 
+function isChildTaskCreationEnabled(options = {}) {
+  if (typeof options.childTaskCreationEnabled === 'boolean') return options.childTaskCreationEnabled;
+  const raw = options.ffChildTaskCreation
+    ?? options.ff_child_task_creation
+    ?? options['ff-child-task-creation']
+    ?? process.env.FF_CHILD_TASK_CREATION;
+  if (raw === undefined || raw === null || raw === '') return true;
+  return !['0', 'false', 'off', 'disabled', 'no'].includes(String(raw).trim().toLowerCase());
+}
+
+function assertChildTaskCreationEnabled(options = {}) {
+  if (!isChildTaskCreationEnabled(options)) {
+    const error = new Error('Child task creation is disabled by ff_child_task_creation');
+    error.code = 'feature_disabled';
+    error.statusCode = 503;
+    error.details = { feature: 'ff_child_task_creation' };
+    throw error;
+  }
+}
+
 function isReassignmentGhostingEnabled(options = {}) {
   if (typeof options.reassignmentGhostingEnabled === 'boolean') return options.reassignmentGhostingEnabled;
   const raw = options.ffReassignmentGhosting ?? process.env.FF_REASSIGNMENT_GHOSTING;
@@ -281,6 +301,8 @@ module.exports = {
   assertQaContextRoutingEnabled,
   isSreMonitoringEnabled,
   assertSreMonitoringEnabled,
+  isChildTaskCreationEnabled,
+  assertChildTaskCreationEnabled,
   isReassignmentGhostingEnabled,
   assertReassignmentGhostingEnabled,
   isSpecialistDelegationEnabled,

--- a/lib/audit/http.js
+++ b/lib/audit/http.js
@@ -22,6 +22,7 @@ const {
   assertQaStageEnabled,
   assertQaContextRoutingEnabled,
   assertSreMonitoringEnabled,
+  assertChildTaskCreationEnabled,
   assertReassignmentGhostingEnabled,
 } = require('./feature-flags');
 const { isWorkflowAuditEventType } = require('./event-types');
@@ -1029,6 +1030,19 @@ function canManageSreMonitoring(context) {
   return hasAnyRole(context, ['sre', 'admin']);
 }
 
+function canCompletePmBusinessContext(context) {
+  return hasAnyRole(context, ['pm', 'admin']);
+}
+
+function assertNoRestrictedAnomalyWorkflowEventWrite(context, eventType) {
+  if (eventType === 'task.pm_business_context_completed' && !canCompletePmBusinessContext(context)) {
+    throw createHttpError(403, 'forbidden', 'Only PM/admin may complete machine-generated business context.');
+  }
+  if (eventType === 'task.unblocked') {
+    throw createHttpError(403, 'forbidden', 'Active anomaly-child blocks may only be cleared by the linked child resolution flow.');
+  }
+}
+
 function validateSreMonitoringStartBody(body = {}) {
   const deploymentEnvironment = String(body.deploymentEnvironment || '').trim();
   const deploymentUrl = String(body.deploymentUrl || '').trim();
@@ -1065,6 +1079,117 @@ function validateSreApprovalBody(body = {}) {
   return { reason, evidence };
 }
 
+function buildMonitoringAnomalyPrefill({ parentTaskId, telemetry = null, monitoring = null } = {}) {
+  const service = String(monitoring?.architectMonitoringSpec?.service || '').trim();
+  const keySignals = Object.entries(telemetry?.key_signals || {})
+    .map(([key, value]) => `${key}: ${String(value)}`)
+    .filter(Boolean);
+  const drilldowns = monitoring?.telemetry?.drilldowns || {};
+  const deployment = monitoring?.deployment || null;
+  const signalSummary = keySignals.slice(0, 3).join('; ');
+  const anomalySummary = signalSummary
+    ? `${service || 'Service'} anomaly detected during ${deployment?.environment || 'production'} monitoring: ${signalSummary}.`
+    : deployment?.version
+      ? `${service || 'Service'} anomaly detected after deployment ${deployment.version}.`
+      : (service ? `${service} anomaly requires tracked investigation.` : '');
+  return {
+    service,
+    anomalySummary,
+    metrics: keySignals.slice(0, 5),
+    logs: [
+      drilldowns.logs ? `Log drilldown: ${drilldowns.logs}` : null,
+      deployment?.url ? `Deployment evidence: ${deployment.url}` : null,
+    ].filter(Boolean),
+    errorSamples: [
+      drilldowns.traces ? `Trace drilldown: ${drilldowns.traces}` : null,
+      drilldowns.metrics ? `Metrics drilldown: ${drilldowns.metrics}` : null,
+    ].filter(Boolean),
+  };
+}
+
+function validateMonitoringAnomalyChildTaskBody(body = {}, { parentTaskId, parentTitle, telemetry, monitoring } = {}) {
+  const prefill = buildMonitoringAnomalyPrefill({ parentTaskId, telemetry, monitoring });
+  const service = String(body.service || prefill.service || '').trim();
+  const anomalySummary = String(body.anomalySummary || prefill.anomalySummary || '').trim();
+  const title = String(body.title || `Investigate ${service || 'production'} anomaly for ${parentTaskId}`).trim();
+  const metrics = normalizeMultilineList(body.metrics).length
+    ? normalizeMultilineList(body.metrics)
+    : prefill.metrics;
+  const logs = normalizeMultilineList(body.logs).length
+    ? normalizeMultilineList(body.logs)
+    : prefill.logs;
+  const errorSamples = normalizeMultilineList(body.errorSamples).length
+    ? normalizeMultilineList(body.errorSamples)
+    : prefill.errorSamples;
+
+  const missingFields = [];
+  if (!service) missingFields.push('service');
+  if (!anomalySummary) missingFields.push('anomalySummary');
+  if (!metrics.length) missingFields.push('metrics');
+  if (!logs.length) missingFields.push('logs');
+  if (!errorSamples.length) missingFields.push('errorSamples');
+  if (missingFields.length) {
+    throw createHttpError(400, 'missing_required_monitoring_anomaly_fields', 'Monitoring anomaly child-task creation requires service, anomaly summary, metrics, logs, and error samples.', {
+      missing_fields: missingFields,
+    });
+  }
+
+  const parentLabel = parentTitle ? `${parentTaskId} ${parentTitle}` : parentTaskId;
+  const deploymentLabel = monitoring?.deployment?.environment
+    ? `${monitoring.deployment.environment}${monitoring.deployment.version ? ` ${monitoring.deployment.version}` : ''}`
+    : 'deployment context unavailable';
+  const telemetryLinks = monitoring?.telemetry?.drilldowns || {};
+  const references = [
+    telemetryLinks.metrics ? `Metrics: ${telemetryLinks.metrics}` : null,
+    telemetryLinks.logs ? `Logs: ${telemetryLinks.logs}` : null,
+    telemetryLinks.traces ? `Traces: ${telemetryLinks.traces}` : null,
+  ].filter(Boolean);
+
+  return {
+    title,
+    service,
+    anomaly_summary: anomalySummary,
+    metrics,
+    logs,
+    error_samples: errorSamples,
+    business_context: [
+      '[Machine-generated anomaly context. PM should refine business impact before architect work starts.]',
+      `Parent task: ${parentLabel}`,
+      `Affected service: ${service}`,
+      `Anomaly summary: ${anomalySummary}`,
+      `Deployment context: ${deploymentLabel}`,
+      references.length ? `Telemetry references: ${references.join(' | ')}` : 'Telemetry references: unavailable',
+      'Metrics:',
+      ...metrics.map((entry) => `- ${entry}`),
+      'Logs:',
+      ...logs.map((entry) => `- ${entry}`),
+      'Error samples:',
+      ...errorSamples.map((entry) => `- ${entry}`),
+    ].join('\n'),
+    acceptance_criteria: [
+      `Telemetry evidence for ${service} is reviewed and root-cause hypotheses are documented.`,
+      `PM confirms business context and customer impact for parent task ${parentTaskId} before Architect details begin.`,
+      `Parent-child lineage remains visible across both task records.`,
+    ],
+    definition_of_done: [
+      'PM business context is updated for the anomaly child task.',
+      'An architect-ready investigation package exists or mitigation work is routed explicitly.',
+      `Parent task ${parentTaskId} is unblocked or its blocking reason is refreshed with the latest anomaly status.`,
+    ],
+    task_type: 'Bug',
+    assignee: 'pm',
+    prefill,
+  };
+}
+
+function validatePmBusinessContextCompletionBody(body = {}) {
+  const businessContext = String(body.businessContext || body.business_context || '').trim();
+  if (!businessContext) {
+    throw createHttpError(400, 'missing_business_context', 'Finalized PM business context is required.');
+  }
+  return { business_context: businessContext };
+}
+
 function findLatestSreMonitoringStart(history = []) {
   return history.find((event) => event?.event_type === 'task.sre_monitoring_started') || null;
 }
@@ -1075,6 +1200,26 @@ function findLatestSreApproval(history = []) {
 
 function findLatestSreExpiryEscalation(history = []) {
   return history.find((event) => event?.event_type === 'task.escalated' && event?.payload?.reason === 'sre_monitoring_window_expired') || null;
+}
+
+function findLatestPmBusinessContextCompletion(history = []) {
+  return history.find((event) => event?.event_type === 'task.pm_business_context_completed') || null;
+}
+
+function findLatestAnomalyContextEvent(history = []) {
+  return history.find((event) => event?.payload?.anomaly_context) || null;
+}
+
+function findActiveTaskBlock(history = []) {
+  const latestUnblockedIndex = history.findIndex((event) => event?.event_type === 'task.unblocked');
+  const candidateHistory = latestUnblockedIndex === -1 ? history : history.slice(0, latestUnblockedIndex);
+  return candidateHistory.find((event) => event?.event_type === 'task.blocked') || null;
+}
+
+function findActiveAnomalyChildBlock(history = []) {
+  const latestUnblockedIndex = history.findIndex((event) => event?.event_type === 'task.unblocked');
+  const candidateHistory = latestUnblockedIndex === -1 ? history : history.slice(0, latestUnblockedIndex);
+  return candidateHistory.find((event) => event?.event_type === 'task.blocked' && event?.payload?.child_task_id) || null;
 }
 
 function formatDurationFromNow(targetIso) {
@@ -1161,7 +1306,7 @@ function deriveSreMonitoringProjection({
   const drilldowns = buildTelemetryDrilldowns(telemetry, architectHandoff);
   const telemetryFresh = telemetry?.freshness?.status === 'fresh' && !telemetry?.degraded;
   const canStart = summary?.current_stage === STAGES.SRE_MONITORING && !startEvent && mergedPrs.length > 0;
-  const canApprove = summary?.current_stage === STAGES.SRE_MONITORING && Boolean(startEvent) && !approvalEvent && !expiryEvent && telemetryFresh;
+  const canApprove = summary?.current_stage === STAGES.SRE_MONITORING && Boolean(startEvent) && !approvalEvent && !expiryEvent && telemetryFresh && !summary?.blocked;
   const riskLevel = expiryEvent || expired || telemetry?.degraded
     ? 'high'
     : timeRemainingMs != null && timeRemainingMs <= 12 * 60 * 60 * 1000
@@ -1224,6 +1369,7 @@ function deriveSreMonitoringProjection({
 function summarizeTaskForDetail(taskId, state, history = []) {
   const createdEvent = history.find(event => event.event_type === 'task.created');
   const newestEvent = history[0] || null;
+  const pmBusinessContextCompletion = findLatestPmBusinessContextCompletion(history);
   const latestPayload = newestEvent?.payload || {};
   const title = createdEvent?.payload?.title || latestPayload.title || taskId;
   const now = Date.now();
@@ -1265,7 +1411,7 @@ function summarizeTaskForDetail(taskId, state, history = []) {
       freshness: freshnessStatus,
     },
     closed: Boolean(state.closed),
-    business_context: createdEvent?.payload?.business_context || null,
+    business_context: pmBusinessContextCompletion?.payload?.business_context || createdEvent?.payload?.business_context || null,
     acceptance_criteria: createdEvent?.payload?.acceptance_criteria || null,
     definition_of_done: createdEvent?.payload?.definition_of_done || null,
     task_type: createdEvent?.payload?.task_type || null,
@@ -1332,6 +1478,7 @@ function buildTaskDetailViewModel({
   history,
   telemetry,
   childTaskSummaries = [],
+  parentTaskSummary = null,
   context,
   timelineHistory = history,
   timelinePageInfo = null,
@@ -1361,8 +1508,14 @@ function buildTaskDetailViewModel({
   const missedCheckIns = computeMissedCheckIns(latestActivitySignal?.occurredAt, new Date().toISOString());
   const technicalSpec = formatArchitectHandoffTechnicalSpec(architectHandoff) || lastDefinedPayloadValue(history, ['technical_spec', 'technicalSpec']);
   const monitoringSpec = formatArchitectHandoffMonitoringSpec(architectHandoff) || lastDefinedPayloadValue(history, ['monitoring_spec', 'monitoringSpec']);
+  const anomalyContextEvent = findLatestAnomalyContextEvent(history);
+  const anomalyContext = anomalyContextEvent?.payload?.anomaly_context || null;
+  const pmBusinessContextReview = findLatestPmBusinessContextCompletion(history);
   const queueStartedAt = summary.queue_entered_at || createdEvent?.occurred_at || null;
-  const blockerEvents = history.filter(event => event.event_type === 'task.blocked');
+  const activeBlockerEvent = summary.blocked ? findActiveTaskBlock(history) : null;
+  const activeAnomalyBlockerEvent = summary.blocked ? findActiveAnomalyChildBlock(history) : null;
+  const blockerEvents = [activeAnomalyBlockerEvent, activeBlockerEvent]
+    .filter((event, index, items) => event && items.findIndex((candidate) => candidate?.event_id === event?.event_id) === index);
   const commentEvents = canViewHistory ? history.filter(event => event.event_type === 'task.comment_workflow_recorded') : [];
   const childTasks = canViewRelationships ? childTaskSummaries.map((child) => ({
     id: child.task_id,
@@ -1371,6 +1524,7 @@ function buildTaskDetailViewModel({
     status: inferTaskStatus(child),
     owner: formatActor(child.current_owner),
     blocked: Boolean(child.blocked),
+    waitingState: child.waiting_state || null,
   })) : [];
   const blockedChildren = childTasks.filter((child) => child.status === 'blocked');
   const childStatus = childTasks.length
@@ -1384,11 +1538,13 @@ function buildTaskDetailViewModel({
     : 'empty';
   const blockers = blockerEvents.map((event) => {
     const ageMs = event.occurred_at ? Math.max(0, Date.now() - Date.parse(event.occurred_at)) : null;
+    const blockingChild = childTasks.find((child) => child.id === event.payload?.child_task_id) || null;
     return {
       id: event.event_id,
       type: event.payload?.blocker_type || event.payload?.waiting_state || 'workflow_blocker',
       label: event.payload?.summary || event.payload?.reason || 'Task is blocked',
-      source: blockedChildren.some((child) => child.id === event.payload?.child_task_id)
+      reason: event.payload?.reason || null,
+      source: blockingChild
         ? 'child_task'
         : event.payload?.external_dependency
           ? 'external_dependency'
@@ -1400,6 +1556,19 @@ function buildTaskDetailViewModel({
       owner: formatActor(event.payload?.owner_id || null, 'No blocker owner'),
       ageLabel: formatDurationFromMs(ageMs) || 'Unknown age',
       occurredAt: event.occurred_at || null,
+      childTaskId: event.payload?.child_task_id || null,
+      childTask: blockingChild ? {
+        id: blockingChild.id,
+        title: blockingChild.title,
+        stage: blockingChild.stage,
+        status: blockingChild.status,
+        owner: blockingChild.owner,
+        waitingState: blockingChild.waitingState,
+      } : null,
+      freezeScope: Array.isArray(event.payload?.freeze_scope) ? event.payload.freeze_scope : [],
+      viewable: event.payload?.viewable !== false,
+      commentable: event.payload?.commentable !== false,
+      nextRequiredAction: event.payload?.next_required_action || null,
     };
   });
 
@@ -1506,10 +1675,41 @@ function buildTaskDetailViewModel({
         lastActivity: latestActivitySignal,
       },
       transferredContext: latestReassignment?.transferSummary || null,
+      anomalyChildTask: anomalyContext ? {
+        machineGenerated: anomalyContext.machine_generated !== false,
+        sourceTaskId: anomalyContext.source_task_id || null,
+        service: anomalyContext.service || null,
+        summary: anomalyContext.summary || null,
+        metrics: Array.isArray(anomalyContext.metrics) ? anomalyContext.metrics : [],
+        logs: Array.isArray(anomalyContext.logs) ? anomalyContext.logs : [],
+        errorSamples: Array.isArray(anomalyContext.error_samples) ? anomalyContext.error_samples : [],
+        prefill: anomalyContext.prefill || null,
+        finalizedByPm: Boolean(anomalyContext.finalized_by_pm),
+        finalizedAt: anomalyContext.finalized_at || null,
+        finalizedBy: anomalyContext.finalized_by || null,
+      } : null,
+      pmBusinessContextReview: pmBusinessContextReview ? {
+        completedAt: pmBusinessContextReview.occurred_at || null,
+        completedBy: pmBusinessContextReview.actor_id || null,
+        finalized: true,
+      } : {
+        completedAt: null,
+        completedBy: null,
+        finalized: false,
+      },
     },
     relations: {
       linkedPrs,
       githubSync,
+      parentTask: parentTaskSummary ? {
+        id: parentTaskSummary.task_id,
+        title: parentTaskSummary.title || parentTaskSummary.task_id,
+        stage: parentTaskSummary.current_stage || null,
+        status: inferTaskStatus(parentTaskSummary),
+        owner: formatActor(parentTaskSummary.current_owner),
+        blocked: Boolean(parentTaskSummary.blocked),
+        waitingState: parentTaskSummary.waiting_state || null,
+      } : null,
       childTasks,
     },
     activity: {
@@ -1726,6 +1926,57 @@ async function trySyncCanonicalTask(taskPlatform, store, tenantId, taskId, logge
       ...metadata,
     });
   }
+}
+
+function isResolvedTaskState(state = {}) {
+  return Boolean(state?.closed) || String(state?.current_stage || '').toUpperCase() === STAGES.DONE;
+}
+
+async function maybeReleaseParentAnomalyBlock({
+  store,
+  taskPlatform,
+  tenantId,
+  childTaskId,
+  actorId,
+  actorType = 'user',
+  logger,
+  source = 'http',
+}) {
+  const [childState, childHistory] = await Promise.all([
+    store.getTaskCurrentState(childTaskId, { tenantId }),
+    store.getTaskHistory(childTaskId, { tenantId, limit: 500 }),
+  ]);
+  if (!childState || !isResolvedTaskState(childState)) return null;
+  const childCreated = childHistory.find((event) => event?.event_type === 'task.created');
+  const parentTaskId = childCreated?.payload?.parent_task_id || null;
+  if (!parentTaskId) return null;
+
+  const [parentState, parentHistory] = await Promise.all([
+    store.getTaskCurrentState(parentTaskId, { tenantId }),
+    store.getTaskHistory(parentTaskId, { tenantId, limit: 500 }),
+  ]);
+  if (!parentState?.blocked) return null;
+  const activeBlock = findActiveTaskBlock(parentHistory);
+  if (!activeBlock || activeBlock.payload?.child_task_id !== childTaskId) return null;
+
+  const result = await store.appendEvent({
+    taskId: parentTaskId,
+    tenantId,
+    eventType: 'task.unblocked',
+    actorId: actorId || 'system:anomaly-child-resolution',
+    actorType,
+    idempotencyKey: `anomaly-child:unblock:${parentTaskId}:${childTaskId}:${childState.last_event_id || 'resolved'}`,
+    payload: {
+      child_task_id: childTaskId,
+      reason: `Linked anomaly child task ${childTaskId} reached a resolved state.`,
+      summary: `Parent task resumed after anomaly child task ${childTaskId} was resolved.`,
+      waiting_state: null,
+      next_required_action: 'Parent task may continue through the normal SRE monitoring workflow.',
+    },
+    source,
+  });
+  await trySyncCanonicalTask(taskPlatform, store, tenantId, parentTaskId, logger, { route: 'anomaly_child_parent_unblocked' });
+  return result;
 }
 
 function createAssignmentIdempotencyKey(req, taskId, state, agentId) {
@@ -2282,7 +2533,8 @@ function createAuditApiServer(options = {}) {
       const checkInsMatch = routePath.match(/^\/tasks\/([^/]+)\/check-ins$/);
       const retierMatch = routePath.match(/^\/tasks\/([^/]+)\/retier$/);
       const reassignmentMatch = routePath.match(/^\/tasks\/([^/]+)\/reassignment$/);
-      const sreMonitoringMatch = routePath.match(/^\/tasks\/([^/]+)\/sre-monitoring\/(start|approve)$/);
+      const sreMonitoringMatch = routePath.match(/^\/tasks\/([^/]+)\/sre-monitoring\/(start|approve|anomaly-child-task)$/);
+      const pmBusinessContextMatch = routePath.match(/^\/tasks\/([^/]+)\/pm-business-context$/);
       const architectHandoffMatch = routePath.match(/^\/tasks\/([^/]+)\/architect-handoff$/);
       const engineerSubmissionMatch = routePath.match(/^\/tasks\/([^/]+)\/engineer-submission$/);
       const workflowThreadsMatch = routePath.match(/^\/tasks\/([^/]+)\/workflow-threads$/);
@@ -2291,8 +2543,8 @@ function createAuditApiServer(options = {}) {
       const reviewQuestionsMatch = routePath.match(/^\/tasks\/([^/]+)\/review-questions$/);
       const reviewQuestionActionMatch = routePath.match(/^\/tasks\/([^/]+)\/review-questions\/([^/]+)\/(answers|resolve|reopen)$/);
       const resourceMatch = routePath.match(/^\/tasks\/([^/]+)\/(detail|events|history|state|relationships|observability-summary)$/);
-      if (!summaryMatch && !resourceMatch && !assignmentMatch && !lockMatch && !skillEscalationMatch && !checkInsMatch && !retierMatch && !reassignmentMatch && !sreMonitoringMatch && !architectHandoffMatch && !engineerSubmissionMatch && !workflowThreadsMatch && !workflowThreadActionMatch && !qaResultsMatch && !reviewQuestionsMatch && !reviewQuestionActionMatch) throw createHttpError(404, 'not_found', 'Route not found');
-      const taskId = (summaryMatch || resourceMatch || assignmentMatch || lockMatch || skillEscalationMatch || checkInsMatch || retierMatch || reassignmentMatch || sreMonitoringMatch || architectHandoffMatch || engineerSubmissionMatch || workflowThreadsMatch || workflowThreadActionMatch || qaResultsMatch || reviewQuestionsMatch || reviewQuestionActionMatch)[1];
+      if (!summaryMatch && !resourceMatch && !assignmentMatch && !lockMatch && !skillEscalationMatch && !checkInsMatch && !retierMatch && !reassignmentMatch && !sreMonitoringMatch && !pmBusinessContextMatch && !architectHandoffMatch && !engineerSubmissionMatch && !workflowThreadsMatch && !workflowThreadActionMatch && !qaResultsMatch && !reviewQuestionsMatch && !reviewQuestionActionMatch) throw createHttpError(404, 'not_found', 'Route not found');
+      const taskId = (summaryMatch || resourceMatch || assignmentMatch || lockMatch || skillEscalationMatch || checkInsMatch || retierMatch || reassignmentMatch || sreMonitoringMatch || pmBusinessContextMatch || architectHandoffMatch || engineerSubmissionMatch || workflowThreadsMatch || workflowThreadActionMatch || qaResultsMatch || reviewQuestionsMatch || reviewQuestionActionMatch)[1];
       const resource = assignmentMatch
         ? 'assignment'
         : lockMatch
@@ -2307,6 +2559,8 @@ function createAuditApiServer(options = {}) {
           ? 'reassignment'
           : sreMonitoringMatch
             ? `sre-monitoring:${sreMonitoringMatch[2]}`
+          : pmBusinessContextMatch
+            ? 'pm-business-context'
           : architectHandoffMatch
             ? 'architect-handoff'
         : engineerSubmissionMatch
@@ -2730,6 +2984,12 @@ function createAuditApiServer(options = {}) {
         if (telemetry?.degraded || telemetry?.freshness?.status !== 'fresh') {
           throw createHttpError(409, 'telemetry_not_stable', 'Early approval requires fresh, stable telemetry.');
         }
+        const activeBlock = state.blocked ? findActiveTaskBlock(history) : null;
+        if (activeBlock?.payload?.freeze_scope?.includes('stage_transitions')) {
+          throw createHttpError(409, 'task_blocked_by_anomaly_child', activeBlock.payload?.reason || 'The parent task is blocked by a linked anomaly child task.', {
+            child_task_id: activeBlock.payload?.child_task_id || null,
+          });
+        }
 
         const approval = await store.appendEvent({
           taskId,
@@ -2780,6 +3040,190 @@ function createAuditApiServer(options = {}) {
             approvedAt: approval.event.occurred_at,
             approvedBy: context.actorId,
             nextStage: STAGES.PM_CLOSE_REVIEW,
+          },
+        }, requestId);
+      }
+      if (resource === 'sre-monitoring:anomaly-child-task' && req.method === 'POST') {
+        assertSreMonitoringEnabled(runtimeOptions);
+        assertChildTaskCreationEnabled(runtimeOptions);
+        if (!canManageSreMonitoring(context)) throw createHttpError(403, 'forbidden', 'Only SRE/admin may create anomaly child tasks.');
+        await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, options: runtimeOptions });
+        const [state, history, relationships, telemetry] = await Promise.all([
+          store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
+          store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 500 }),
+          typeof store.getTaskRelationships === 'function' ? store.getTaskRelationships(taskId, { tenantId: context.tenantId }) : Promise.resolve({}),
+          typeof store.getTaskObservabilitySummary === 'function' ? store.getTaskObservabilitySummary(taskId, { tenantId: context.tenantId }) : Promise.resolve(null),
+        ]);
+        if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        if (state.current_stage !== STAGES.SRE_MONITORING) {
+          throw createHttpError(409, 'invalid_stage', 'Monitoring anomaly child tasks can only be created while the parent task is in SRE monitoring.', { current_stage: state.current_stage });
+        }
+
+        const summary = summarizeTaskForDetail(taskId, state, history);
+        const monitoring = deriveSreMonitoringProjection({ taskId, summary, history, relationships, telemetry });
+        const body = validateMonitoringAnomalyChildTaskBody(await parseJson(req), {
+          parentTaskId: taskId,
+          parentTitle: summary.title,
+          telemetry,
+          monitoring,
+        });
+        const childTaskId = `TSK-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+        const occurredAt = new Date().toISOString();
+
+        const created = await store.appendEvent({
+          taskId: childTaskId,
+          tenantId: context.tenantId,
+          eventType: 'task.created',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `anomaly-child:create:${taskId}:${childTaskId}`,
+          occurredAt,
+          payload: {
+            title: body.title,
+            business_context: body.business_context,
+            acceptance_criteria: body.acceptance_criteria,
+            definition_of_done: body.definition_of_done,
+            priority: 'P0',
+            task_type: body.task_type,
+            initial_stage: STAGES.BACKLOG,
+            assignee: body.assignee,
+            parent_task_id: taskId,
+            waiting_state: 'pm_business_context_required',
+            next_required_action: 'PM must review and complete the machine-generated business context before Architect details begin.',
+            anomaly_context: {
+              machine_generated: true,
+              source_task_id: taskId,
+              service: body.service,
+              summary: body.anomaly_summary,
+              metrics: body.metrics,
+              logs: body.logs,
+              error_samples: body.error_samples,
+              prefill: body.prefill,
+            },
+          },
+          source: 'http',
+        });
+        await store.appendEvent({
+          taskId: childTaskId,
+          tenantId: context.tenantId,
+          eventType: 'task.priority_changed',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `anomaly-child:priority:${childTaskId}`,
+          occurredAt,
+          payload: {
+            priority: 'P0',
+            previous_priority: null,
+            reason: 'monitoring_anomaly_child_default',
+            summary: `Priority elevated to P0 because ${childTaskId} was created from a live monitoring anomaly.`,
+            waiting_state: 'pm_business_context_required',
+            next_required_action: 'PM must review and complete the machine-generated business context before Architect details begin.',
+          },
+          source: 'http',
+        });
+        await trySyncCanonicalTask(taskPlatform, store, context.tenantId, childTaskId, logger, { route: 'anomaly_child_task_create' });
+        await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.child_link_added',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `anomaly-child:link:${taskId}:${childTaskId}`,
+          occurredAt,
+          payload: {
+            child_task_id: childTaskId,
+            relationship_type: 'monitoring_anomaly',
+            service: body.service,
+            summary: body.anomaly_summary,
+          },
+          source: 'http',
+        });
+        await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.blocked',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `anomaly-child:block:${taskId}:${childTaskId}`,
+          occurredAt,
+          payload: {
+            blocker_type: 'child_task',
+            child_task_id: childTaskId,
+            waiting_state: 'child_task_investigation',
+            reason: `Linked anomaly child task ${childTaskId} must be resolved before the parent can continue.`,
+            summary: `Parent task paused for anomaly investigation in ${body.service}.`,
+            next_required_action: 'Track the linked child task investigation. Parent comments and review remain available, but stage changes and closure should stay paused until the child is resolved.',
+            freeze_scope: ['stage_transitions', 'closure'],
+            viewable: true,
+            commentable: true,
+          },
+          source: 'http',
+        });
+        await trySyncCanonicalTask(taskPlatform, store, context.tenantId, taskId, logger, { route: 'anomaly_child_task_parent_blocked' });
+
+        return sendJson(res, 201, {
+          success: true,
+          data: {
+            parentTaskId: taskId,
+            childTaskId,
+            createdAt: created.event.occurred_at,
+            priority: 'P0',
+            status: STAGES.BACKLOG,
+            waitingState: 'pm_business_context_required',
+          },
+        }, requestId);
+      }
+      if (resource === 'pm-business-context' && req.method === 'POST') {
+        if (!canCompletePmBusinessContext(context)) throw createHttpError(403, 'forbidden', 'Only PM/admin may complete machine-generated business context.');
+        await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, options: runtimeOptions });
+        const body = validatePmBusinessContextCompletionBody(await parseJson(req));
+        const [state, history] = await Promise.all([
+          store.getTaskCurrentState(taskId, { tenantId: context.tenantId }),
+          store.getTaskHistory(taskId, { tenantId: context.tenantId, limit: 500 }),
+        ]);
+        if (!state) throw createHttpError(404, 'task_not_found', 'Task not found', { task_id: taskId });
+        if (state.current_stage !== STAGES.BACKLOG) {
+          throw createHttpError(409, 'invalid_stage', 'PM business context review can only be completed while the anomaly child task is in Backlog.', { current_stage: state.current_stage });
+        }
+        if (state.waiting_state !== 'pm_business_context_required') {
+          throw createHttpError(409, 'pm_business_context_not_required', 'This task is not currently waiting on PM business context review.');
+        }
+        if (findLatestPmBusinessContextCompletion(history)) {
+          throw createHttpError(409, 'pm_business_context_already_completed', 'PM business context review has already been completed for this task.');
+        }
+        const createdEvent = history.find((event) => event?.event_type === 'task.created');
+        const anomalyContext = createdEvent?.payload?.anomaly_context || null;
+        const finalizedAt = new Date().toISOString();
+        const result = await store.appendEvent({
+          taskId,
+          tenantId: context.tenantId,
+          eventType: 'task.pm_business_context_completed',
+          actorId: context.actorId,
+          actorType: 'user',
+          idempotencyKey: `pm-business-context:${taskId}:${state.last_event_id || 'initial'}`,
+          payload: {
+            business_context: body.business_context,
+            completed_by: context.actorId,
+            completed_at: finalizedAt,
+            waiting_state: null,
+            next_required_action: 'Architect can begin detailing the anomaly child task.',
+            anomaly_context: anomalyContext ? {
+              ...anomalyContext,
+              finalized_by_pm: true,
+              finalized_by: context.actorId,
+              finalized_at: finalizedAt,
+            } : null,
+          },
+          source: 'http',
+        });
+        await trySyncCanonicalTask(taskPlatform, store, context.tenantId, taskId, logger, { route: 'pm_business_context_complete' });
+        return sendJson(res, 200, {
+          success: true,
+          data: {
+            taskId,
+            completedAt: result.event.occurred_at,
+            completedBy: context.actorId,
+            nextAction: 'Architect can begin detailing the anomaly child task.',
           },
         }, requestId);
       }
@@ -3026,6 +3470,8 @@ function createAuditApiServer(options = {}) {
         const summary = summarizeTaskForDetail(taskId, state, initialHistory);
         const childTaskIds = Array.isArray(relationships?.child_task_ids) ? relationships.child_task_ids : [];
         const taskSummaryById = new Map((taskSummaries || []).map((item) => [item.task_id, item]));
+        const createdEvent = initialHistory.find((event) => event.event_type === 'task.created');
+        const parentTaskId = createdEvent?.payload?.parent_task_id || null;
         const childTaskSummaries = childTaskIds.map((childTaskId) => taskSummaryById.get(childTaskId) || {
           task_id: childTaskId,
           title: childTaskId,
@@ -3034,6 +3480,14 @@ function createAuditApiServer(options = {}) {
           blocked: false,
           closed: false,
         });
+        const parentTaskSummary = parentTaskId ? (taskSummaryById.get(parentTaskId) || {
+          task_id: parentTaskId,
+          title: parentTaskId,
+          current_stage: null,
+          current_owner: null,
+          blocked: false,
+          closed: false,
+        }) : null;
         const result = buildTaskDetailViewModel({
           taskId,
           summary,
@@ -3043,6 +3497,7 @@ function createAuditApiServer(options = {}) {
           timelinePageInfo: buildPaginatedHistoryResponse(timelineHistory, limit).page_info,
           telemetry: telemetry ? toTelemetryResponse(telemetry, context) : null,
           childTaskSummaries,
+          parentTaskSummary,
           context,
         });
         logger.info({ feature: 'ff_audit_foundation', action: 'audit_access', outcome: 'success', request_id: requestId, method: req.method, path: url.pathname, tenant_id: context.tenantId, actor_id: context.actorId, task_id: taskId, resource: 'task_detail', duration_ms: Date.now() - startedAt });
@@ -3052,6 +3507,7 @@ function createAuditApiServer(options = {}) {
       if (resource === 'events' && req.method === 'POST') {
         requirePermission(context, 'events:write');
         const body = await parseJson(req);
+        assertNoRestrictedAnomalyWorkflowEventWrite(context, body.eventType);
         if (!isTaskLockEventType(body.eventType) && body.eventType !== 'task.created') {
           await assertTaskUnlockedForMutation({ store, taskId, tenantId: context.tenantId, actorId: context.actorId, resource, eventType: body.eventType, payload: body.payload, requestBody: body, options: runtimeOptions });
         }
@@ -3100,6 +3556,7 @@ function createAuditApiServer(options = {}) {
             'task.reassigned',
             'task.unassigned',
             'task.priority_changed',
+            'task.pm_business_context_completed',
           ].includes(body.eventType)) {
             await trySyncCanonicalTask(taskPlatform, store, context.tenantId, taskId, logger, { event_type: body.eventType });
           }
@@ -3112,6 +3569,28 @@ function createAuditApiServer(options = {}) {
               actorType: body.actorType || 'user',
               source: body.source || 'http',
               idempotencyKey: `lock-release:${taskId}:${result.event.event_id}:stage-transition`,
+            });
+            await maybeReleaseParentAnomalyBlock({
+              store,
+              taskPlatform,
+              tenantId: context.tenantId,
+              childTaskId: taskId,
+              actorId: body.actorId || context.actorId,
+              actorType: body.actorType || 'user',
+              logger,
+              source: body.source || 'http',
+            });
+          }
+          if (body.eventType === 'task.closed') {
+            await maybeReleaseParentAnomalyBlock({
+              store,
+              taskPlatform,
+              tenantId: context.tenantId,
+              childTaskId: taskId,
+              actorId: body.actorId || context.actorId,
+              actorType: body.actorType || 'user',
+              logger,
+              source: body.source || 'http',
             });
           }
           logger.info({ feature: 'ff_audit_foundation', action: 'audit_access', outcome: 'success', request_id: requestId, method: req.method, path: url.pathname, tenant_id: context.tenantId, actor_id: context.actorId, task_id: taskId, resource: 'events', duration_ms: Date.now() - startedAt });

--- a/lib/audit/store.js
+++ b/lib/audit/store.js
@@ -41,6 +41,16 @@ function lastQaResultFromHistory(history = []) {
   return history.find((event) => event?.event_type === 'task.qa_result_recorded') || null;
 }
 
+function lastPmBusinessContextCompletedFromHistory(history = []) {
+  return history.find((event) => event?.event_type === 'task.pm_business_context_completed') || null;
+}
+
+function findActiveFreezeBlock(history = []) {
+  const latestUnblockedIndex = history.findIndex((event) => event?.event_type === 'task.unblocked');
+  const candidateHistory = latestUnblockedIndex === -1 ? history : history.slice(0, latestUnblockedIndex);
+  return candidateHistory.find((event) => event?.event_type === 'task.blocked' && Array.isArray(event?.payload?.freeze_scope) && event.payload.freeze_scope.length) || null;
+}
+
 function createAdapterBackedPostgresStore(options = {}) {
   const pool = options.pool;
   async function appendEvent(input) {
@@ -509,13 +519,22 @@ function createAuditStore(options = {}) {
         const state = await store.getTaskCurrentState(input.taskId, { tenantId: input.tenantId });
         const fromStage = state?.current_stage || STAGES.BACKLOG;
         const toStage = input.payload?.to_stage;
+        const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
+        const activeFreezeBlock = state?.blocked ? findActiveFreezeBlock(history) : null;
 
         if (!toStage) {
           throw new Error('to_stage is required for task.stage_changed events');
         }
 
+        if (activeFreezeBlock?.payload?.freeze_scope?.includes('stage_transitions')) {
+          throw new WorkflowError(activeFreezeBlock.payload?.reason || 'Task stage changes are blocked until the active blocker is resolved.');
+        }
+
+        if (state?.waiting_state === 'pm_business_context_required' && !lastPmBusinessContextCompletedFromHistory(history)) {
+          throw new WorkflowError('PM must complete the machine-generated business context before architect work can begin.');
+        }
+
         if (fromStage === STAGES.ARCHITECT_REVIEW && toStage === STAGES.TECHNICAL_SPEC) {
-          const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
           const questions = deriveReviewQuestions(history);
           if (questions.summary.unresolvedBlockingCount > 0) {
             throw new WorkflowError('Architect Review cannot be completed while blocking review questions remain unresolved.');
@@ -527,7 +546,6 @@ function createAuditStore(options = {}) {
           && fromStage === STAGES.TECHNICAL_SPEC
           && (toStage === STAGES.IMPLEMENTATION || toStage === STAGES.IN_PROGRESS)
         ) {
-          const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
           const handoff = lastArchitectHandoffFromHistory(history);
           if (!handoff || !handoff.payload?.ready_for_engineering) {
             throw new WorkflowError('Implementation cannot begin until the architect handoff is submitted and marked ready for engineering.');
@@ -539,7 +557,6 @@ function createAuditStore(options = {}) {
           && [STAGES.IMPLEMENTATION, STAGES.IN_PROGRESS].includes(fromStage)
           && toStage === STAGES.QA_TESTING
         ) {
-          const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
           const submission = lastEngineerSubmissionFromHistory(history);
           if (!submission || (!submission.payload?.commit_sha && !submission.payload?.pr_url)) {
             throw new WorkflowError('QA handoff cannot be completed until engineer submission includes a commit SHA or PR URL.');
@@ -551,7 +568,6 @@ function createAuditStore(options = {}) {
           && fromStage === STAGES.QA_TESTING
           && [STAGES.IMPLEMENTATION, STAGES.SRE_MONITORING].includes(toStage)
         ) {
-          const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
           const qaResult = lastQaResultFromHistory(history);
           if (!qaResult) {
             throw new WorkflowError('QA stage cannot transition until a structured QA result is recorded.');
@@ -570,11 +586,13 @@ function createAuditStore(options = {}) {
       if (input.eventType === 'task.closed') {
         const state = await store.getTaskCurrentState(input.taskId, { tenantId: input.tenantId });
         const fromStage = state?.current_stage || STAGES.BACKLOG;
+        const history = await store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 });
+        const activeFreezeBlock = state?.blocked ? findActiveFreezeBlock(history) : null;
+        if (activeFreezeBlock?.payload?.freeze_scope?.includes('closure')) {
+          throw new WorkflowError(activeFreezeBlock.payload?.reason || 'Task closure is blocked until the active blocker is resolved.');
+        }
         if (isGitHubSyncEnabled(options)) {
-          const [history, relationships] = await Promise.all([
-            store.getTaskHistory(input.taskId, { tenantId: input.tenantId, limit: 500 }),
-            store.getTaskRelationships(input.taskId, { tenantId: input.tenantId }),
-          ]);
+          const relationships = await store.getTaskRelationships(input.taskId, { tenantId: input.tenantId });
           const blockingPrs = openLinkedPrs(collectLinkedPrs(history, relationships, input.taskId));
           if (blockingPrs.length) {
             const refs = blockingPrs.slice(0, 3).map((pr) => pr.number ? `#${pr.number}` : pr.title || pr.id).join(', ');
@@ -642,6 +660,17 @@ function createAuditStore(options = {}) {
         const currentStage = state?.current_stage || STAGES.BACKLOG;
         if (currentStage !== STAGES.QA_TESTING) {
           throw new WorkflowError('Structured QA results can only be recorded during QA Testing.');
+        }
+      }
+
+      if (input.eventType === 'task.pm_business_context_completed') {
+        const state = await store.getTaskCurrentState(input.taskId, { tenantId: input.tenantId });
+        const currentStage = state?.current_stage || STAGES.BACKLOG;
+        if (currentStage !== STAGES.BACKLOG) {
+          throw new WorkflowError('PM business context completion can only be recorded while the anomaly child task is in Backlog.');
+        }
+        if (state?.waiting_state !== 'pm_business_context_required') {
+          throw new WorkflowError('PM business context completion is only valid when PM business context review is required.');
         }
       }
 

--- a/src/app/App.jsx
+++ b/src/app/App.jsx
@@ -308,6 +308,14 @@ function formatBlockedStateLabel(blockedState, fallbackStatus) {
   return 'Active';
 }
 
+function formatFreezeScopeLabels(freezeScope = []) {
+  return freezeScope.map((item) => {
+    if (item === 'stage_transitions') return 'Stage changes paused';
+    if (item === 'closure') return 'Closure paused';
+    return String(item || '').trim();
+  }).filter(Boolean);
+}
+
 function renderBlockerMeta(blocker = {}) {
   const entries = [
     blocker.source ? `Source: ${blocker.source}` : null,
@@ -464,6 +472,34 @@ function normalizeSreApprovalDraft(monitoring = {}) {
   };
 }
 
+function normalizeMonitoringAnomalyChildDraft(detail = {}) {
+  const monitoring = detail?.context?.sreMonitoring || {};
+  const telemetrySummary = detail?.telemetry?.summary || {};
+  const anomalyContext = detail?.context?.anomalyChildTask || {};
+  const prefill = anomalyContext.prefill || {};
+  const firstSignal = Object.entries(telemetrySummary).find(([, value]) => value != null && value !== '');
+  const defaultMetric = firstSignal ? `${firstSignal[0]}: ${String(firstSignal[1])}` : '';
+  const logsLink = monitoring.telemetry?.drilldowns?.logs || '';
+  const metricsLink = monitoring.telemetry?.drilldowns?.metrics || '';
+  const tracesLink = monitoring.telemetry?.drilldowns?.traces || '';
+  return {
+    title: anomalyContext.summary
+      ? `Investigate ${anomalyContext.service || 'production'} anomaly for ${detail?.task?.id || 'task'}`
+      : `Investigate ${monitoring.architectMonitoringSpec?.service || 'production'} anomaly for ${detail?.task?.id || 'task'}`,
+    service: anomalyContext.service || prefill.service || monitoring.architectMonitoringSpec?.service || '',
+    anomalySummary: anomalyContext.summary || prefill.anomalySummary || (detail?.summary?.nextAction?.label ? `Follow up on ${detail.summary.nextAction.label.toLowerCase()}.` : ''),
+    metrics: anomalyContext.metrics?.length ? anomalyContext.metrics.join('\n') : Array.isArray(prefill.metrics) && prefill.metrics.length ? prefill.metrics.join('\n') : defaultMetric,
+    logs: anomalyContext.logs?.length ? anomalyContext.logs.join('\n') : Array.isArray(prefill.logs) && prefill.logs.length ? prefill.logs.join('\n') : logsLink,
+    errorSamples: anomalyContext.errorSamples?.length ? anomalyContext.errorSamples.join('\n') : Array.isArray(prefill.errorSamples) && prefill.errorSamples.length ? prefill.errorSamples.join('\n') : [metricsLink, tracesLink].filter(Boolean).join('\n'),
+  };
+}
+
+function normalizePmBusinessContextDraft(detail = {}) {
+  return {
+    businessContext: detail?.context?.businessContext || '',
+  };
+}
+
 function splitTextareaLines(value) {
   return String(value || '')
     .split(/\n+/)
@@ -555,6 +591,10 @@ function canManageReassignmentGhosting(tokenClaims) {
 
 function canManageSreMonitoring(tokenClaims) {
   return hasAnyRole(tokenClaims, ['sre', 'admin']);
+}
+
+function canCompletePmBusinessContext(tokenClaims) {
+  return hasAnyRole(tokenClaims, ['pm', 'admin']);
 }
 
 function canAnswerReviewQuestion(tokenClaims) {
@@ -661,6 +701,10 @@ export function App() {
   const [sreMonitoringStartStatus, setSreMonitoringStartStatus] = React.useState({ kind: 'idle', message: '' });
   const [sreApprovalDraft, setSreApprovalDraft] = React.useState(() => normalizeSreApprovalDraft());
   const [sreApprovalStatus, setSreApprovalStatus] = React.useState({ kind: 'idle', message: '' });
+  const [monitoringAnomalyChildDraft, setMonitoringAnomalyChildDraft] = React.useState(() => normalizeMonitoringAnomalyChildDraft());
+  const [monitoringAnomalyChildStatus, setMonitoringAnomalyChildStatus] = React.useState({ kind: 'idle', message: '' });
+  const [pmBusinessContextDraft, setPmBusinessContextDraft] = React.useState(() => normalizePmBusinessContextDraft());
+  const [pmBusinessContextStatus, setPmBusinessContextStatus] = React.useState({ kind: 'idle', message: '' });
   const [lifecycleStatus, setLifecycleStatus] = React.useState({ kind: 'idle', message: '', taskId: null });
   const [sreFindingDraft, setSreFindingDraft] = React.useState('');
   const [dragState, setDragState] = React.useState({ taskId: null, overStage: '' });
@@ -753,6 +797,8 @@ export function App() {
       setQaResultDraft(normalizeQaResultDraft(model.detail?.context?.qaResults?.latest));
       setSreMonitoringStartDraft(normalizeSreMonitoringStartDraft(model.detail?.context?.sreMonitoring));
       setSreApprovalDraft(normalizeSreApprovalDraft(model.detail?.context?.sreMonitoring));
+      setMonitoringAnomalyChildDraft(normalizeMonitoringAnomalyChildDraft(model.detail));
+      setPmBusinessContextDraft(normalizePmBusinessContextDraft(model.detail));
       setSreFindingDraft('');
       setHistoryLoadMoreState({ kind: 'idle', message: '' });
 
@@ -771,6 +817,8 @@ export function App() {
         setQaResultStatus({ kind: 'idle', message: '' });
         setSreMonitoringStartStatus({ kind: 'idle', message: '' });
         setSreApprovalStatus({ kind: 'idle', message: '' });
+        setMonitoringAnomalyChildStatus({ kind: 'idle', message: '' });
+        setPmBusinessContextStatus({ kind: 'idle', message: '' });
         setLifecycleStatus({ kind: 'idle', message: '', taskId: null });
       }
     }
@@ -960,6 +1008,13 @@ export function App() {
   const canSubmitQaResult = qaStageEnabled && hasAnyRole(tokenClaims, ['qa', 'admin', 'contributor']);
   const sreMonitoring = model.kind === 'detail' ? (model.detail?.context?.sreMonitoring || null) : null;
   const sreMonitoringEnabled = model.kind === 'detail' && model.detail?.task?.stage === 'SRE_MONITORING' && canManageSreMonitoring(tokenClaims);
+  const canCreateMonitoringAnomalyChildTask = sreMonitoringEnabled;
+  const pmBusinessContextRequired = model.kind === 'detail'
+    && model.detail?.task?.stage === 'BACKLOG'
+    && model.detail?.context?.pmBusinessContextReview?.finalized === false
+    && Boolean(model.detail?.context?.anomalyChildTask)
+    && Boolean(model.detail?.relations?.parentTask);
+  const canSubmitPmBusinessContext = model.kind === 'detail' && canCompletePmBusinessContext(tokenClaims) && model.detail?.task?.stage === 'BACKLOG' && pmBusinessContextRequired;
   const workflowThreadNotificationTargets = defaultWorkflowNotificationTargets(workflowThreadDraft.commentType, workflowThreadDraft.blocking);
   const latestQaResult = model.kind === 'detail' ? (model.detail?.context?.qaResults?.latest || null) : null;
   const latestFailedQa = model.kind === 'detail' ? (model.detail?.context?.qaResults?.items || []).find((item) => item.outcome === 'fail') || null : null;
@@ -1236,6 +1291,44 @@ export function App() {
       setSreApprovalStatus({ kind: 'error', message: error?.message || 'SRE approval failed.' });
     }
   }, [reloadTask, routeTaskId, sreApprovalDraft, taskClient]);
+
+  const submitMonitoringAnomalyChildTask = React.useCallback(async (event) => {
+    event.preventDefault();
+    if (!routeTaskId) return;
+    setMonitoringAnomalyChildStatus({ kind: 'loading', message: 'Creating anomaly child task…' });
+    try {
+      const result = await taskClient.createMonitoringAnomalyChildTask(routeTaskId, {
+        title: monitoringAnomalyChildDraft.title,
+        service: monitoringAnomalyChildDraft.service,
+        anomalySummary: monitoringAnomalyChildDraft.anomalySummary,
+        metrics: splitTextareaLines(monitoringAnomalyChildDraft.metrics),
+        logs: splitTextareaLines(monitoringAnomalyChildDraft.logs),
+        errorSamples: splitTextareaLines(monitoringAnomalyChildDraft.errorSamples),
+      });
+      await reloadTask();
+      setMonitoringAnomalyChildStatus({
+        kind: 'success',
+        message: `Anomaly child task ${result?.data?.childTaskId || 'created'} linked to the parent and routed back to PM context review.`,
+      });
+    } catch (error) {
+      setMonitoringAnomalyChildStatus({ kind: 'error', message: error?.message || 'Monitoring anomaly child task creation failed.' });
+    }
+  }, [monitoringAnomalyChildDraft, reloadTask, routeTaskId, taskClient]);
+
+  const submitPmBusinessContext = React.useCallback(async (event) => {
+    event.preventDefault();
+    if (!routeTaskId) return;
+    setPmBusinessContextStatus({ kind: 'loading', message: 'Finalizing PM business context…' });
+    try {
+      await taskClient.completePmBusinessContext(routeTaskId, {
+        businessContext: pmBusinessContextDraft.businessContext,
+      });
+      await reloadTask();
+      setPmBusinessContextStatus({ kind: 'success', message: 'PM business context review completed. Architect work can now begin.' });
+    } catch (error) {
+      setPmBusinessContextStatus({ kind: 'error', message: error?.message || 'PM business context review failed.' });
+    }
+  }, [pmBusinessContextDraft.businessContext, reloadTask, routeTaskId, taskClient]);
 
   const handleSignIn = React.useCallback(async (event) => {
     event.preventDefault();
@@ -2052,6 +2145,79 @@ export function App() {
             </div>
           </section>
 
+          {(model.detail?.relations?.parentTask || model.detail?.relations?.childTasks?.length || model.detail?.context?.anomalyChildTask || model.detail?.blockers?.some((blocker) => blocker.childTaskId)) ? (
+            <section className="detail-card detail-card--full" aria-label="Anomaly lineage and blocking">
+              <h2>Anomaly lineage</h2>
+              {model.detail?.relations?.parentTask ? (
+                <div className="review-question-note">
+                  <span>Created from parent monitoring anomaly</span>
+                  <p><strong>{model.detail.relations.parentTask.title}</strong></p>
+                  <p className="task-list-meta">
+                    {model.detail.relations.parentTask.id} · {model.detail.relations.parentTask.stage || 'No stage'} · {formatStatusLabel(model.detail.relations.parentTask.status)}
+                    {model.detail.relations.parentTask.blocked ? ' · parent currently blocked' : ''}
+                  </p>
+                  {model.detail.context?.pmBusinessContextReview?.finalized ? (
+                    <p className="task-list-meta">PM finalized business context at {model.detail.context.pmBusinessContextReview.completedAt || 'unknown time'} by {model.detail.context.pmBusinessContextReview.completedBy || 'unknown actor'}.</p>
+                  ) : (
+                    <p className="task-list-meta">PM review is still required before architect detail work can begin.</p>
+                  )}
+                </div>
+              ) : null}
+              {model.detail?.blockers?.filter((blocker) => blocker.childTaskId).map((blocker) => (
+                <div className="review-question-note" key={blocker.id}>
+                  <span>Blocked by anomaly child task</span>
+                  <p><strong>{blocker.childTask?.title || blocker.label}</strong></p>
+                  {blocker.childTask ? (
+                    <p className="task-list-meta">
+                      {blocker.childTask.id} · {blocker.childTask.stage || 'No stage'} · {formatStatusLabel(blocker.childTask.status)} · {blocker.childTask.owner?.label || 'Unassigned'}
+                      {blocker.childTask.waitingState ? ` · ${blocker.childTask.waitingState}` : ''}
+                    </p>
+                  ) : null}
+                  {blocker.reason ? <p>{blocker.reason}</p> : null}
+                  {blocker.nextRequiredAction ? <p className="task-list-meta">{blocker.nextRequiredAction}</p> : null}
+                  {formatFreezeScopeLabels(blocker.freezeScope).length ? (
+                    <p className="task-list-meta">
+                      {formatFreezeScopeLabels(blocker.freezeScope).join(' · ')} · {blocker.viewable ? 'Viewable' : 'Not viewable'} · {blocker.commentable ? 'Commentable' : 'Comments paused'}
+                    </p>
+                  ) : null}
+                </div>
+              ))}
+              {model.detail?.relations?.childTasks?.length ? (
+                <div className="review-question-note">
+                  <span>Linked anomaly child tasks</span>
+                  <ul className="detail-bullets">
+                    {model.detail.relations.childTasks.map((childTask) => (
+                      <li key={childTask.id}>
+                        <strong>{childTask.title}</strong>
+                        <span>{childTask.id} · {childTask.stage || 'No stage'} · {formatStatusLabel(childTask.status)} · {childTask.owner?.label || 'Unassigned'}{childTask.waitingState ? ` · ${childTask.waitingState}` : ''}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+              {model.detail?.context?.anomalyChildTask ? (
+                <div className="review-question-note">
+                  <span>Machine-generated anomaly context</span>
+                  <p>{model.detail.context.anomalyChildTask.summary || 'No anomaly summary captured.'}</p>
+                  <p className="task-list-meta">
+                    {model.detail.context.anomalyChildTask.service || 'Unknown service'} · Source parent: {model.detail.context.anomalyChildTask.sourceTaskId || 'Unavailable'} · {model.detail.context.anomalyChildTask.finalizedByPm ? 'Finalized by PM' : 'Machine-generated defaults pending PM review'}
+                  </p>
+                  {model.detail.context.anomalyChildTask.finalizedByPm ? (
+                    <p className="task-list-meta">
+                      Finalized at {model.detail.context.anomalyChildTask.finalizedAt || 'unknown time'} by {model.detail.context.anomalyChildTask.finalizedBy || 'unknown actor'}.
+                    </p>
+                  ) : null}
+                  <h3>Metrics</h3>
+                  {renderList(model.detail.context.anomalyChildTask.metrics, 'No metrics captured.')}
+                  <h3>Logs</h3>
+                  {renderList(model.detail.context.anomalyChildTask.logs, 'No logs captured.')}
+                  <h3>Error samples</h3>
+                  {renderList(model.detail.context.anomalyChildTask.errorSamples, 'No error samples captured.')}
+                </div>
+              ) : null}
+            </section>
+          ) : null}
+
           {detailLifecycleItem && isLifecycleStage(detailLifecycleItem.current_stage) ? (
             <section className="detail-card detail-card--full" aria-label="Lifecycle controls">
               <h2>Lifecycle controls</h2>
@@ -2170,6 +2336,32 @@ export function App() {
             <section className="detail-card">
               <h2>Overview</h2>
               <p>{model.detail?.context?.businessContext || model.summary.businessContext || 'Business context is missing.'}</p>
+              {pmBusinessContextRequired ? (
+                <form className="architect-handoff-form" onSubmit={submitPmBusinessContext}>
+                  <div className="review-question-note">
+                    <span>PM business-context re-entry</span>
+                    <p>Finalize the machine-generated business context before architect detail work can begin.</p>
+                  </div>
+                  <label>
+                    Finalized business context
+                    <textarea
+                      value={pmBusinessContextDraft.businessContext}
+                      onChange={(event) => setPmBusinessContextDraft({ businessContext: event.target.value })}
+                      placeholder="Refine the business impact, customer risk, and delivery expectations for this anomaly child task."
+                    />
+                  </label>
+                  <div className="assignment-form__actions">
+                    <button type="submit" disabled={pmBusinessContextStatus.kind === 'loading' || !canSubmitPmBusinessContext}>
+                      {pmBusinessContextStatus.kind === 'loading' ? 'Finalizing…' : 'Complete PM context review'}
+                    </button>
+                  </div>
+                  {pmBusinessContextStatus.kind !== 'idle' ? (
+                    <p className={`assignment-status assignment-status--${pmBusinessContextStatus.kind}`} role={pmBusinessContextStatus.kind === 'error' ? 'alert' : 'status'}>
+                      {pmBusinessContextStatus.message}
+                    </p>
+                  ) : null}
+                </form>
+              ) : null}
               <h3>Acceptance criteria</h3>
               {renderList(model.detail?.context?.acceptanceCriteria || model.summary.acceptanceCriteria, 'Acceptance criteria are missing.')}
               <h3>Definition of Done</h3>
@@ -2852,6 +3044,17 @@ export function App() {
                   ))}
                 </ul>
               ) : <p>No linked PRs yet.</p>}
+              {model.detail?.relations?.parentTask ? (
+                <>
+                  <h3>Linked parent task</h3>
+                  <ul className="detail-bullets">
+                    <li key={model.detail.relations.parentTask.id}>
+                      <strong>{model.detail.relations.parentTask.title}</strong>
+                      <span>{model.detail.relations.parentTask.stage || 'No stage'} · {formatStatusLabel(model.detail.relations.parentTask.status)} · {model.detail.relations.parentTask.owner?.label || 'Unassigned'}</span>
+                    </li>
+                  </ul>
+                </>
+              ) : null}
               {detailPermissions.canViewChildTasks === false ? (
                 <p>Child task relationships are hidden for this session.</p>
               ) : model.detail?.relations?.childTasks?.length ? (
@@ -2864,6 +3067,13 @@ export function App() {
                   ))}
                 </ul>
               ) : <p>No child tasks linked yet.</p>}
+              {model.detail?.context?.anomalyChildTask ? (
+                <div className="review-question-note">
+                  <span>Machine-generated anomaly context</span>
+                  <p>{model.detail.context.anomalyChildTask.summary || 'No anomaly summary captured.'}</p>
+                  <p className="task-list-meta">{model.detail.context.anomalyChildTask.service || 'Unknown service'} · Source parent: {model.detail.context.anomalyChildTask.sourceTaskId || 'Unavailable'}</p>
+                </div>
+              ) : null}
             </section>
 
             <section className="detail-card detail-card--full">
@@ -3487,6 +3697,52 @@ export function App() {
                     </div>
                   ) : null}
 
+                  {canCreateMonitoringAnomalyChildTask ? (
+                    <form className="architect-handoff-form" onSubmit={submitMonitoringAnomalyChildTask}>
+                      <div className="review-question-note">
+                        <span>Create child task from anomaly</span>
+                        <p>These fields are prefilled from monitoring context and remain editable before the child task is created.</p>
+                        <p className="task-list-meta">This defaults the child to P0, links it to the parent, blocks the parent, and routes the child back to PM business-context review.</p>
+                      </div>
+                      <div className="summary-grid architect-handoff-grid">
+                        <label>
+                          Child task title
+                          <input value={monitoringAnomalyChildDraft.title} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, title: event.target.value }))} placeholder="Investigate checkout-api anomaly for TSK-123" />
+                        </label>
+                        <label>
+                          Affected service
+                          <input value={monitoringAnomalyChildDraft.service} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, service: event.target.value }))} placeholder="checkout-api" />
+                        </label>
+                        <label className="architect-handoff-grid__full">
+                          Anomaly summary
+                          <textarea value={monitoringAnomalyChildDraft.anomalySummary} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, anomalySummary: event.target.value }))} placeholder="Describe the production anomaly that should become tracked work." />
+                        </label>
+                        <label>
+                          Metrics
+                          <textarea value={monitoringAnomalyChildDraft.metrics} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, metrics: event.target.value }))} placeholder="One metric signal per line" />
+                        </label>
+                        <label>
+                          Logs
+                          <textarea value={monitoringAnomalyChildDraft.logs} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, logs: event.target.value }))} placeholder="One log sample or drilldown per line" />
+                        </label>
+                        <label>
+                          Error samples
+                          <textarea value={monitoringAnomalyChildDraft.errorSamples} onChange={(event) => setMonitoringAnomalyChildDraft((current) => ({ ...current, errorSamples: event.target.value }))} placeholder="One error sample or trace per line" />
+                        </label>
+                      </div>
+                      <div className="assignment-form__actions">
+                        <button type="submit" disabled={monitoringAnomalyChildStatus.kind === 'loading'}>
+                          {monitoringAnomalyChildStatus.kind === 'loading' ? 'Creating…' : 'Create anomaly child task'}
+                        </button>
+                      </div>
+                      {monitoringAnomalyChildStatus.kind !== 'idle' ? (
+                        <p className={`assignment-status assignment-status--${monitoringAnomalyChildStatus.kind}`} role={monitoringAnomalyChildStatus.kind === 'error' ? 'alert' : 'status'}>
+                          {monitoringAnomalyChildStatus.message}
+                        </p>
+                      ) : null}
+                    </form>
+                  ) : null}
+
                   {sreMonitoringEnabled && sreMonitoring.canStart ? (
                     <form className="architect-handoff-form" onSubmit={submitSreMonitoringStart}>
                       <div className="summary-grid architect-handoff-grid">
@@ -3543,6 +3799,13 @@ export function App() {
                         </p>
                       ) : null}
                     </form>
+                  ) : null}
+                  {sreMonitoringEnabled && !sreMonitoring.canApprove && model.detail?.summary?.blockedState?.isBlocked ? (
+                    <div className="review-question-note">
+                      <span>Approval paused</span>
+                      <p>The parent task is blocked by linked anomaly investigation work.</p>
+                      <p className="task-list-meta">Comments and review remain available, but stage progression stays paused until the child task is resolved or unblocked.</p>
+                    </div>
                   ) : null}
                 </>
               ) : (

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -203,6 +203,30 @@ function installTaskFetchMock({
       }, 201);
     }
 
+    if (url.endsWith('/tasks/TSK-42/sre-monitoring/anomaly-child-task') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          parentTaskId: 'TSK-42',
+          childTaskId: 'TSK-CHILD-ANOM',
+          priority: 'P0',
+          waitingState: 'pm_business_context_required',
+        },
+      }, 201);
+    }
+
+    if (url.endsWith('/tasks/TSK-42/pm-business-context') && init?.method === 'POST') {
+      return createJsonResponse({
+        success: true,
+        data: {
+          taskId: 'TSK-42',
+          completedAt: '2026-04-01T19:00:00.000Z',
+          completedBy: 'pm-1',
+          nextAction: 'Architect can begin detailing the anomaly child task.',
+        },
+      }, 200);
+    }
+
     if (url.includes('/tasks/TSK-42/detail')) {
       if (detailStatus !== 200) {
         return createJsonResponse({
@@ -684,7 +708,7 @@ describe('Task browser runtime coverage', () => {
     expect(screen.getByText('Server-rendered technical spec')).toBeInTheDocument();
     expect(screen.getByText('Server-rendered monitoring spec')).toBeInTheDocument();
     expect(screen.getByText('feat: task detail')).toBeInTheDocument();
-    expect(screen.getByText(/Triage queue drift/)).toBeInTheDocument();
+    expect(screen.getAllByText(/Triage queue drift/).length).toBeGreaterThan(0);
   });
 
   it('renders structured architect handoff details when the backend supplies them', async () => {
@@ -1639,6 +1663,187 @@ describe('Task browser runtime coverage', () => {
     expect(screen.getByText('production')).toBeInTheDocument();
     expect(screen.getByText(/2026\.04\.14-1 · https:\/\/deploy\.example\/releases\/501/)).toBeInTheDocument();
     expect(screen.getByText(/actively in the SRE monitoring stage/i)).toBeInTheDocument();
+  });
+
+  it('creates an anomaly child task from the SRE monitoring panel', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'sre-1',
+        tenant_id: 'tenant-a',
+        roles: ['sre', 'reader'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    const fetchMock = installTaskFetchMock({
+      detailOverride: {
+        task: { stage: 'SRE_MONITORING' },
+        context: {
+          sreMonitoring: {
+            state: 'active',
+            riskLevel: 'low',
+            timeRemainingLabel: '47h remaining',
+            deployment: { environment: 'production', version: '2026.04.15-1', url: 'https://deploy.example/releases/901' },
+            telemetry: {
+              freshness: 'fresh',
+              drilldowns: {
+                metrics: 'https://metrics.example/sre-901',
+                logs: 'https://logs.example/sre-901',
+                traces: 'https://traces.example/sre-901',
+              },
+            },
+            architectMonitoringSpec: { service: 'checkout-api' },
+          },
+        },
+      },
+    });
+    window.history.pushState({}, '', '/tasks/TSK-42');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    expect(screen.getByText('Create child task from anomaly')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Anomaly summary'), { target: { value: 'Checkout 5xx errors spiked after deployment.' } });
+    fireEvent.change(screen.getByLabelText('Metrics'), { target: { value: '5xx_rate: 8%' } });
+    fireEvent.change(screen.getByLabelText('Logs'), { target: { value: 'checkout-api pod restart loop' } });
+    fireEvent.change(screen.getByLabelText('Error samples'), { target: { value: 'TimeoutError at /checkout' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create anomaly child task' }));
+
+    await screen.findByText(/Anomaly child task TSK-CHILD-ANOM linked to the parent/i);
+    const childTaskRequest = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith('/tasks/TSK-42/sre-monitoring/anomaly-child-task') && init?.method === 'POST');
+    expect(childTaskRequest).toBeTruthy();
+    expect(JSON.parse(String(childTaskRequest?.[1]?.body))).toMatchObject({
+      service: 'checkout-api',
+      anomalySummary: 'Checkout 5xx errors spiked after deployment.',
+      metrics: ['5xx_rate: 8%'],
+      logs: ['checkout-api pod restart loop'],
+      errorSamples: ['TimeoutError at /checkout'],
+    });
+  });
+
+  it('shows strong anomaly lineage UX and lets PM finalize business context on the child task', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'pm-1',
+        tenant_id: 'tenant-a',
+        roles: ['pm', 'reader'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    const fetchMock = installTaskFetchMock({
+      detailOverride: {
+        task: { id: 'TSK-42', stage: 'BACKLOG', status: 'waiting' },
+        summary: {
+          nextAction: {
+            label: 'PM must review and complete the machine-generated business context before Architect details begin.',
+            source: 'system',
+            overdue: false,
+            waitingOn: 'Pm Business Context Required',
+          },
+          blockedState: { isBlocked: false, label: 'Waiting', waitingOn: 'Pm Business Context Required' },
+        },
+        relations: {
+          parentTask: {
+            id: 'TSK-PARENT-9',
+            title: 'Watch checkout rollout',
+            stage: 'SRE_MONITORING',
+            status: 'blocked',
+            owner: { label: 'sre' },
+            blocked: true,
+            waitingState: 'child_task_investigation',
+          },
+          childTasks: [],
+        },
+        context: {
+          businessContext: '[Machine-generated anomaly context. PM should refine business impact before architect work starts.]',
+          pmBusinessContextReview: {
+            completedAt: null,
+            completedBy: null,
+            finalized: false,
+          },
+          anomalyChildTask: {
+            machineGenerated: true,
+            sourceTaskId: 'TSK-PARENT-9',
+            service: 'checkout-api',
+            summary: 'Checkout latency and 5xx errors spiked after deployment.',
+            metrics: ['5xx_rate: 8%'],
+            logs: ['Log drilldown: https://logs.example/sre-901'],
+            errorSamples: ['Trace drilldown: https://traces.example/sre-901'],
+            finalizedByPm: false,
+            finalizedAt: null,
+            finalizedBy: null,
+          },
+        },
+      },
+    });
+    window.history.pushState({}, '', '/tasks/TSK-42');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    expect(screen.getByRole('heading', { name: 'Anomaly lineage' })).toBeInTheDocument();
+    expect(screen.getByText('Created from parent monitoring anomaly')).toBeInTheDocument();
+    expect(screen.getByText(/Machine-generated defaults pending PM review/i)).toBeInTheDocument();
+    expect(screen.getByText('PM business-context re-entry')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Finalized business context'), {
+      target: { value: 'Checkout revenue risk is elevated. PM validated customer impact and expects architect mitigation planning today.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Complete PM context review' }));
+
+    await screen.findByText(/PM business context review completed/i);
+    const pmContextRequest = fetchMock.mock.calls.find(([url, init]) => String(url).endsWith('/tasks/TSK-42/pm-business-context') && init?.method === 'POST');
+    expect(pmContextRequest).toBeTruthy();
+    expect(JSON.parse(String(pmContextRequest?.[1]?.body))).toMatchObject({
+      businessContext: 'Checkout revenue risk is elevated. PM validated customer impact and expects architect mitigation planning today.',
+    });
+  });
+
+  it('does not show PM business-context re-entry for non-anomaly backlog children', async () => {
+    writeBrowserSessionConfig({
+      apiBaseUrl: '',
+      bearerToken: makeToken({
+        sub: 'pm-1',
+        tenant_id: 'tenant-a',
+        roles: ['pm', 'reader'],
+        exp: makeFutureExp(),
+      }),
+      expiresAt: makeFutureExpiry(),
+    });
+    installTaskFetchMock({
+      detailOverride: {
+        task: { id: 'TSK-42', stage: 'BACKLOG', status: 'waiting' },
+        relations: {
+          parentTask: {
+            id: 'TSK-PARENT-ALT',
+            title: 'Parent task without anomaly context',
+            stage: 'BACKLOG',
+            status: 'waiting',
+            owner: { label: 'pm' },
+            blocked: false,
+            waitingState: null,
+          },
+          childTasks: [],
+        },
+        context: {
+          businessContext: 'Regular parent-linked backlog work.',
+          anomalyChildTask: null,
+          pmBusinessContextReview: {
+            completedAt: null,
+            completedBy: null,
+            finalized: false,
+          },
+        },
+      },
+    });
+    window.history.pushState({}, '', '/tasks/TSK-42');
+    render(<App />);
+
+    await screen.findByRole('heading', { name: 'Wire task detail' });
+    expect(screen.queryByText('PM business-context re-entry')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Finalized business context')).not.toBeInTheDocument();
   });
 
   it('keeps role inbox counts hidden and shows a degraded state when canonical roster loading fails', async () => {

--- a/src/features/task-detail/adapter.browser.js
+++ b/src/features/task-detail/adapter.browser.js
@@ -355,6 +355,20 @@ export function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, get
         body: JSON.stringify(payload),
       });
     },
+    createMonitoringAnomalyChildTask(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/anomaly-child-task`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
+    completePmBusinessContext(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/pm-business-context`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
     fetchAssignableAgents() { return request('/ai-agents'); },
     assignTaskOwner(taskId, agentId) {
       return request(`/tasks/${encodeURIComponent(taskId)}/assignment`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agentId }) });

--- a/src/features/task-detail/adapter.js
+++ b/src/features/task-detail/adapter.js
@@ -357,6 +357,20 @@ function createTaskDetailApiClient({ baseUrl = '', fetchImpl = fetch, getHeaders
         body: JSON.stringify(payload),
       });
     },
+    createMonitoringAnomalyChildTask(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/sre-monitoring/anomaly-child-task`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
+    completePmBusinessContext(taskId, payload) {
+      return request(`/tasks/${encodeURIComponent(taskId)}/pm-business-context`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    },
     fetchAssignableAgents() { return request('/ai-agents'); },
     assignTaskOwner(taskId, agentId) {
       return request(`/tasks/${encodeURIComponent(taskId)}/assignment`, { method: 'PATCH', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agentId }) });

--- a/tests/accessibility/task-assignment.a11y.spec.ts
+++ b/tests/accessibility/task-assignment.a11y.spec.ts
@@ -19,6 +19,7 @@ describe('task assignment accessibility', () => {
     await screen.findByRole('heading', { name: /wire task detail/i });
     await waitFor(() => expect(screen.getByRole('button', { name: /save owner/i })).toBeInTheDocument());
     expect(screen.getByLabelText(/owner/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /assignment/i })).toBeInTheDocument();
 
     const results = await axe.run(container, {
       rules: {

--- a/tests/browser/auth-shell.browser.spec.ts
+++ b/tests/browser/auth-shell.browser.spec.ts
@@ -85,6 +85,7 @@ test.describe('authenticated browser app shell', () => {
     await page.goto('/tasks?view=board', { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: 'Sign in to the workflow app' })).toBeVisible();
     await expect(page).toHaveURL(/\/sign-in\?/);
+    await expect(page.getByLabel('Trusted auth code')).toBeEditable();
 
     await page.getByLabel('Trusted auth code').fill('signed-browser-auth-code');
     await page.getByLabel('API base URL').fill('/api');

--- a/tests/browser/task-detail.browser.spec.ts
+++ b/tests/browser/task-detail.browser.spec.ts
@@ -385,5 +385,6 @@ test.describe('task detail browser verification', () => {
     await expect(page.getByText(/2026\.04\.15-1/)).toBeVisible();
     await expect(page.getByText('PR #901')).toBeVisible();
     await expect(page.getByText('abc1234def5678')).toBeVisible();
+    await expect(page.getByText('47h remaining')).toBeVisible();
   });
 });

--- a/tests/contract/audit-openapi.contract.test.js
+++ b/tests/contract/audit-openapi.contract.test.js
@@ -62,6 +62,8 @@ test('openapi contract documents the live audit routes and auth model', () => {
     '/tasks/{id}/observability-summary:',
     '/tasks/{id}/sre-monitoring/start:',
     '/tasks/{id}/sre-monitoring/approve:',
+    '/tasks/{id}/sre-monitoring/anomaly-child-task:',
+    '/tasks/{id}/pm-business-context:',
     '/metrics:',
     '/projections/process:',
     'BearerAuth:',
@@ -77,6 +79,7 @@ test('openapi contract documents the live audit routes and auth model', () => {
     'processExpiredSreMonitoring',
     'approved_correlation_ids',
     'current_owner',
+    'task.pm_business_context_completed',
     'List projected task summaries with additive owner metadata',
   ]) {
     assert.match(spec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
@@ -121,6 +124,12 @@ test('openapi contract documents the live audit routes and auth model', () => {
     'telemetry',
     'approval',
     'escalation',
+    'pmBusinessContextReview',
+    'finalizedByPm',
+    'freezeScope',
+    'commentable',
+    'childTaskId',
+    'waitingState',
   ]) {
     assert.match(taskDetailSpec, new RegExp(snippet.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
@@ -205,6 +214,59 @@ test('documented endpoints satisfy the runtime contract', async () => {
     assert.equal(summary.event_count, 2);
     assert.equal(summary.access.restricted, true);
     assert.deepEqual(summary.correlation.approved_correlation_ids, ['child:TSK-CONTRACT-1', 'create:TSK-CONTRACT-1']);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-CONTRACT-ANOM/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-CONTRACT-ANOM',
+        payload: { title: 'Contract anomaly task', initial_stage: 'SRE_MONITORING', priority: 'P1' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-CONTRACT-ANOM/sre-monitoring/anomaly-child-task`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...authHeaders(secret, { roles: ['sre', 'reader'] }),
+      },
+      body: JSON.stringify({
+        title: 'Investigate contract anomaly',
+        service: 'checkout-api',
+        anomalySummary: '5xx rate spiked after deployment.',
+        metrics: ['5xx_rate: 8%'],
+        logs: ['checkout-api log sample'],
+        errorSamples: ['TimeoutError'],
+      }),
+    });
+    assert.equal(response.status, 201);
+    const anomalyChild = await response.json();
+    assert.equal(anomalyChild.data.parentTaskId, 'TSK-CONTRACT-ANOM');
+    assert.equal(anomalyChild.data.priority, 'P0');
+
+    response = await fetch(`${baseUrl}/tasks/${anomalyChild.data.childTaskId}/pm-business-context`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...authHeaders(secret, { sub: 'pm-1', roles: ['pm', 'reader'] }),
+      },
+      body: JSON.stringify({
+        businessContext: 'PM validated customer impact and cleared architect follow-up.',
+      }),
+    });
+    assert.equal(response.status, 200);
+
+    response = await fetch(`${baseUrl}/tasks/${anomalyChild.data.childTaskId}/detail`, {
+      headers: authHeaders(secret, { roles: ['reader'] }),
+    });
+    assert.equal(response.status, 200);
+    const detail = await response.json();
+    assert.equal(detail.context.pmBusinessContextReview.finalized, true);
+    assert.equal(detail.context.anomalyChildTask.finalizedByPm, true);
+    assert.equal(detail.relations.parentTask.id, 'TSK-CONTRACT-ANOM');
 
     response = await fetch(`${baseUrl}/metrics`, { headers: authHeaders(secret, { roles: ['admin'] }) });
     assert.equal(response.status, 200);

--- a/tests/e2e/audit-foundation.e2e.test.js
+++ b/tests/e2e/audit-foundation.e2e.test.js
@@ -353,6 +353,103 @@ test('must-have: worker processing materializes expired SRE monitoring escalatio
   });
 });
 
+test('must-have: live monitoring anomalies can become linked child tasks with parent blocking and PM re-entry', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const contributorHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, ['contributor']),
+    };
+    const sreHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, ['sre', 'reader']),
+    };
+    const pmHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, ['pm', 'reader']),
+    };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-E2E-ANOM-1/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-E2E-ANOM-1',
+        payload: { title: 'Live anomaly parent', initial_stage: 'SRE_MONITORING', priority: 'P1' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-ANOM-1/sre-monitoring/anomaly-child-task`, {
+      method: 'POST',
+      headers: sreHeaders,
+      body: JSON.stringify({
+        title: 'Investigate checkout-api anomaly',
+        service: 'checkout-api',
+        anomalySummary: 'Checkout 5xx errors spiked in production.',
+        metrics: ['5xx_rate: 8%'],
+        logs: ['checkout-api pod restart loop'],
+        errorSamples: ['TimeoutError at /checkout'],
+      }),
+    });
+    assert.equal(response.status, 201);
+    const created = await response.json();
+    const childTaskId = created.data.childTaskId;
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-ANOM-1/relationships`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    const relationships = await response.json();
+    assert.deepEqual(relationships.child_task_ids, [childTaskId]);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-ANOM-1/state`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    const parentState = await response.json();
+    assert.equal(parentState.blocked, true);
+    assert.equal(parentState.waiting_state, 'child_task_investigation');
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/state`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    const childState = await response.json();
+    assert.equal(childState.priority, 'P0');
+    assert.equal(childState.assignee, 'pm');
+    assert.equal(childState.waiting_state, 'pm_business_context_required');
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/pm-business-context`, {
+      method: 'POST',
+      headers: pmHeaders,
+      body: JSON.stringify({
+        businessContext: 'PM confirmed customer impact and approved architect follow-up.',
+      }),
+    });
+    assert.equal(response.status, 200);
+
+    for (const [fromStage, toStage] of [
+      ['BACKLOG', 'TODO'],
+      ['TODO', 'IN_PROGRESS'],
+      ['IN_PROGRESS', 'VERIFY'],
+      ['VERIFY', 'DONE'],
+    ]) {
+      response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+        method: 'POST',
+        headers: contributorHeaders,
+        body: JSON.stringify({
+          eventType: 'task.stage_changed',
+          actorType: 'agent',
+          idempotencyKey: `e2e:${childTaskId}:${fromStage}:${toStage}`,
+          payload: { from_stage: fromStage, to_stage: toStage },
+        }),
+      });
+      assert.equal(response.status, 202);
+    }
+
+    response = await fetch(`${baseUrl}/tasks/TSK-E2E-ANOM-1/state`, { headers: authHeaders(secret, ['reader']) });
+    assert.equal(response.status, 200);
+    const unblockedParentState = await response.json();
+    assert.equal(unblockedParentState.blocked, false);
+    assert.equal(unblockedParentState.waiting_state, null);
+  });
+});
+
 test('must-have: feature flag kill switch disables write and read surfaces cleanly', async () => {
   await withServer(async ({ baseUrl, secret }) => {
     let response = await fetch(`${baseUrl}/healthz`);

--- a/tests/property/audit-foundation.property.test.js
+++ b/tests/property/audit-foundation.property.test.js
@@ -18,7 +18,7 @@ function seededRandom(seed) {
   };
 }
 
-const EVENT_TYPES = WORKFLOW_AUDIT_EVENT_TYPES.filter(type => !['task.unassigned', 'task.unblocked', 'task.child_link_removed', 'task.escalation_resolved', 'task.decision_revised', 'task.rollback_recorded', 'task.closed'].includes(type));
+const EVENT_TYPES = WORKFLOW_AUDIT_EVENT_TYPES.filter(type => !['task.unassigned', 'task.unblocked', 'task.child_link_removed', 'task.escalation_resolved', 'task.decision_revised', 'task.rollback_recorded', 'task.closed', 'task.pm_business_context_completed'].includes(type));
 
 function randomChoice(random, items) {
   return items[Math.floor(random() * items.length)];

--- a/tests/security/audit-api.security.test.js
+++ b/tests/security/audit-api.security.test.js
@@ -205,9 +205,22 @@ test('rejects engineer-only delivery mutations when the task has been reassigned
 
 test('rejects SRE monitoring mutations for callers without SRE or admin privileges', async () => {
   await withServer(async ({ baseUrl, secret }) => {
+    const contributorAuth = { authorization: `Bearer ${sign({ sub: 'eng', tenant_id: 'tenant-sec', roles: ['contributor'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
     const readerAuth = { authorization: `Bearer ${sign({ sub: 'reader', tenant_id: 'tenant-sec', roles: ['reader'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
 
-    let response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/sre-monitoring/start`, {
+    let response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...contributorAuth },
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-SEC-SRE',
+        payload: { title: 'Restricted SRE task', initial_stage: 'SRE_MONITORING' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/sre-monitoring/start`, {
       method: 'POST',
       headers: { 'content-type': 'application/json', ...readerAuth },
       body: JSON.stringify({
@@ -229,6 +242,82 @@ test('rejects SRE monitoring mutations for callers without SRE or admin privileg
     });
     assert.equal(response.status, 403);
     assert.equal((await response.json()).error.code, 'forbidden');
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-SRE/sre-monitoring/anomaly-child-task`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...readerAuth },
+      body: JSON.stringify({
+        title: 'Investigate restricted anomaly',
+        service: 'checkout-api',
+        anomalySummary: 'Reader attempted anomaly creation.',
+        metrics: ['5xx_rate: 8%'],
+        logs: ['reader-request log sample'],
+        errorSamples: ['TimeoutError'],
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.equal((await response.json()).error.code, 'forbidden');
+  });
+});
+
+test('rejects generic anomaly-workflow event bypasses for PM completion and parent unblocking', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const contributorAuth = { authorization: `Bearer ${sign({ sub: 'eng', tenant_id: 'tenant-sec', roles: ['contributor'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+    const pmAuth = { authorization: `Bearer ${sign({ sub: 'pm-1', tenant_id: 'tenant-sec', roles: ['pm', 'reader'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+    const sreAuth = { authorization: `Bearer ${sign({ sub: 'sre-1', tenant_id: 'tenant-sec', roles: ['sre', 'reader'], exp: Math.floor(Date.now() / 1000) + 60 }, secret)}` };
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SEC-ANOM/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...contributorAuth },
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-SEC-ANOM',
+        payload: { title: 'Security anomaly parent', initial_stage: 'SRE_MONITORING' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-ANOM/sre-monitoring/anomaly-child-task`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...sreAuth },
+      body: JSON.stringify({
+        title: 'Investigate restricted anomaly',
+        service: 'checkout-api',
+        anomalySummary: 'Security test anomaly',
+        metrics: ['5xx_rate: 8%'],
+        logs: ['security log sample'],
+        errorSamples: ['TimeoutError'],
+      }),
+    });
+    assert.equal(response.status, 201);
+    const { data } = await response.json();
+
+    response = await fetch(`${baseUrl}/tasks/${data.childTaskId}/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...contributorAuth },
+      body: JSON.stringify({
+        eventType: 'task.pm_business_context_completed',
+        actorType: 'user',
+        idempotencyKey: `forbidden-pm-complete:${data.childTaskId}`,
+        payload: { business_context: 'Contributor tried to bypass PM review.' },
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.match(JSON.stringify(await response.json()), /PM\/admin/i);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SEC-ANOM/events`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...contributorAuth },
+      body: JSON.stringify({
+        eventType: 'task.unblocked',
+        actorType: 'user',
+        idempotencyKey: 'forbidden-parent-unblock',
+        payload: { child_task_id: data.childTaskId, reason: 'Manual override' },
+      }),
+    });
+    assert.equal(response.status, 403);
+    assert.match(JSON.stringify(await response.json()), /resolution flow/i);
   });
 });
 

--- a/tests/unit/audit-api.test.js
+++ b/tests/unit/audit-api.test.js
@@ -1990,6 +1990,185 @@ test('auto-escalates expired SRE monitoring windows into human stakeholder revie
   });
 });
 
+test('creates a linked P0 child task from an SRE monitoring anomaly and blocks the parent with PM re-entry context', async () => {
+  await withServer(async ({ baseUrl, secret }) => {
+    const contributorHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['contributor'] }),
+    };
+    const sreHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'sre-1', tenant_id: 'tenant-sre', roles: ['sre', 'reader'] }),
+    };
+    const pmHeaders = {
+      'content-type': 'application/json',
+      ...authHeaders(secret, { sub: 'pm-1', tenant_id: 'tenant-sre', roles: ['pm', 'reader'] }),
+    };
+    const readerHeaders = authHeaders(secret, { tenant_id: 'tenant-sre', roles: ['reader'] });
+
+    let response = await fetch(`${baseUrl}/tasks/TSK-SRE-ANOM-1/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.created',
+        actorType: 'agent',
+        idempotencyKey: 'create:TSK-SRE-ANOM-1',
+        payload: {
+          title: 'Watch checkout rollout',
+          initial_stage: 'SRE_MONITORING',
+          linked_prs: [{
+            id: 'pr-sre-anom-1',
+            number: 503,
+            title: 'feat: rollout checkout',
+            repository: 'wiinc1/engineering-team',
+            merged: true,
+            state: 'closed',
+            merged_at: '2026-04-14T12:00:00.000Z',
+          }],
+        },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-ANOM-1/sre-monitoring/anomaly-child-task`, {
+      method: 'POST',
+      headers: sreHeaders,
+      body: JSON.stringify({
+        title: 'Investigate checkout-api anomaly for TSK-SRE-ANOM-1',
+        service: 'checkout-api',
+        anomalySummary: '5xx rate spiked after deployment.',
+        metrics: ['5xx_rate: 8%', 'latency_p95: 4.2s'],
+        logs: ['checkout-api pod restart loop', 'gateway timeout burst'],
+        errorSamples: ['TimeoutError at POST /checkout'],
+      }),
+    });
+    assert.equal(response.status, 201);
+    const created = await response.json();
+    assert.equal(created.data.parentTaskId, 'TSK-SRE-ANOM-1');
+    assert.equal(created.data.priority, 'P0');
+    assert.equal(created.data.waitingState, 'pm_business_context_required');
+    const childTaskId = created.data.childTaskId;
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-ANOM-1/detail`, {
+      headers: readerHeaders,
+    });
+    assert.equal(response.status, 200);
+    const parentDetail = await response.json();
+    assert.equal(parentDetail.summary.blockedState.label, 'Blocked');
+    assert.equal(parentDetail.summary.blockedState.waitingOn, 'Child task investigation');
+    assert.equal(parentDetail.summary.childStatus.total, 1);
+    assert.equal(parentDetail.relations.childTasks[0].id, childTaskId);
+    assert.equal(parentDetail.blockers[0].freezeScope.join(','), 'stage_transitions,closure');
+    assert.equal(parentDetail.blockers[0].commentable, true);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-ANOM-1/sre-monitoring/approve`, {
+      method: 'POST',
+      headers: sreHeaders,
+      body: JSON.stringify({
+        reason: 'Telemetry is stable.',
+        evidence: ['no new errors'],
+      }),
+    });
+    assert.equal(response.status, 409);
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/detail`, {
+      headers: readerHeaders,
+    });
+    assert.equal(response.status, 200);
+    const childDetail = await response.json();
+    assert.equal(childDetail.task.priority, 'P0');
+    assert.equal(childDetail.summary.owner.label, 'pm');
+    assert.equal(childDetail.summary.nextAction.label, 'PM must review and complete the machine-generated business context before Architect details begin.');
+    assert.equal(childDetail.relations.parentTask.id, 'TSK-SRE-ANOM-1');
+    assert.equal(childDetail.context.anomalyChildTask.service, 'checkout-api');
+    assert.equal(childDetail.context.anomalyChildTask.summary, '5xx rate spiked after deployment.');
+    assert.equal(childDetail.context.pmBusinessContextReview.finalized, false);
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/state`, {
+      headers: readerHeaders,
+    });
+    assert.equal(response.status, 200);
+    const childState = await response.json();
+    assert.equal(childState.priority, 'P0');
+    assert.equal(childState.assignee, 'pm');
+    assert.equal(childState.waiting_state, 'pm_business_context_required');
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'agent',
+        idempotencyKey: `move:${childTaskId}:ARCHITECT_REVIEW:blocked`,
+        payload: { from_stage: 'BACKLOG', to_stage: 'ARCHITECT_REVIEW' },
+      }),
+    });
+    assert.equal(response.status, 400);
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/pm-business-context`, {
+      method: 'POST',
+      headers: pmHeaders,
+      body: JSON.stringify({
+        businessContext: 'PM reviewed the anomaly, confirmed customer impact, and approved architect follow-up.',
+      }),
+    });
+    assert.equal(response.status, 200);
+
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'agent',
+        idempotencyKey: `move:${childTaskId}:TODO`,
+        payload: { from_stage: 'BACKLOG', to_stage: 'TODO' },
+      }),
+    });
+    assert.equal(response.status, 202);
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'agent',
+        idempotencyKey: `move:${childTaskId}:IN_PROGRESS`,
+        payload: { from_stage: 'TODO', to_stage: 'IN_PROGRESS' },
+      }),
+    });
+    assert.equal(response.status, 202);
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'agent',
+        idempotencyKey: `move:${childTaskId}:VERIFY`,
+        payload: { from_stage: 'IN_PROGRESS', to_stage: 'VERIFY' },
+      }),
+    });
+    assert.equal(response.status, 202);
+    response = await fetch(`${baseUrl}/tasks/${childTaskId}/events`, {
+      method: 'POST',
+      headers: contributorHeaders,
+      body: JSON.stringify({
+        eventType: 'task.stage_changed',
+        actorType: 'agent',
+        idempotencyKey: `move:${childTaskId}:DONE`,
+        payload: { from_stage: 'VERIFY', to_stage: 'DONE' },
+      }),
+    });
+    assert.equal(response.status, 202);
+
+    response = await fetch(`${baseUrl}/tasks/TSK-SRE-ANOM-1/detail`, {
+      headers: readerHeaders,
+    });
+    assert.equal(response.status, 200);
+    const unblockedParentDetail = await response.json();
+    assert.equal(unblockedParentDetail.summary.blockedState.label, 'Active');
+    assert.equal(unblockedParentDetail.blockers.length, 0);
+  });
+});
+
 test('supports all documented SRE monitoring feature-flag aliases', async () => {
   await withServer(async ({ baseUrl, secret }) => {
     let response = await fetch(`${baseUrl}/tasks/TSK-SRE-FLAG/sre-monitoring/start`, {

--- a/tests/unit/task-detail-adapter.test.js
+++ b/tests/unit/task-detail-adapter.test.js
@@ -298,10 +298,23 @@ test('task detail client submits SRE monitoring workflow actions to dedicated en
     reason: 'Telemetry stayed stable across the first hour.',
     evidence: ['metrics steady', 'error budget unchanged'],
   });
+  await client.createMonitoringAnomalyChildTask('TSK-91', {
+    title: 'Investigate checkout-api anomaly for TSK-91',
+    service: 'checkout-api',
+    anomalySummary: 'Error rate spiked after deployment.',
+    metrics: ['5xx_rate: 8%'],
+    logs: ['checkout-api pod restart loop'],
+    errorSamples: ['TimeoutError at /checkout'],
+  });
+  await client.completePmBusinessContext('TSK-91', {
+    businessContext: 'PM reviewed the anomaly and confirmed customer impact.',
+  });
 
   assert.deepEqual(calls.map((entry) => entry.url), [
     'http://audit.local/tasks/TSK-91/sre-monitoring/start',
     'http://audit.local/tasks/TSK-91/sre-monitoring/approve',
+    'http://audit.local/tasks/TSK-91/sre-monitoring/anomaly-child-task',
+    'http://audit.local/tasks/TSK-91/pm-business-context',
   ]);
   assert.ok(calls.every((entry) => entry.init.method === 'POST'));
 });


### PR DESCRIPTION
## Summary
Close the remaining SF-015 anomaly-child workflow gaps end to end. This makes parent blocking authoritative in runtime, adds a PM/admin-only business-context completion step, strengthens anomaly prefills from live monitoring context, surfaces lineage/blocking semantics in task detail, and closes generic-event bypasses.

Closes #20.

## Linked Task
- Task: SF-015

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/standards/software-development-standards.md
- Relevant standards areas: workflow invariants, API contracts, task-detail UX, documentation parity, automated verification
- Standards gaps or exceptions: No exceptions; backend, UI, docs, and tests were updated together.

## Required Evidence
- Standards check result: `npm run standards:check` passed
- Lint result: `npm run lint` passed
- Tests: `npm test` passed; `npm run standards:check` passed; `npm run lint` passed
- Test evidence paths: tests/unit/audit-api.test.js, tests/unit/task-detail-adapter.test.js, tests/security/audit-api.security.test.js, tests/e2e/audit-foundation.e2e.test.js, tests/contract/audit-openapi.contract.test.js, tests/property/audit-foundation.property.test.js, src/app/App.test.tsx
- Docs updated: yes
- Doc evidence paths: docs/api/audit-foundation-openapi.yml, docs/api/task-detail-history-telemetry-openapi.yml, docs/runbooks/audit-foundation.md

## Risk and Rollback
- Risk level: medium
- Rollback path: revert commit `457dbac` or revert PR #81 to restore the previous anomaly-child workflow behavior.

## Notes
- Parent blocking now rejects stage progression, SRE approval, and closure until the linked anomaly child resolves.
- PM business-context completion is only supported through the dedicated PM/admin route, and generic event bypasses are rejected.
- Full verification results from `npm test`: unit 96 passed, Vitest 79 passed, contract/integration/e2e/property/performance/security/chaos 51 passed, Playwright 36 passed and 3 skipped.
- The 3 skipped browser tests are existing skips in the Playwright suite, not new failures from this change.
