### PR TITLE
[US-003] Document intake draft workflow

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,158 @@
+# Engineering Team Context
+
+## Glossary
+
+### Software Factory control plane
+
+An internal product for creating, assigning, executing, reviewing, and closing software work across humans and AI agents, with auditability and PM/SRE governance as first-class product behavior.
+
+The Kanban board is one view of the control plane, not the product category.
+
+### Software Factory operator
+
+The primary human user of the Software Factory control plane.
+
+The operator creates the initial task requirements that start delivery work and remains accountable for turning the request into verified, closed software delivery.
+
+This is distinct from a release operator, who executes production release or smoke-test procedures.
+
+### Initial task requirements
+
+The operator-authored intake draft that starts delivery work.
+
+Initial task requirements are not yet an execution-ready contract. The control plane must refine them into an execution-ready task by adding acceptance criteria, dependencies, owner routing, verification requirements, and risk flags before agent implementation begins.
+
+### Task refinement
+
+The pre-execution process that converts initial task requirements into an execution-ready task.
+
+The Product Manager owns task refinement overall. The Architect contributes technical feasibility, implementation constraints, and current-stack guidance. The UX Designer owns user workflow and usability requirements, including interaction flows, accessibility needs, and edge-case user journeys.
+
+Business-domain intent remains owned by the Product Manager. The Software Factory operator approves or corrects the refined task before execution begins.
+
+### Execution-ready task
+
+A refined task that is ready to dispatch for implementation.
+
+An execution-ready task has a selected template tier and all required pre-execution story sections completed for that tier: user story, business context, success metrics, Given-When-Then acceptance criteria, standards alignment, workflow and user journey when required, UX requirements when user-facing, architecture/API/data/security/deployment/observability impacts when applicable, dependencies and risks when required, and required automated evidence.
+
+Implementation outputs such as code, tests, diagrams, runbooks, dashboards, and production validation artifacts belong to delivery and Definition of Done, not pre-execution readiness.
+
+### Specialist delivery workflow
+
+The execution model for an approved execution-ready task.
+
+Delivery is a coordinated workflow of specialist agents rather than a single implementation handoff. The Product Manager produces the story contract, the Architect and UX Designer contribute during refinement, the appropriate Engineer implements, QA verifies functional and regression behavior, and SRE verifies operational readiness before closure.
+
+### Software Factory lifecycle
+
+The canonical domain lifecycle for work in the control plane:
+
+1. Intake Draft
+2. Task Refinement
+3. Operator Approval
+4. Implementation
+5. QA Verification
+6. SRE Verification
+7. Operator Closeout
+
+Board statuses are views over this lifecycle, not the lifecycle itself.
+
+### Operator Approval
+
+The stage where the Software Factory operator approves the full execution contract before implementation begins.
+
+Approval covers refined requirements, scope and non-goals, template tier, agent routing, dependencies, risks, and required verification evidence.
+
+### Progressive autonomy
+
+The product direction for reducing required operator involvement as the Software Factory control plane proves it can refine, route, execute, and verify work reliably.
+
+The operator remains in the approval path until they are comfortable delegating some or all approval decisions to the control plane under explicit policy.
+
+The first candidate for automation is auto-approval of low-risk Simple-tier tasks. A task may bypass explicit operator approval only when it is Simple tier, touches no production authentication, security, or data-model paths, has complete acceptance criteria, has no unresolved dependencies, and has a clear rollback path.
+
+### Operator-trusted autonomous delivery rate
+
+The product's primary success metric.
+
+It measures the percentage of tasks that move from approved or auto-approved refined intake to verified closeout without the Software Factory operator needing to intervene after approval, while still passing QA, SRE, and required evidence gates.
+
+### Operator intervention
+
+An operator action after approval that repairs, clarifies, or completes a workflow the control plane should have handled.
+
+Operator interventions include changing task scope, clarifying missing requirements, resolving agent confusion, restarting failed workflow routing, manually verifying evidence, or deciding whether to accept incomplete work.
+
+Routine status viewing and final closeout acknowledgement do not count as operator intervention.
+
+### Refinement blocking question
+
+A targeted question raised during task refinement when missing or ambiguous requirements prevent the task from becoming execution-ready.
+
+The Product Manager owns consolidating blocking questions for the Software Factory operator. The Architect and UX Designer may contribute blocking questions from technical feasibility, current-stack, workflow, usability, or accessibility concerns.
+
+The control plane must resolve refinement blocking questions before requesting Operator Approval or dispatching implementation.
+
+Refinement blocking questions should be presented one decision cluster at a time. Each cluster should include the recommended answer and the consequence of accepting it.
+
+### Intake-to-execution-ready refinement workflow
+
+The next highest-value product capability for the Software Factory control plane.
+
+This workflow lets the Software Factory operator submit initial task requirements, then coordinates Product Manager, Architect, and UX Designer refinement into a reviewable execution contract with blocking questions, recommended answers, and an approval or auto-approval decision.
+
+### Intake Draft stage
+
+The first stage of a Task in the Software Factory lifecycle.
+
+An Intake Draft is the operator's raw initial task requirements plus minimal metadata. It is not a separate domain object from Task. The same Task ID, task detail surface, and audit trail should carry the work from Intake Draft through refinement, approval, delivery, verification, and closeout.
+
+Refinement fills in the execution contract fields before Operator Approval.
+
+Only raw requirements text is strictly required to create an Intake Draft. Title, priority, urgency, desired outcome, and task type are optional at intake and may be suggested by the Product Manager during refinement.
+
+After an Intake Draft is created, it enters Product Manager refinement automatically. The control plane should create a PM-owned refinement work item or stage assignment, with Architect and UX Designer contribution requests created as needed based on task tier, user-facing impact, and technical ambiguity.
+
+Architect and UX Designer refinement contributions are conditional.
+
+Architect contribution is mandatory for Standard, Complex, or Epic tasks; data-model changes; API changes; production or security paths; and unclear technical feasibility.
+
+UX Designer contribution is mandatory for user-facing changes, role workflow changes, task detail/list/board changes, and accessibility-sensitive flows.
+
+Simple backend or internal changes may skip Architect or UX contribution when the Product Manager documents why the contribution is unnecessary.
+
+Near-term UI work should optimize first for creating Intake Drafts and second for reviewing refined execution contracts.
+
+The current app already has task detail and review surfaces, but intake is inverted because it asks the operator for refined fields before refinement begins.
+
+The broader product direction includes the full Intake-to-execution-ready refinement workflow. The next implementation story should be scoped narrowly to Intake Draft creation: raw requirements text is enough, the Task is persisted in `DRAFT`, PM refinement routing is created, and the draft is visible in task list/detail.
+
+Next implementation story title: Create Intake Drafts From Raw Operator Requirements.
+
+The next implementation story should use the Standard template tier because it changes a user-facing form, API validation, task persistence semantics, PM refinement routing, and task list/detail visibility while excluding the full multi-specialist refinement workflow.
+
+Next implementation story user story: As a Software Factory operator, I want to create an Intake Draft from raw initial requirements, so that the control plane can start PM refinement without requiring me to pre-fill the execution-ready story contract.
+
+Next implementation story must-have acceptance criteria:
+
+1. Given the operator opens task creation, when they enter only raw requirements text and submit, then a Task is created in `DRAFT` as an Intake Draft.
+2. Given optional title, priority, or type are omitted, when the draft is created, then the system stores safe defaults or leaves those fields unset without blocking intake.
+3. Given an Intake Draft is created, when task list or task detail loads, then it is visibly labeled as Intake Draft and its next required action is PM refinement.
+4. Given an Intake Draft is created, when the audit or task history is inspected, then creation and PM refinement routing are recorded without claiming implementation has started.
+
+Next implementation story out of scope: full Product Manager, Architect, and UX Designer refinement generation; auto-approval; implementation dispatch; QA or SRE verification changes; production release automation; and multi-task decomposition.
+
+For the narrow story, PM refinement routing should be recorded as task state metadata and audit/history rather than a separate child task. The target state is `current_owner=pm`, `next_required_action='PM refinement required'`, and a new audit event named `task.refinement_requested`.
+
+For the first Intake Draft implementation, the creation form should collect raw requirements text and an optional title only. Priority, task type, urgency, owner, acceptance criteria, and Definition of Done are refinement outputs unless the operator includes them naturally in the raw requirements text.
+
+If the operator omits a title, the system should use the placeholder title `Untitled intake draft` and include the Task ID in list and detail contexts. The Product Manager can propose the real title during refinement.
+
+Raw requirements text should appear on task detail above refined execution-contract sections, labeled `Operator intake requirements`. It should remain visible after refinement so future agents can compare the refined contract against the operator's original intent.
+
+Raw intake requirements may be revised before Operator Approval, but revisions must be recorded as new audit events rather than silent edits. The original intake text remains preserved in history, and Product Manager refinement must use the latest revision while retaining visibility into earlier revisions.
+
+After Operator Approval, changes to intake requirements are scope-change events rather than intake revisions.
+
+Intake requirement revision is a follow-up capability, not part of the first Intake Draft creation story.

--- a/docs/adr/ADD-2026-04-28-intake-draft-as-task-stage.md
+++ b/docs/adr/ADD-2026-04-28-intake-draft-as-task-stage.md
@@ -1,0 +1,66 @@
+# Architecture Decision Record: Intake Draft Is a Task Stage
+
+**Date:** 2026-04-28
+**Status:** Accepted
+**Deciders:** Software Factory operator, Codex
+
+## Context
+
+The Software Factory control plane starts work from operator-authored initial task requirements. Those requirements are an intake draft, not an execution-ready contract.
+
+The product needs to represent that early intake state without losing continuity as Product Manager, Architect, and UX Designer refinement turns the draft into an execution-ready task.
+
+## Decision
+
+Represent Intake Draft as the first stage of the same Task, not as a separate Intake entity.
+
+The same Task ID, task detail surface, and audit trail carry work from Intake Draft through refinement, approval, implementation, QA verification, SRE verification, and operator closeout.
+
+## Rationale
+
+Keeping intake and delivery on the same Task preserves continuity for the operator and avoids forcing users to reconcile a pre-task intake record with a later delivery task.
+
+It also matches the existing repo direction: `/tasks` creation already records `initial_stage: 'DRAFT'`, and the task platform already centers task history, ownership, and detail views around a Task.
+
+## Consequences
+
+### Positive
+
+- One stable Task ID from intake through closeout.
+- One audit trail for every requirement, refinement, approval, and delivery event.
+- One task detail page can become the control surface for the whole lifecycle.
+- Lower product complexity than introducing an Intake-to-Task conversion flow now.
+
+### Negative
+
+- Task schemas and views must distinguish raw intake fields from refined execution-contract fields.
+- Task lists and board views need clear filtering or labeling so Intake Drafts are not confused with implementation-ready work.
+- Future analytics must avoid treating every created Task as approved delivery demand.
+
+### Neutral
+
+- A separate Intake entity can still be introduced later if the product needs anonymous intake, external submitters, or multi-task decomposition before a Task exists.
+
+## Alternatives Considered
+
+- Separate Intake entity that later becomes one or more Tasks.
+- Keep intake as a UI-only draft before creating any server-side record.
+
+## Related Artifacts
+
+- [CONTEXT.md](/Users/wiinc1/repos/engineering-team/CONTEXT.md)
+- [src/features/task-creation/TaskCreationForm.tsx](/Users/wiinc1/repos/engineering-team/src/features/task-creation/TaskCreationForm.tsx)
+- [lib/audit/http.js](/Users/wiinc1/repos/engineering-team/lib/audit/http.js)
+
+## Standards Alignment
+
+- Applicable standards areas: architecture and design, team and process
+- Evidence in this decision: existing `/tasks` creation already writes a `DRAFT` initial stage, while the product glossary defines initial requirements as intake rather than execution-ready work.
+- Gap observed: the current task-creation UI still requires execution-contract fields up front. Documented rationale: this ADR establishes the target domain model before implementation changes align the UI and API behavior (source https://github.com/wiinc1/engineering-team/issues/95).
+
+## Required Evidence
+
+- Commands run: `git diff --cached --check`
+- Tests added or updated: Documentation-only decision; implementation test coverage is specified in `docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md`
+- Rollout or rollback notes: implementation should remain additive by allowing Intake Draft tasks before changing delivery dispatch behavior
+- Docs updated: `CONTEXT.md`, this ADR

--- a/docs/diagrams/architecture-US-003.mmd
+++ b/docs/diagrams/architecture-US-003.mmd
@@ -1,0 +1,14 @@
+flowchart LR
+  Operator[Software Factory operator] --> Browser[Browser task creation UI]
+  Browser --> Adapter[Task creation adapter]
+  Adapter --> Api[Task API POST /tasks]
+  Api --> Audit[Workflow audit store]
+  Api --> Platform[Task platform service]
+  Audit --> History[Task history/detail read model]
+  Platform --> List[Task list/read surfaces]
+  History --> Detail[Task detail]
+  List --> Browser
+  Detail --> Browser
+
+  Api --> Event[task.refinement_requested]
+  Event --> History

--- a/docs/diagrams/workflow-US-003.mmd
+++ b/docs/diagrams/workflow-US-003.mmd
@@ -1,0 +1,13 @@
+flowchart TD
+  A[Software Factory operator opens task creation] --> B[Enter raw requirements text]
+  B --> C{Optional title provided?}
+  C -->|Yes| D[Use operator-provided title]
+  C -->|No| E[Use placeholder title Untitled intake draft]
+  D --> F[Submit intake]
+  E --> F
+  F --> G[Create Task in DRAFT]
+  G --> H[Record operator intake requirements]
+  H --> I[Record PM refinement routing]
+  I --> J[Append task.refinement_requested audit event]
+  J --> K[Show Intake Draft in task list and detail]
+  K --> L[Next required action: PM refinement required]

--- a/docs/reports/ISSUE-92-production-evidence.md
+++ b/docs/reports/ISSUE-92-production-evidence.md
@@ -3,11 +3,19 @@
 - Date: 2026-04-27
 - Issue: #92 Replace internal auth bootstrap with magic-link session auth
 - Status: Complete
-- Applicable standards areas: security, deployment and release, observability and monitoring, testing and quality assurance
-- Evidence expected for this change: Vercel production deployment status, production auth config gate, Resend delivery event, invited-user smoke, protected-route smoke, logout/replay/unknown-email smoke, monitoring counts/rates, rollback target
-- Gap observed: repository implementation and automated local verification are complete, but production remediation cannot be closed until the release operator runs the production smoke against the deployed app and attaches external Vercel/Resend/monitoring evidence. Documented rationale: production authentication changes require direct operational verification because local tests cannot prove deployed env values, provider delivery, cookie behavior on the production origin, or rollback readiness.
-- Commands run: local verification commands are recorded in the PR or issue closeout; production operator must run `npm run auth:config:check:vercel` and `npm run auth:magic-link:production-smoke`
+
+## Standards Alignment
+
+- Applicable standards areas: deployment and release, observability and monitoring, testing and quality assurance
+- Evidence in this report: Vercel production deployment status, production auth config gate, Resend delivery event, invited-user smoke, protected-route smoke, logout/replay/unknown-email smoke, monitoring counts/rates, and rollback target
+- Gap observed: repository implementation and automated local verification were not sufficient to close production remediation alone. Documented rationale: production authentication changes require direct operational verification because local tests cannot prove deployed env values, provider delivery, cookie behavior on the production origin, or rollback readiness (source https://github.com/wiinc1/engineering-team/issues/92).
+
+## Required Evidence
+
+- Commands run: `npm run auth:config:check:vercel`; `npm run auth:magic-link:production-smoke`; `npm run auth:magic-link:production-smoke -- --require-complete`
+- Tests added or updated: production smoke artifact `observability/magic-link-production-smoke.json` captures invited-user, protected-route, logout, replay, and unknown-email checks with redacted evidence only
 - Rollout or rollback notes: rollback restores the last known-good production deployment and auth config for the selected strategy; do not switch strategies during rollback unless a separate emergency exception is approved
+- Docs updated: `docs/reports/ISSUE-92-production-evidence.md`
 
 ## Workspace Evidence Captured
 

--- a/docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md
+++ b/docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md
@@ -1,0 +1,380 @@
+# USER STORY — Create Intake Drafts From Raw Operator Requirements
+
+**Story ID:** US-003
+**GitHub Issue:** [#95](https://github.com/wiinc1/engineering-team/issues/95)
+**Template Tier:** Standard
+**Standards Verified:** Story authored from `docs/templates/USER_STORY_TEMPLATE.md`, [CONTEXT.md](/Users/wiinc1/repos/engineering-team/CONTEXT.md), and ADR [ADD-2026-04-28-intake-draft-as-task-stage.md](/Users/wiinc1/repos/engineering-team/docs/adr/ADD-2026-04-28-intake-draft-as-task-stage.md).
+
+## 1. User Story
+
+As a Software Factory operator,
+I want to create an Intake Draft from raw initial requirements,
+so that the control plane can start PM refinement without requiring me to pre-fill the execution-ready story contract.
+
+**Business Context & Success Metrics**
+
+The Software Factory control plane should optimize first for capturing operator intent. The current task creation flow asks for business context, acceptance criteria, Definition of Done, priority, and task type before a task can exist. That inverts the intended lifecycle because those fields are refinement outputs, not intake prerequisites.
+
+This story changes intake so the operator can submit raw requirements quickly and let the control plane route the new Task into Product Manager refinement.
+
+**Success Metrics**
+- 100% of automated happy-path coverage can create an Intake Draft with only raw requirements text.
+- 0 required fields remain in the intake form beyond raw requirements text.
+- 100% of created Intake Drafts are persisted as `DRAFT` and show `PM refinement required` as the next required action.
+- 0 Intake Draft creation flows claim implementation, QA, or SRE work has started.
+
+## 2. Acceptance Criteria
+
+### Must Have
+
+**Scenario 1 — Operator creates an Intake Draft from raw requirements only**
+Given the operator opens task creation
+When they enter only raw requirements text and submit
+Then a Task is created in `DRAFT` as an Intake Draft.
+
+**Scenario 2 — Optional metadata does not block intake**
+Given optional title, priority, or type are omitted
+When the draft is created
+Then the system stores safe defaults or leaves those fields unset without blocking intake.
+
+**Scenario 3 — Intake Draft is visible as refinement work**
+Given an Intake Draft is created
+When task list or task detail loads
+Then it is visibly labeled as Intake Draft
+And its next required action is PM refinement.
+
+**Scenario 4 — Audit/history records intake and routing only**
+Given an Intake Draft is created
+When the audit or task history is inspected
+Then creation and PM refinement routing are recorded
+And implementation has not been claimed as started.
+
+### Out of Scope
+
+- Full Product Manager, Architect, and UX Designer refinement generation
+- Auto-approval
+- Implementation dispatch
+- QA or SRE verification changes
+- Production release automation
+- Multi-task decomposition
+- Editing or revising raw intake requirements after creation
+
+## 2a. Standards Alignment
+
+- Applicable standards areas: architecture and design, testing and quality assurance, auditability, deployment and release, observability and monitoring
+- Evidence expected for this change: UI/API tests for raw-requirements intake, task state/history assertions, task list/detail visibility checks, and documentation updates
+- Known gaps stated using: Gap observed: the full multi-specialist refinement workflow remains out of scope. Documented rationale: Intake Draft creation is the narrow first slice needed before PM/Architect/UX refinement automation can be safely designed and implemented (source [CONTEXT.md](/Users/wiinc1/repos/engineering-team/CONTEXT.md)).
+
+## 3. Workflow & User Journey
+
+**User Journey (step-by-step)**
+1. Operator opens the task creation route.
+2. Operator sees a lightweight intake form with raw requirements text and optional title.
+3. Operator submits the intake.
+4. System creates a Task in `DRAFT`.
+5. System routes the Task to PM refinement.
+6. Operator lands on task detail or sees the new draft in the task list.
+7. Task detail shows `Operator intake requirements` above refined execution-contract sections.
+8. The next required action is `PM refinement required`.
+
+**System Flow (technical)**
+1. Task creation UI collects `raw_requirements` and optional `title`.
+2. UI submits to the existing task creation API.
+3. API validates that raw requirements text is present.
+4. API creates a Task with `initial_stage: 'DRAFT'`.
+5. API records PM refinement routing as task state metadata: `current_owner=pm` and `next_required_action='PM refinement required'`.
+6. API appends audit/history for `task.created` and `task.refinement_requested`.
+7. Task list and task detail adapters surface Intake Draft label, raw intake text, current owner, and next required action.
+
+**Error & Edge Cases**
+- Raw requirements text is empty or whitespace only.
+- Optional title is omitted.
+- Optional title is excessively long.
+- Existing clients still submit the older refined-field payload.
+- Task creation succeeds but PM refinement routing event fails.
+- Task list or detail receives a DRAFT task without PM routing metadata from older data.
+
+**Required Diagram**
+- Mermaid workflow diagram to be committed at: `/docs/diagrams/workflow-US-003.mmd`
+
+## 4. Automated Test Deliverables
+
+**Required automated deliverables for Standard tier**
+
+```text
+tests/
+├── unit/
+│   ├── task-creation-intake-schema.test.js
+│   └── intake-draft-history.test.js
+├── integration/
+│   └── intake-draft-task-creation.integration.test.js
+├── e2e/
+│   └── intake-draft-creation.spec.ts
+├── contract/
+│   └── intake-draft-task-creation.contract.test.js
+├── visual/
+│   └── intake-draft-creation.visual.spec.ts
+├── accessibility/
+│   └── intake-draft-creation.a11y.spec.ts
+├── performance/
+│   └── lighthouse-intake-draft.spec.ts
+└── security/
+    └── intake-draft-creation-security.test.js
+```
+
+**Additional Standard Tier Test Requirements**
+- Unit coverage for intake payload validation and optional-title handling.
+- API/integration coverage that raw requirements only creates `DRAFT` and PM refinement routing metadata.
+- E2E coverage for each Given-When-Then scenario in Section 2.
+- Visual coverage for the intake form and Intake Draft task detail state.
+- Accessibility coverage with axe-core on the creation form and task detail display.
+- Security coverage that unauthenticated users cannot create Intake Drafts and unauthorized roles cannot bypass task creation permissions.
+
+**Test Data Management**
+- Fixture for raw intake text only.
+- Fixture for raw intake text with optional title.
+- Fixture for legacy task creation payload compatibility if retained.
+
+## 5. Data Model & Schema
+
+Not required for Standard tier as a standalone migration unless implementation discovers that the current audit/task payloads cannot persist raw intake text, PM routing metadata, or `task.refinement_requested`.
+
+## 6. Architecture & Integration
+
+**Pattern**
+- Feature-sliced browser application architecture, using the existing task creation feature and existing audit/task APIs.
+
+**New/Changed Components**
+- `src/features/task-creation/TaskCreationForm.tsx`
+- `src/features/task-creation/schema.js`
+- `src/features/task-creation/adapter.js`
+- `src/features/task-creation/TaskCreationPage.tsx`
+- `lib/audit/event-types.js`
+- `lib/audit/http.js`
+- task list and task detail mapping surfaces in `src/app/App.jsx` and task-detail adapters as needed
+
+**Required Diagram**
+- C4 context/container diagram to be committed at: `/docs/diagrams/architecture-US-003.mmd`
+
+**External Integrations**
+- Existing authenticated task API only.
+- No new third-party provider integration.
+
+**Retry/Timeout Configuration**
+- Reuse existing browser API client timeout/retry behavior.
+- Do not retry validation failures.
+
+**Circuit Breaker Settings**
+- Not required for this slice.
+
+**Feature Flag**
+- Flag name: `ff_intake_draft_creation`
+- Platform: existing repo feature-flag mechanism
+- Targeting rules: internal operator users first, then all authenticated task creators after validation
+
+## 7. API Design
+
+**API Contract**
+
+Existing task creation endpoint remains authoritative:
+
+- `POST /tasks`
+
+**Request body**
+
+```json
+{
+  "raw_requirements": "The operator's raw initial requirements text.",
+  "title": "Optional short title"
+}
+```
+
+**Success response**
+
+```json
+{
+  "taskId": "TSK-123",
+  "status": "DRAFT",
+  "nextRequiredAction": "PM refinement required"
+}
+```
+
+**Validation/error response examples**
+- `400` when `raw_requirements` is missing or blank
+- `401` when no authenticated session is present
+- `403` when the actor lacks `tasks:create`
+- `503` when task creation is feature-disabled
+
+**Committed spec location**
+- If an API spec is changed, update `/docs/api/task-platform-openapi.yml` or the relevant audit/task API spec rather than creating a disconnected contract.
+
+**Versioning Strategy**
+- Additive request-shape change to existing task creation behavior.
+- Preserve compatibility for existing callers where practical.
+
+**Backwards Compatibility**
+- Older refined-field creation payloads may continue to work during transition.
+- New UI should use raw intake fields only.
+
+**Automated API Testing**
+- Contract coverage for raw requirements only.
+- Regression coverage for missing auth, missing permission, and blank requirements.
+
+## 10. UI/UX Requirements
+
+**Owner:** UX Designer during the PM + Architect review stage.
+
+### 10.1 Design Assets
+
+- Wireframe or inline design notes are acceptable for this narrow slice.
+
+### 10.2 Core Screens & Purpose
+
+| Screen | Purpose | Primary User/Agent |
+|---|---|---|
+| Task Creation | Capture raw operator intake requirements quickly | Software Factory operator |
+| Task List / Board | Make Intake Drafts visible as PM refinement work | Operator, PM |
+| Task Detail | Preserve original operator intent and show next action | Operator, PM, Architect, UX Designer |
+
+### 10.3 Role-Based Inbox / Queue Requirements
+
+- PM Inbox: Intake Drafts routed to PM refinement should be visible as PM-owned work.
+- Architect Inbox: no required change in this story.
+- Engineer Inbox: Intake Drafts must not appear as implementation-ready work.
+- QA Inbox: no required change in this story.
+- SRE Inbox: no required change in this story.
+
+### 10.4 Task Detail Page Information Architecture
+
+**Above the fold**
+- Task title or `Untitled intake draft`
+- `Intake Draft` label
+- Current owner: PM
+- Current stage: `DRAFT`
+- Next required action: `PM refinement required`
+
+**Below the fold or in tabs**
+- `Operator intake requirements`
+- Audit/history entries for creation and PM refinement routing
+- Existing refined execution-contract sections may remain empty or pending
+
+### 10.5 Threaded Comment Model
+
+No new threaded comment type is required for the first slice.
+
+### 10.6 Escalation UX
+
+Not required for this slice.
+
+### 10.7 Stage Visualization
+
+Task list/detail must visually distinguish Intake Drafts from implementation-ready tasks.
+
+### 10.8 Component Library
+
+Use existing app styles and components. Do not introduce a new design system.
+
+### 10.9 Responsive Design
+
+Creation form and Intake Draft detail state must remain usable at mobile, tablet, and desktop breakpoints already covered by the app.
+
+### 10.10 Visual Regression
+
+Capture baseline states for:
+- raw intake form
+- created Intake Draft in task detail
+- Intake Draft in task list or board
+
+### 10.11 Accessibility Automation
+
+Run axe-core coverage against the intake form and Intake Draft detail state.
+
+### 10.13 Automated UX Validation
+
+Validate form labels, error messages, focus handling, and submit behavior without manual review.
+
+## 11. Deployment & Release Strategy
+
+**Deployment Type**
+- Feature flag toggle through `ff_intake_draft_creation`.
+
+**Progressive Rollout**
+- Enable for internal operator usage first.
+- Expand to all authenticated task creators after automated coverage and local validation pass.
+
+**Automated Rollback Triggers**
+- Disable `ff_intake_draft_creation` if task creation error rate increases, Intake Drafts fail to route to PM refinement, or list/detail display regresses.
+
+**Rollback Procedure**
+- Disable the feature flag and keep existing task creation behavior available until the regression is fixed.
+
+**Synthetic Monitoring**
+- Add or update a smoke path that verifies authenticated task creation can create a DRAFT task from raw requirements in a non-production or safe test tenant.
+
+## 12. Monitoring & Observability
+
+**Service Level Objectives**
+- Intake Draft creation success rate should remain within existing task creation baseline.
+- PM refinement routing should be recorded for 100% of created Intake Drafts.
+
+**Events and Error Codes**
+- Add `task.refinement_requested` to the workflow audit event taxonomy.
+- Use unique validation and routing error codes for blank requirements and PM routing failure.
+
+**Metrics**
+- Intake Draft creation count.
+- Intake Draft creation failures by reason.
+- PM refinement routing failures.
+- Intake Drafts without PM routing metadata.
+
+**Dashboards and Alerts**
+- Reuse existing task/audit dashboards unless implementation requires a new panel.
+- Alert on routing failures or unexplained DRAFT tasks without next action.
+
+## 15. Definition of Done
+
+- Intake form requires raw requirements text only.
+- Optional title is supported.
+- Omitted title displays as `Untitled intake draft` plus Task ID in list/detail contexts.
+- API accepts raw requirements only and persists a `DRAFT` Task.
+- PM refinement routing is recorded as `current_owner=pm`, `next_required_action='PM refinement required'`, and `task.refinement_requested`.
+- Task list/detail visibly labels Intake Drafts and shows `Operator intake requirements`.
+- Engineer/QA/SRE execution states are not claimed during intake creation.
+- Unit, integration, E2E, contract, visual, accessibility, performance, and security coverage required by Section 4 are added or updated.
+- Lint, typecheck, and relevant test scripts pass.
+- Documentation and API/diagram artifacts are updated where changed.
+
+## 16. Production Validation Strategy
+
+**Automated Pre-Flight Checks**
+- Unit, integration, E2E, visual, accessibility, security, and contract checks pass before rollout.
+
+**Automatic Verification in Production**
+- If production validation is required, use a safe internal test tenant and verify that an authenticated operator can create a DRAFT from raw requirements without exposing sensitive content in logs.
+
+**Escape Hatch**
+- Disable `ff_intake_draft_creation`.
+
+**Post-Deployment Verification Checklist**
+- Deployment reports healthy.
+- Task creation smoke passes.
+- Task list/detail show Intake Drafts correctly.
+- No spike in task creation errors.
+- No Intake Drafts are missing PM refinement routing metadata.
+
+## 17. Compliance & Handoff
+
+**Code Repository**
+- All implementation code should land on a feature branch named `feature/US-003-intake-draft-creation`.
+- PR title: `[US-003] Create Intake Drafts From Raw Operator Requirements`
+- PR description links to this story, [CONTEXT.md](/Users/wiinc1/repos/engineering-team/CONTEXT.md), and ADR [ADD-2026-04-28-intake-draft-as-task-stage.md](/Users/wiinc1/repos/engineering-team/docs/adr/ADD-2026-04-28-intake-draft-as-task-stage.md).
+
+**Artifact Locations**
+- Tests: `/tests/[unit|integration|e2e|contract|visual|accessibility|performance|security]/...`
+- Diagrams: `/docs/diagrams/workflow-US-003.mmd`, `/docs/diagrams/architecture-US-003.mmd`
+- API contract: existing task API spec if changed
+- Runbook: update existing task workflow runbook if operator behavior changes
+
+**Final Actions**
+- Feature flag state documented in `/docs/feature-flags.md` if a flag is added.
+- Story evidence captured in the PR or a report under `/docs/reports/`.


### PR DESCRIPTION
## Summary
- Defines the Software Factory control plane glossary and lifecycle in CONTEXT.md.
- Adds the accepted ADR that Intake Draft is a Task stage, not a separate Intake entity.
- Adds US-003 planning artifacts for creating Intake Drafts from raw operator requirements.
- Adds workflow and architecture diagrams for US-003.
- Adds missing standards metadata to the Issue 92 production evidence report so repo standards checks pass.

## Linked Task
- Task: Refs #95

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md
- Relevant standards areas: architecture and design, deployment and release, observability and monitoring, testing and quality assurance, team and process
- Standards gaps or exceptions: US-003 intentionally defers full PM/Architect/UX refinement generation, auto-approval, implementation dispatch, QA/SRE verification changes, production release automation, multi-task decomposition, and intake revision editing.

## Required Evidence
- Standards check result: npm run standards:check passed
- Lint result: not run, docs-only planning change
- Tests: not run, docs-only planning change
- Test evidence paths: docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md specifies required implementation test evidence
- Docs updated: yes
- Doc evidence paths: CONTEXT.md; docs/adr/ADD-2026-04-28-intake-draft-as-task-stage.md; docs/user-stories/US-003-create-intake-drafts-from-raw-operator-requirements.md; docs/diagrams/workflow-US-003.mmd; docs/diagrams/architecture-US-003.mmd; docs/reports/ISSUE-92-production-evidence.md

## Risk and Rollback
- Risk level: Low, documentation and planning artifacts only
- Rollback path: Revert commit ecf8ac6 if the domain model or US-003 scope needs to be replaced.

## Notes
- This PR prepares the next implementation session. It does not implement US-003.
- Issue #95 should remain open for implementation.