### PR TITLE
Tighten Execution Contract metadata versioning

### DIFF
--- a/docs/api/audit-foundation-openapi.yml
+++ b/docs/api/audit-foundation-openapi.yml
@@ -113,6 +113,7 @@ components:
         createdAt: { type: string, format: date-time }
     ExecutionContractSection:
       type: object
+      description: Structured section record. Material changes include body, owner/approval metadata, payload schema version, payload JSON, and provenance references.
       required: [id, title, body, owner, owner_role, section_status, approval_status, payload_schema_version, payload_json, provenance_references, required]
       properties:
         id: { type: string }
@@ -467,7 +468,7 @@ paths:
     post:
       summary: Create or version a structured Execution Contract from an Intake Draft
       description: |
-        PM/admin-only mutation. Creates the first draft contract version from the selected `USER_STORY_TEMPLATE.md` tier or records a new version when material contract sections change. The contract remains PM-owned and does not dispatch implementation.
+        PM/admin-only mutation. Creates the first draft contract version from the selected `USER_STORY_TEMPLATE.md` tier or records a new version when material contract sections change, including structured payload or section metadata updates. The contract remains PM-owned and does not dispatch implementation.
       parameters:
         - name: id
           in: path

--- a/docs/reports/ISSUE-102-verification.md
+++ b/docs/reports/ISSUE-102-verification.md
@@ -4,7 +4,7 @@
 
 - `POST /tasks/{id}/execution-contract` creates a PM-owned structured draft version from an Intake Draft.
 - Simple, Standard, Complex, and Epic required-section validation is covered in unit tests.
-- Material section changes record a new version.
+- Material section changes, including structured payload and section metadata changes, record a new version.
 - Markdown generation reflects structured contract data and marks the view as non-authoritative.
 - Approval records `task.execution_contract_approved` and commits only `committed_scope.committed_requirements` for future implementation.
 - Out-of-scope, Deferred Consideration, and follow-up Task items remain outside committed requirements unless promoted through a new approved version or new Intake Draft.
@@ -18,7 +18,7 @@
 | --- | --- |
 | Intake Draft creates same-Task draft Execution Contract | Passed: `task.execution_contract_version_recorded` is recorded for the original Task ID. |
 | Selected tier enforces required sections | Passed: Simple, Standard, Complex, and Epic required-section validation is covered. |
-| Material section changes create a new version | Passed: material hash changes increment the contract version. |
+| Material section changes create a new version | Passed: material hash changes across section body, structured payload, ownership, approval metadata, and provenance increment the contract version. |
 | Markdown reflects structured contract and is non-authoritative | Passed: generated Markdown is marked `authoritative: false`. |
 | Approved requirements become committed implementation scope | Passed: approval records `committed_scope.committed_requirements` with `commitment_status=committed`. |
 | Excluded ideas stay out of committed scope | Passed: `out_of_scope`, `deferred_considerations`, and `follow_up_tasks` remain separate from committed requirements. |
@@ -26,7 +26,8 @@
 
 ## Commands
 
-- `node --test tests/unit/execution-contracts.test.js tests/unit/audit-api.test.js` - passed, 61 tests.
+- `node --test tests/unit/execution-contracts.test.js tests/unit/audit-api.test.js` - passed, 62 tests.
+- `node --test tests/unit/execution-contracts.test.js tests/unit/audit-api.test.js tests/e2e/audit-foundation.e2e.test.js tests/performance/audit-foundation.performance.test.js tests/security/audit-api.security.test.js tests/contract/audit-openapi.contract.test.js` - passed, 98 tests.
 - `node --test tests/contract/audit-openapi.contract.test.js` - passed, 3 tests.
 - `node --test tests/security/audit-api.security.test.js` - passed, 17 tests.
 - `node --test tests/e2e/audit-foundation.e2e.test.js` - passed, 12 tests.
@@ -44,7 +45,7 @@
 ## Required Evidence
 
 - Commands run: listed above.
-- Tests added or updated: unit, e2e, contract, and security tests for Execution Contracts.
+- Tests added or updated: unit, e2e, performance, contract, and security tests for Execution Contracts.
 - Docs updated: API, task detail contract, design, diagrams, generated story, and reports.
 - Rollout or rollback notes: controlled by `FF_EXECUTION_CONTRACTS`; disable it to stop contract reads and mutations while preserving audit history.
 

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -254,12 +254,13 @@ Symptom: PM needs to turn a raw Intake Draft into an approval-ready structured c
 Immediate action:
 1. Confirm the task is an Intake Draft in `DRAFT` and is assigned to `pm`.
 2. Use `POST /tasks/{id}/execution-contract` with the selected template tier and any completed section bodies.
-3. Use `POST /tasks/{id}/execution-contract/validate` to enforce the tier-required sections.
-4. If validation is valid, use `POST /tasks/{id}/execution-contract/markdown` to generate a non-authoritative review story.
-5. Use `POST /tasks/{id}/execution-contract/approve` only when the structured contract is approved; this records committed implementation scope without dispatching engineering work.
-6. Confirm task history includes `task.execution_contract_version_recorded`, `task.execution_contract_validated`, `task.execution_contract_markdown_generated`, and `task.execution_contract_approved`.
-7. Confirm `committed_scope.committed_requirements` contains only approved implementation scope, while `out_of_scope`, `deferred_considerations`, and `follow_up_tasks` remain excluded.
-8. Confirm implementation dispatch is still blocked until a future dispatch workflow is implemented.
+3. Save another contract version when section body, payload JSON, payload schema version, owner/approval metadata, or provenance references change materially.
+4. Use `POST /tasks/{id}/execution-contract/validate` to enforce the tier-required sections.
+5. If validation is valid, use `POST /tasks/{id}/execution-contract/markdown` to generate a non-authoritative review story.
+6. Use `POST /tasks/{id}/execution-contract/approve` only when the structured contract is approved; this records committed implementation scope without dispatching engineering work.
+7. Confirm task history includes `task.execution_contract_version_recorded`, `task.execution_contract_validated`, `task.execution_contract_markdown_generated`, and `task.execution_contract_approved`.
+8. Confirm `committed_scope.committed_requirements` contains only approved implementation scope, while `out_of_scope`, `deferred_considerations`, and `follow_up_tasks` remain excluded.
+9. Confirm implementation dispatch is still blocked until a future dispatch workflow is implemented.
 Rollback: set `FF_EXECUTION_CONTRACTS=false` to stop contract reads and mutations while preserving historical audit events.
 
 ## Observability hooks

--- a/lib/audit/execution-contracts.js
+++ b/lib/audit/execution-contracts.js
@@ -366,6 +366,16 @@ function normalizeBodyForMaterialComparison(value) {
   return normalizeSectionBody(value).replace(/\s+/g, ' ');
 }
 
+function stableMaterialValue(value) {
+  if (Array.isArray(value)) {
+    return value.map(stableMaterialValue);
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableMaterialValue(value[key])]));
+  }
+  return value ?? null;
+}
+
 function materialFingerprint(contract = {}) {
   const sections = contract.sections || {};
   const sectionFingerprint = Object.fromEntries(orderedSectionIds(Object.keys(sections)).map((sectionId) => [
@@ -373,6 +383,17 @@ function materialFingerprint(contract = {}) {
     {
       title: normalizeBodyForMaterialComparison(sections[sectionId]?.title),
       body: normalizeBodyForMaterialComparison(sections[sectionId]?.body),
+      owner_role: normalizeRole(sections[sectionId]?.owner_role ?? sections[sectionId]?.owner),
+      section_status: normalizeSectionStatus(sections[sectionId]?.section_status, sections[sectionId]?.body ? 'complete' : 'draft'),
+      contributor: normalizeSectionBody(sections[sectionId]?.contributor) || null,
+      contributors: normalizeStructuredList(sections[sectionId]?.contributors),
+      approver: normalizeSectionBody(sections[sectionId]?.approver) || null,
+      approvals: normalizeStructuredList(sections[sectionId]?.approvals),
+      approval_status: normalizeApprovalStatus(sections[sectionId]?.approval_status, sections[sectionId]?.approvals),
+      payload_schema_version: Number(sections[sectionId]?.payload_schema_version ?? 1) || 1,
+      payload_json: stableMaterialValue(sections[sectionId]?.payload_json || {}),
+      provenance_references: normalizeStructuredList(sections[sectionId]?.provenance_references),
+      required: sections[sectionId]?.required === true,
     },
   ]));
   return JSON.stringify({

--- a/tests/e2e/audit-foundation.e2e.test.js
+++ b/tests/e2e/audit-foundation.e2e.test.js
@@ -202,9 +202,40 @@ test('e2e: PM generates a versioned Execution Contract and Markdown without disp
       }),
     });
     assert.equal(response.status, 201);
-    const contract = await response.json();
+    let contract = await response.json();
     assert.equal(contract.data.version, 1);
     assert.equal(contract.data.validation.status, 'valid');
+
+    response = await fetch(`${baseUrl}/tasks/${created.taskId}/execution-contract`, {
+      method: 'POST',
+      headers: pmHeaders,
+      body: JSON.stringify({
+        templateTier: 'Complex',
+        sections: {
+          ...complexExecutionContractSections(),
+          6: {
+            title: 'Architecture & Integration',
+            body: 'E2E completed Complex-tier section 6.',
+            ownerRole: 'architect',
+            contributor: 'architect-e2e',
+            approvalStatus: 'approved',
+            payloadSchemaVersion: 2,
+            payloadJson: { architecture_decision: 'Metadata-only material change is versioned.' },
+            provenanceReferences: ['CONTEXT.md#execution-contract'],
+          },
+        },
+        scopeBoundaries: {
+          committedRequirements: ['Future implementation must satisfy the approved contract sections.'],
+          outOfScope: ['Runtime engineer dispatch is not performed by this workflow.'],
+          deferredConsiderations: ['Deferred Considerations promotion is tracked separately.'],
+        },
+      }),
+    });
+    assert.equal(response.status, 201);
+    contract = await response.json();
+    assert.equal(contract.data.version, 2);
+    assert.equal(contract.data.materialChange, true);
+    assert.equal(contract.data.contract.sections['6'].payload_schema_version, 2);
 
     response = await fetch(`${baseUrl}/tasks/${created.taskId}/execution-contract/markdown`, {
       method: 'POST',

--- a/tests/performance/audit-foundation.performance.test.js
+++ b/tests/performance/audit-foundation.performance.test.js
@@ -5,6 +5,7 @@ const os = require('os');
 const path = require('path');
 const { performance } = require('perf_hooks');
 const { createFileAuditStore } = require('../../lib/audit/store');
+const { createExecutionContractDraft, REQUIRED_SECTIONS_BY_TIER } = require('../../lib/audit/execution-contracts');
 
 function makeTempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'audit-perf-'));
@@ -112,4 +113,69 @@ test('close-review escalation and projection stay within baseline budget', () =>
   assert.equal(history.length, 2);
   assert.ok(appendDuration < 250, `close escalation append budget exceeded: ${appendDuration}ms`);
   assert.ok(readDuration < 150, `close escalation read budget exceeded: ${readDuration}ms`);
+});
+
+test('execution contract structured metadata versioning stays within baseline budget', () => {
+  const sections = Object.fromEntries(REQUIRED_SECTIONS_BY_TIER.Complex.map((sectionId) => [
+    sectionId,
+    `Perf completed Complex section ${sectionId}.`,
+  ]));
+  const history = [{
+    event_type: 'task.created',
+    event_id: 'evt-perf-contract',
+    payload: {
+      intake_draft: true,
+      title: 'Metadata hash performance',
+      raw_requirements: 'Version structured metadata changes without slowing contract saves.',
+    },
+  }];
+  const summary = {
+    task_id: 'TSK-PERF-CONTRACT',
+    title: 'Metadata hash performance',
+    intake_draft: true,
+    operator_intake_requirements: 'Version structured metadata changes without slowing contract saves.',
+  };
+
+  const initial = createExecutionContractDraft({
+    taskId: 'TSK-PERF-CONTRACT',
+    summary,
+    history,
+    actorId: 'pm-perf',
+    body: { templateTier: 'Complex', sections },
+  });
+
+  const started = performance.now();
+  const updated = createExecutionContractDraft({
+    taskId: 'TSK-PERF-CONTRACT',
+    summary,
+    history,
+    actorId: 'pm-perf',
+    previousContract: initial.contract,
+    body: {
+      templateTier: 'Complex',
+      sections: {
+        ...sections,
+        6: {
+          title: 'Architecture & Integration',
+          body: 'Perf completed Complex section 6.',
+          ownerRole: 'architect',
+          contributor: 'architect-perf',
+          approvalStatus: 'approved',
+          payloadSchemaVersion: 2,
+          payloadJson: {
+            integration: {
+              mode: 'approved',
+              dependencies: Array.from({ length: 20 }, (_, index) => `dependency-${index}`),
+            },
+          },
+          provenanceReferences: ['CONTEXT.md', 'docs/templates/USER_STORY_TEMPLATE.md'],
+        },
+      },
+    },
+  });
+  const duration = performance.now() - started;
+
+  assert.equal(updated.materialChange, true);
+  assert.equal(updated.contract.version, 2);
+  assert.ok(duration < 250, `execution contract metadata versioning budget exceeded: ${duration}ms`);
 });

--- a/tests/unit/execution-contracts.test.js
+++ b/tests/unit/execution-contracts.test.js
@@ -123,6 +123,73 @@ test('creates a PM-owned structured draft from Intake Draft history and versions
   assert.deepEqual(updated.contract.committed_scope.deferred_considerations.map((item) => item.text), ['Deferred Considerations workflow is issue #110.']);
 });
 
+test('versions material changes to structured section payload and metadata', () => {
+  const history = [
+    {
+      event_type: 'task.created',
+      event_id: 'evt-create',
+      payload: { intake_draft: true, title: 'Structured metadata', raw_requirements: 'Capture structured metadata changes.' },
+    },
+  ];
+  const summary = {
+    task_id: 'TSK-102-META',
+    title: 'Structured metadata',
+    intake_draft: true,
+    operator_intake_requirements: 'Capture structured metadata changes.',
+  };
+  const initial = createExecutionContractDraft({
+    taskId: 'TSK-102-META',
+    summary,
+    history,
+    actorId: 'pm-1',
+    body: {
+      templateTier: 'Standard',
+      sections: {
+        ...sectionBodiesFor('Standard'),
+        6: {
+          title: 'Architecture & Integration',
+          body: 'Completed section 6.',
+          ownerRole: 'architect',
+          contributor: 'architect-1',
+          approvalStatus: 'pending',
+          payloadSchemaVersion: 1,
+          payloadJson: { integration: { mode: 'draft' } },
+          provenanceReferences: ['CONTEXT.md'],
+        },
+      },
+    },
+  });
+
+  const updated = createExecutionContractDraft({
+    taskId: 'TSK-102-META',
+    summary,
+    history,
+    actorId: 'pm-1',
+    previousContract: initial.contract,
+    body: {
+      templateTier: 'Standard',
+      sections: {
+        ...sectionBodiesFor('Standard'),
+        6: {
+          title: 'Architecture & Integration',
+          body: 'Completed section 6.',
+          ownerRole: 'architect',
+          contributor: 'architect-1',
+          approvalStatus: 'approved',
+          approver: 'architect-lead',
+          payloadSchemaVersion: 2,
+          payloadJson: { integration: { mode: 'approved' } },
+          provenanceReferences: ['CONTEXT.md', 'docs/adr/ADD-2026-04-29-committed-requirements-and-contract-coverage.md'],
+        },
+      },
+    },
+  });
+
+  assert.equal(updated.materialChange, true);
+  assert.equal(updated.previousVersion, 1);
+  assert.equal(updated.contract.version, 2);
+});
+
 test('generates Markdown from structured data without making Markdown authoritative', () => {
   const contract = {
     task_id: 'TSK-102',


### PR DESCRIPTION
## Summary
Tightens Issue #102 material-change tracking so structured section metadata and payload changes create a new Execution Contract version.

## Linked Task
- Task: #102

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/reports/ISSUE-102-verification.md
- Relevant standards areas: testing and quality assurance; architecture and design; security; observability and monitoring
- Standards gaps or exceptions: No new gaps.

## Required Evidence
- Standards check result: `npm run standards:check` passed
- Lint result: `npm run lint` passed
- Tests: `node --test tests/unit/execution-contracts.test.js tests/unit/audit-api.test.js tests/e2e/audit-foundation.e2e.test.js tests/performance/audit-foundation.performance.test.js tests/security/audit-api.security.test.js tests/contract/audit-openapi.contract.test.js` passed; `npm test` passed including 60 browser tests; `npm run typecheck` passed; `npm run change:check` passed; `npm run ownership:lint` passed; `git diff --check` passed
- Test evidence paths: tests/unit/execution-contracts.test.js, tests/e2e/audit-foundation.e2e.test.js, tests/performance/audit-foundation.performance.test.js
- Docs updated: API contract, audit runbook, and issue verification report updated for metadata material-versioning behavior.
- Doc evidence paths: docs/api/audit-foundation-openapi.yml, docs/runbooks/audit-foundation.md, docs/reports/ISSUE-102-verification.md

## Risk and Rollback
- Risk level: Low
- Rollback path: Revert this PR. Emergency mitigation remains disabling `FF_EXECUTION_CONTRACTS=false` to stop contract reads and mutations while preserving historical audit events.

## Notes
This is a follow-up from the issue #102 requirement audit after PR #118. It does not add implementation dispatch.