### PR TITLE
Tighten registration auth audit traceability

### DIFF
--- a/docs/design/ISSUE-160-registration-auth-policy.md
+++ b/docs/design/ISSUE-160-registration-auth-policy.md
@@ -6,6 +6,21 @@ Decision date: 2026-05-08
 
 Use registration auth as the active no-IdP production strategy. Keep OIDC available only when selected explicitly. Keep internal bootstrap as an emergency/local fallback. Treat magic-link as historical after the cutover.
 
+Issue #151 and PR #159 are reconciled by this decision. PR #159 documented the earlier magic-link/OIDC production-auth status evidence path for Issue #151; the registration cutover supersedes that path with registration smoke evidence, registration production gates, and historical-only magic-link evidence.
+
+## Issue Flag Mapping
+
+The issues used `ff_registration_*` names as conceptual rollout controls. The implemented production gates are environment and status-check controls:
+
+| Issue wording | Implemented control | Purpose |
+|---|---|---|
+| `ff_registration_auth_strategy` | `AUTH_PRODUCTION_AUTH_STRATEGY=registration` plus `VITE_AUTH_PRODUCTION_AUTH_STRATEGY=registration` or runtime-config evidence | selects registration as the active backend and browser auth strategy |
+| `ff_registration_credentials` | `AUTH_REGISTRATION_MODE` plus credential schema and password service | enables credential-backed registration modes |
+| `ff_registration_email_verification` | `AUTH_REQUIRE_EMAIL_VERIFICATION` and `AUTH_EMAIL_VERIFICATION_TTL_HOURS` | controls pending-verification behavior and token expiry |
+| `ff_registration_password_reset` | `AUTH_PASSWORD_RESET_TTL_MINUTES` and the reset endpoints | controls reset token expiry and reset flow availability |
+| `ff_registration_abuse_controls` | registration service rate-limit and audit settings | applies login, registration, and reset abuse controls |
+| `ff_registration_magic_link_removed` | production status checks plus removed `/auth/magic-link/*` behavior | prevents magic-link from satisfying production gates |
+
 ## Registration Modes
 
 | Mode | Registration behavior | Login behavior | Operator requirement |

--- a/docs/reports/ISSUE-160-167-registration-auth-audit.md
+++ b/docs/reports/ISSUE-160-167-registration-auth-audit.md
@@ -13,12 +13,16 @@ Registration auth is the no-IdP production strategy. The active registration mod
 
 Magic-link is historical after cutover. `/auth/magic-link/request` returns `410`, and `/auth/magic-link/consume` redirects to `/sign-in?reason=magic_link_removed` without creating a session.
 
+Issue #151 and PR #159 are reconciled as historical production-auth evidence paths. The active closure evidence is registration-based through PR #168, `observability/registration-auth-production-smoke.json`, and `npm run auth:status:check -- --require-complete`.
+
+The `ff_registration_*` labels in the issue text are implemented as explicit environment/status gates: `AUTH_PRODUCTION_AUTH_STRATEGY`, browser runtime strategy evidence, `AUTH_REGISTRATION_MODE`, email-verification and password-reset TTL variables, redacted abuse-control monitoring, and removed magic-link endpoint behavior.
+
 ## Requirement Matrix
 
 | Issue | Requirement coverage | Implementation evidence | Verification |
 |---|---|---|---|
 | #160 Define registration auth product policy and migration plan | active strategy, modes, first-admin seed, rollback, Issue #151 supersession | `docs/runbooks/production-auth-status.md`, `docs/runbooks/production-identity-provider.md`, `docs/diagrams/workflow-registration-auth-strategy.mmd`, `config/change-ownership-map.json` | `tests/unit/production-auth-status.test.js`, `tests/unit/auth-config-check.test.js` |
-| #161 Add credential data model and password hashing service | scrypt hash service, credential table, migration rollback, existing-user credential attach without identity changes | `lib/auth/credentials.js`, `lib/auth/registration.js`, `db/migrations/011_registration_auth.sql`, `db/migrations/011_registration_auth.down.sql`, `docs/diagrams/schema-registration-credentials.mmd` | `tests/unit/registration-auth.test.js` |
+| #161 Add credential data model and password hashing service | scrypt hash service, credential table, migration rollback, existing-user credential attach without identity changes | `lib/auth/credentials.js`, `lib/auth/registration.js`, `db/migrations/011_registration_auth.sql`, `db/migrations/011_registration_auth.down.sql`, `docs/diagrams/schema-registration-credentials.mmd` | `tests/unit/registration-auth.test.js`, `tests/integration/registration-auth-migration-postgres.integration.test.js` |
 | #162 Add email verification and password reset | hashed single-use expiring tokens, generic unknown-email responses, reset credential rotation and session revocation | `lib/auth/registration.js`, `db/migrations/011_registration_auth.sql`, `docs/diagrams/workflow-email-verification-password-reset.mmd` | `tests/unit/registration-auth.test.js`, `tests/unit/registration-api.test.js` |
 | #163 Implement registration and login APIs | `/auth/register`, `/auth/login`, `/auth/me`, `/auth/logout`, disabled registration failure, cookie/CSRF session | `lib/audit/http.js`, `lib/auth/registration.js`, `docs/api/authenticated-browser-app-openapi.yml`, `docs/diagrams/workflow-registration-login-api.mmd` | `tests/unit/registration-api.test.js` |
 | #164 Add security observability and abuse controls | email/IP rate limits, registration-spike classification, login throttling, reset throttling, redacted audit, dashboard, alerts | `lib/auth/registration.js`, `monitoring/dashboards/registration-auth-security.json`, `monitoring/alerts/registration-auth-security.yml`, `docs/diagrams/workflow-registration-auth-abuse-controls.mmd`, `docs/diagrams/schema-registration-auth-abuse-controls.mmd` | `tests/unit/registration-auth.test.js`, `tests/unit/registration-production-smoke.test.js` |
@@ -47,12 +51,13 @@ Resolved in this branch:
 - Disabled magic-link request/consume routes for active sign-in.
 - Added diagrams, dashboard, alerts, OpenAPI, runbooks, and ownership mapping.
 - Updated the migration runner to skip rollback files during normal forward migration and added a regression test.
+- Added live Postgres coverage for the registration auth migration apply, rollback, and reapply cycle in an isolated test schema.
 
 ## Standards Alignment
 
 - Applicable standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; observability and monitoring; team and process.
 - Evidence in this report: Requirement matrix, audit loop, production smoke evidence, registration security dashboard and alert references, and test/gate results recorded below.
-- Gap observed: No remaining compliance gap. Documented rationale: the 2026-05-08 audit loop resolved the missing deployed smoke evidence and migration-runner rollback-file issue; fresh deployed registration smoke evidence is present in `observability/registration-auth-production-smoke.json`, and `npm run auth:status:check -- --require-complete` passes for the selected `registration` strategy (source https://github.com/wiinc1/engineering-team/issues/166).
+- Gap observed: No remaining compliance gap. Documented rationale: the 2026-05-08 audit loop resolved the missing deployed smoke evidence, migration-runner rollback-file issue, PR #159 traceability, conceptual flag mapping, and live registration migration rollback/reapply coverage; fresh deployed registration smoke evidence is present in `observability/registration-auth-production-smoke.json`, and `npm run auth:status:check -- --require-complete` passes for the selected `registration` strategy (source https://github.com/wiinc1/engineering-team/issues/166).
 
 ## Required Evidence
 

--- a/docs/runbooks/production-auth-status.md
+++ b/docs/runbooks/production-auth-status.md
@@ -12,6 +12,8 @@ Registration auth replaces the durable no-IdP magic-link path. Production must e
 
 Issue #151 is superseded by the registration cutover work in Issues #160-#167. The production status gate still exists, but its selected strategy and smoke evidence are now registration-based. Magic-link evidence is historical only and cannot satisfy the ship gate.
 
+PR #159 is the prior Issue #151 production-auth evidence path and is reconciled as historical. Its magic-link/OIDC status evidence is superseded by PR #168, the registration smoke artifact, and this runbook's registration-only production gate.
+
 Registration mode must be explicit:
 
 - `open`: public registration creates active or pending-verification accounts based on email-verification policy.
@@ -84,6 +86,19 @@ If registration must be rolled back before full removal is complete, use the doc
 - Post-logout `/auth/me` is rejected.
 - Monitoring evidence contains counts and classifications only.
 - Rollback target is identified.
+
+## Conceptual Flag Mapping
+
+The registration issues used `ff_registration_*` labels for rollout decisions. Production uses explicit environment gates and status checks instead of standalone feature-flag rows:
+
+| Issue label | Production gate |
+|---|---|
+| `ff_registration_auth_strategy` | `AUTH_PRODUCTION_AUTH_STRATEGY=registration` and browser runtime strategy evidence |
+| `ff_registration_credentials` | `AUTH_REGISTRATION_MODE` plus applied credential migration |
+| `ff_registration_email_verification` | `AUTH_REQUIRE_EMAIL_VERIFICATION` and `AUTH_EMAIL_VERIFICATION_TTL_HOURS` |
+| `ff_registration_password_reset` | `AUTH_PASSWORD_RESET_TTL_MINUTES` and reset endpoint smoke evidence |
+| `ff_registration_abuse_controls` | login, registration, reset throttling and redacted monitoring evidence |
+| `ff_registration_magic_link_removed` | `/auth/magic-link/request` returns `410`, consume redirects without a session, and magic-link evidence is rejected |
 
 ## Monitoring And Alerts
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:performance": "node --test tests/performance/*.test.js",
     "test:security": "node --test tests/security/*.test.js",
     "test:chaos": "node --test chaos/*.test.js",
-    "test:integration:postgres": "node --test tests/integration/audit-postgres-e2e.test.js",
+    "test:integration:postgres": "node --test tests/integration/audit-postgres-e2e.test.js tests/integration/registration-auth-migration-postgres.integration.test.js",
     "test:integration:api": "node --test tests/integration/audit-migrations.integration.test.js tests/integration/role-inbox-filtering.integration.test.js tests/integration/pm-overview-filtering.integration.test.js tests/integration/task-list-owner-filters.integration.test.js tests/integration/task-assignment-integration.test.js tests/integration/task-platform-source-policy.integration.test.js tests/integration/task-platform-github-check.integration.test.js tests/integration/task-platform-branch-protection.integration.test.js tests/integration/task-platform-pr-summary.integration.test.js tests/integration/specialist-delegation.integration.test.js",
     "test:integration:role-inbox": "node --test tests/integration/role-inbox-filtering.integration.test.js",
     "test:integration:pm-overview": "node --test tests/integration/pm-overview-filtering.integration.test.js",

--- a/tests/integration/registration-auth-migration-postgres.integration.test.js
+++ b/tests/integration/registration-auth-migration-postgres.integration.test.js
@@ -1,0 +1,129 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createPgPoolFromEnv } = require('../../lib/audit/postgres');
+
+const connectionString = process.env.DATABASE_URL;
+const shouldRun = !!connectionString;
+const pgTest = shouldRun ? test : test.skip;
+
+const registrationTables = [
+  'auth_credentials',
+  'auth_email_verification_tokens',
+  'auth_password_reset_tokens',
+  'auth_login_failures',
+];
+
+function quoteIdentifier(identifier) {
+  if (!/^[a-z][a-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Unsafe SQL identifier: ${identifier}`);
+  }
+  return `"${identifier}"`;
+}
+
+async function assertTablePresence(client, expected) {
+  for (const tableName of registrationTables) {
+    const result = await client.query('SELECT to_regclass($1) AS regclass', [tableName]);
+    assert.equal(
+      result.rows[0].regclass !== null,
+      expected,
+      `${tableName} presence should be ${expected}`
+    );
+  }
+}
+
+async function readAuthUsersStatusConstraint(client, schemaName) {
+  const result = await client.query(
+    `
+      SELECT pg_get_constraintdef(c.oid) AS definition
+      FROM pg_constraint c
+      JOIN pg_class rel ON rel.oid = c.conrelid
+      JOIN pg_namespace nsp ON nsp.oid = rel.relnamespace
+      WHERE nsp.nspname = $1
+        AND rel.relname = 'auth_users'
+        AND c.conname = 'chk_auth_users_status'
+    `,
+    [schemaName]
+  );
+  assert.equal(result.rows.length, 1);
+  return result.rows[0].definition;
+}
+
+function readMigrationSql(fileName) {
+  return fs.readFileSync(path.join(__dirname, '../..', 'db/migrations', fileName), 'utf8');
+}
+
+async function createAuthUsersBaseline(client) {
+  await client.query(`
+    CREATE TABLE auth_users (
+      user_id UUID PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'active',
+      CONSTRAINT chk_auth_users_status CHECK (status IN ('active', 'disabled'))
+    )
+  `);
+}
+
+async function assertRegistrationStatusesAllowed(client, schemaName) {
+  const statusConstraint = await readAuthUsersStatusConstraint(client, schemaName);
+  assert.match(statusConstraint, /pending_verification/);
+  assert.match(statusConstraint, /pending_approval/);
+  assert.match(statusConstraint, /invited/);
+}
+
+async function assertRegistrationStatusesRemoved(client, schemaName) {
+  const statusConstraint = await readAuthUsersStatusConstraint(client, schemaName);
+  assert.doesNotMatch(statusConstraint, /pending_verification/);
+  assert.doesNotMatch(statusConstraint, /pending_approval/);
+  assert.doesNotMatch(statusConstraint, /invited/);
+}
+
+async function insertPendingVerificationUser(client) {
+  await client.query(
+    "INSERT INTO auth_users (user_id, status) VALUES ('00000000-0000-0000-0000-000000000001', 'pending_verification')"
+  );
+}
+
+async function assertRollbackDisabledPendingUsers(client) {
+  const users = await client.query('SELECT status FROM auth_users');
+  assert.deepEqual(
+    users.rows.map((row) => row.status),
+    ['disabled']
+  );
+}
+
+pgTest(
+  'registration auth migration applies, rolls back, and reapplies on live postgres',
+  async () => {
+    const upSql = readMigrationSql('011_registration_auth.sql');
+    const downSql = readMigrationSql('011_registration_auth.down.sql');
+    const pool = createPgPoolFromEnv(connectionString);
+    const client = await pool.connect();
+    const schemaName = `registration_migration_${process.pid}_${Date.now()}`;
+    const schemaIdentifier = quoteIdentifier(schemaName);
+
+    try {
+      await client.query(`CREATE SCHEMA ${schemaIdentifier}`);
+      await client.query(`SET search_path TO ${schemaIdentifier}`);
+      await createAuthUsersBaseline(client);
+
+      await client.query(upSql);
+      await assertTablePresence(client, true);
+      await assertRegistrationStatusesAllowed(client, schemaName);
+      await insertPendingVerificationUser(client);
+
+      await client.query(downSql);
+      await assertTablePresence(client, false);
+      await assertRegistrationStatusesRemoved(client, schemaName);
+      await assertRollbackDisabledPendingUsers(client);
+
+      await client.query(upSql);
+      await assertTablePresence(client, true);
+      await assertRegistrationStatusesAllowed(client, schemaName);
+    } finally {
+      await client.query(`DROP SCHEMA IF EXISTS ${schemaIdentifier} CASCADE`);
+      client.release();
+      await pool.end();
+    }
+  }
+);


### PR DESCRIPTION
## Summary
- Reconcile PR #159 explicitly as historical Issue #151 production-auth evidence superseded by registration auth.
- Map the issue text's ff_registration_* rollout labels to the implemented environment/status gates.
- Add a live Postgres integration test for the 011 registration auth migration apply -> rollback -> reapply cycle in an isolated schema, and include it in test:integration:postgres.

Refs #160
Refs #161

## Standards Evidence
- Task: Follow-up registration auth audit hardening for Issues #160 and #161.
- Standards baseline reviewed: Yes, current standards and maintainability gates were run.
- Checklist completed or updated: Yes, registration auth audit report updated.
- Compliance checklist path: docs/reports/ISSUE-160-167-registration-auth-audit.md
- Relevant standards areas: architecture and design; testing and quality assurance; deployment and release; team and process.
- Standards gaps or exceptions: No remaining compliance gaps after PR #159 traceability, conceptual flag mapping, and live migration rollback coverage.
- Standards check result: Passed npm run standards:check.
- Lint result: Passed npm run lint.
- Tests: Passed focused registration tests, production auth status check, unit suite, and Postgres integration suite.
- Test evidence paths: tests/integration/registration-auth-migration-postgres.integration.test.js
- Docs updated: Yes, policy, runbook, and audit report updated.
- Doc evidence paths: docs/design/ISSUE-160-registration-auth-policy.md, docs/runbooks/production-auth-status.md, docs/reports/ISSUE-160-167-registration-auth-audit.md
- Risk level: Low, docs plus isolated integration coverage only.
- Rollback path: Revert commit c5b6572 to remove the traceability docs and migration integration test.

## Verification
- node --test tests/unit/registration-auth.test.js tests/unit/production-auth-status.test.js tests/integration/audit-migrations.integration.test.js tests/integration/registration-auth-migration-postgres.integration.test.js
- npm run auth:status:check -- --require-complete
- npm run standards:check
- npm run lint
- npm run change:check
- npm run ownership:lint
- npm run test:unit
- env DATABASE_URL=postgres://audit:audit@127.0.0.1:55432/engineering_team PGSSLMODE=disable npm run audit:migrate
- env DATABASE_URL=postgres://audit:audit@127.0.0.1:55432/engineering_team PGSSLMODE=disable npm run test:integration:postgres