### PR TITLE
Add local DESIGN.md operational gates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ data/
 .vercel
 .artifacts/
 .env*.local
+docs/design/no-design-impact.txt
 __pycache__/
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,13 @@ CHANGE_COMMANDS ?= make verify
 CHANGE_EVIDENCE ?= local-verify
 RELEASE_ENV ?= dev
 
-.PHONY: lint typecheck test build verify
+.PHONY: design-local-gates lint typecheck test build verify
+
+design-local-gates:
+	npm run design:tokens:check
+	npm run design:tokens:enforce
+	npm run design:audit:check
+	npm run design:change-guard
 
 lint:
 	$(PYTHON) dev-standards/tooling/validate_policy_files.py --repo-root $(REPO_ROOT)
@@ -28,8 +34,6 @@ lint:
 	$(PYTHON) dev-standards/tooling/validate_config_boundaries.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))
 	$(PYTHON) dev-standards/tooling/validate_architecture.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))
 	$(PYTHON) dev-standards/tooling/validate_visual_identity.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))
-	npm run design:tokens:check
-	npm run design:tokens:enforce
 	CHANGE_KIND=$(CHANGE_KIND) CHANGE_REFERENCE=$(CHANGE_REFERENCE) $(PYTHON) dev-standards/tooling/validate_docs_freshness.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))
 	CHANGE_KIND=$(CHANGE_KIND) CHANGE_REVERSIBILITY=$(CHANGE_REVERSIBILITY) $(PYTHON) dev-standards/tooling/validate_release_evidence.py --repo-root $(REPO_ROOT) --environment $(RELEASE_ENV)
 	$(PYTHON) dev-standards/tooling/check_maintainability.py --repo-root $(REPO_ROOT)
@@ -43,6 +47,6 @@ test:
 build:
 	PYTHONPYCACHEPREFIX=$(PYCACHE_PREFIX) $(PYTHON) -m compileall tests dev-standards
 
-verify: lint typecheck test build
+verify: design-local-gates lint typecheck test build
 	$(PYTHON) dev-standards/tooling/validate_artifact_provenance.py --repo-root $(REPO_ROOT)
 	CHANGE_KIND=$(CHANGE_KIND) $(PYTHON) dev-standards/tooling/validate_test_policy.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))

--- a/README.md
+++ b/README.md
@@ -13,11 +13,21 @@ Every task file under `tasks/` is expected to carry `## Standards Alignment` and
 
 ## Visual Design Tokens
 
-`DESIGN.md` is the visual design source of truth. Before UI changes, read `DESIGN.md`; change reusable visual tokens there first; regenerate committed CSS outputs with `npm run design:tokens`; do not add hard-coded visual values to migrated CSS. Verify UI token work with `npm run design:tokens:check`, `npm run design:tokens:enforce`, and `make verify`.
+`DESIGN.md` is the visual design source of truth. GitHub Actions is not required for DESIGN.md enforcement; the local source of truth is `make verify`. Before UI changes, read `DESIGN.md`; change reusable visual tokens there first; regenerate committed CSS outputs with `npm run design:tokens`; do not add hard-coded visual values to migrated CSS. Verify UI token work with `npm run design:tokens:check`, `npm run design:tokens:enforce`, `npm run design:audit:check`, `npm run design:change-guard`, and `make verify`.
 
 Rare one-off values in migrated CSS must use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`. Reusable exceptions must become `DESIGN.md` tokens.
 
-The enforced authored CSS scope is tracked in `docs/design/design-md-adoption.config.json` and summarized in `docs/design/DESIGN_MD_ADOPTION_AUDIT.md`. Update both when a new UI component family or authored CSS module enters token enforcement.
+The enforced authored CSS scope is tracked in `docs/design/design-md-adoption.config.json` and generated into `docs/design/DESIGN_MD_ADOPTION_AUDIT.md`. Update the config when a new UI component family or authored CSS module enters token enforcement, then run `npm run design:audit`.
+
+Install local hooks with:
+
+```bash
+scripts/setup-local-hooks.sh
+```
+
+This configures `core.hooksPath` to `scripts/hooks`. The pre-commit hook runs the local DESIGN.md gates, and the pre-push hook runs `make verify`.
+
+If a UI file changes with no design impact, create a local `docs/design/no-design-impact.txt` containing a short reason. Keep the marker local and remove it after the change is complete; reusable visual decisions still belong in `DESIGN.md`.
 
 ## Audit foundation slice
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -84,5 +84,7 @@
 - Every task file must include `## Standards Alignment` and `## Required Evidence`.
 - Gap statements must use: `Gap observed: X. Documented rationale: Y (source Z).`
 - PRs and implementation notes should point back to `docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md`.
-- For UI work, read `DESIGN.md` before editing styles, change reusable visual tokens in `DESIGN.md` first, regenerate with `npm run design:tokens`, avoid hard-coded visual values in migrated CSS, then run `npm run design:tokens:check`, `npm run design:tokens:enforce`, and `make verify`.
-- One-off migrated CSS exceptions must use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`; reusable exceptions must become `DESIGN.md` tokens.
+- For UI work, read `DESIGN.md` before editing styles, change reusable visual tokens in `DESIGN.md` first, regenerate with `npm run design:tokens`, avoid hard-coded visual values in migrated CSS, then run `npm run design:tokens:check`, `npm run design:tokens:enforce`, `npm run design:audit:check`, `npm run design:change-guard`, and `make verify`.
+- GitHub Actions is not required for DESIGN.md enforcement. The local source of truth is `make verify`; install local hooks with `scripts/setup-local-hooks.sh` so pre-commit runs the DESIGN.md gates and pre-push runs full verification.
+- One-off migrated CSS exceptions must use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`; reusable exceptions must become `DESIGN.md` tokens and duplicate exception reasons are not allowed.
+- If a UI change has no design impact, use a local `docs/design/no-design-impact.txt` marker with a short reason, keep it out of the commit, and remove it after the change is complete.

--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -567,7 +567,9 @@
       "runtime_patterns": [
         "^scripts/lint-repo\\.js$",
         "^scripts/governance-lib\\.js$",
-        "^scripts/(check-design-token-usage|generate-design-tokens)\\.mjs$",
+        "^scripts/(check-design-change-guard|check-design-token-usage|generate-design-adoption-audit|generate-design-tokens)\\.mjs$",
+        "^scripts/(finish-ui-change|setup-local-hooks)\\.sh$",
+        "^scripts/hooks/(pre-commit|pre-push)$",
         "^scripts/(check-coverage-policy|check-maintainability|run-coverage)\\.js$",
         "^scripts/(governance-drift|lint-change-ownership-map)\\.js$",
         "^scripts/verify-(standards|pr-body|change-completeness)\\.js$"

--- a/config/maintainability-baseline.json
+++ b/config/maintainability-baseline.json
@@ -169,15 +169,6 @@
       "cap": 50
     },
     {
-      "path": "scripts/check-design-token-usage.mjs",
-      "rule": "maintainability:function-lines",
-      "line": 190,
-      "ordinal": 14,
-      "name": "scanFile",
-      "actual": 55,
-      "cap": 50
-    },
-    {
       "path": "src/app/session.browser.js",
       "rule": "maintainability:function-lines",
       "line": 305,

--- a/docs/design/DESIGN_MD_ADOPTION_AUDIT.md
+++ b/docs/design/DESIGN_MD_ADOPTION_AUDIT.md
@@ -1,12 +1,14 @@
 # DESIGN.md Adoption Audit
 
-Date: 2026-05-08
+Generated from: `docs/design/design-md-adoption.config.json`
+Date: 2026-05-09
 
 ## Summary
 
-`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual value enforcement for all authored UI CSS, PR guidance, agent guidance, machine-readable audit config, and screenshot smoke coverage.
+`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual value enforcement for all authored UI CSS, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage.
 
 Machine-readable audit config: `docs/design/design-md-adoption.config.json`
+Generated audit document: `docs/design/DESIGN_MD_ADOPTION_AUDIT.md`
 
 ## Component Coverage
 
@@ -24,7 +26,7 @@ Machine-readable audit config: `docs/design/design-md-adoption.config.json`
 
 ## Optional DESIGN.md Area Audit
 
-| Area | Status | Notes |
+| Area | Status | Reason |
 | --- | --- | --- |
 | Accessibility | Implemented | `DESIGN.md` includes app-specific requirements for WCAG AA contrast, visible keyboard focus, touch target sizing, disabled/loading state legibility, label/error association, overflow behavior, text wrapping, and reduced motion. |
 | Iconography | Implemented | The product is text-first and has no shipped icon set. `DESIGN.md` allows lightweight status glyphs only as secondary decoration paired with visible text and semantic color, and records that any future icon library must use one consistent style and ADR-backed dependency. |
@@ -33,9 +35,9 @@ Machine-readable audit config: `docs/design/design-md-adoption.config.json`
 | Localization | N/A | Localization and RTL are explicitly not current requirements. `DESIGN.md` still defines text expansion, fixed-height avoidance, readable line length, and explicit RTL declaration expectations. |
 | Navigation | Implemented | `DESIGN.md` includes route and role-surface rules for task workspace, intake, PM overview, governance, deferred considerations, role inboxes, protected-route recovery, and permission-gated controls. Runtime nav styles consume generated variables in `src/app/styles.css`. |
 | Data Visualization | Implemented | `DESIGN.md` defines current telemetry-card, timeline, table, log, label, metadata, task-detail read-model, freshness, redaction, and no-hover-only rules. Rich charting remains blocked until chart-specific tokens are added. |
-| Multi-Brand Theming | N/A | The repo has one internal product identity: Engineering Team Software Factory Control Plane. No multi-brand or tenant-brand theming requirement is present. Add an ADR and token strategy before introducing multi-brand runtime theming. |
+| Multi Brand Theming | N/A | The repo has one internal product identity: Engineering Team Software Factory Control Plane. No multi-brand or tenant-brand theming requirement is present. Add an ADR and token strategy before introducing multi-brand runtime theming. |
 | Motion | Implemented | `DESIGN.md` keeps motion intentionally limited: respect reduced motion, never use motion as the only state indicator, keep transitions local and short, and add duration/easing tokens before reusable animation patterns. |
-| Visual Regression | Implemented | Existing browser screenshots cover task detail. This PR adds screenshot smoke coverage for the primary app screen, Button states, TaskCreationForm token output, task-detail states, and mobile task-detail layout. This is smoke coverage, not a full pixel-baseline system. |
+| Visual Regression | Implemented Smoke | Existing browser screenshots cover task detail. The design-token smoke spec covers the primary app screen, Button states, TaskCreationForm token output, task-detail states, and mobile task-detail layout. This is smoke coverage, not a full pixel-baseline system. |
 
 ## Acceptance Criteria Status
 
@@ -44,15 +46,15 @@ Machine-readable audit config: `docs/design/design-md-adoption.config.json`
 | `DESIGN.md` is declared as source of truth. | Pass | `DESIGN.md` source-of-truth decision and `repo-contract.yaml` `visual_identity.file: DESIGN.md`. |
 | Generated token files are reproducible. | Pass | `npm run design:tokens` regenerates committed outputs; `npm run design:tokens:check` compares generated content with committed files. |
 | Drift check fails if generated files are stale. | Pass | `scripts/generate-design-tokens.mjs --check` exits nonzero when an output differs or is missing. |
-| Enforcement blocks new hard-coded visual values. | Pass | `scripts/check-design-token-usage.mjs` scans all authored UI CSS listed in `docs/design/design-md-adoption.config.json`, rejects forbidden literals unless a reasoned `DESIGN-TOKEN-EXCEPTION:` is present, and fails if authored CSS falls outside enforcement scope. Focused unit coverage validates pass, fail, exception, missing-reason, generated-output allowlist, config scope, and audit coverage behavior. |
+| Enforcement blocks new hard-coded visual values. | Pass | `scripts/check-design-token-usage.mjs` scans all authored UI CSS listed in `docs/design/design-md-adoption.config.json`, rejects forbidden literals unless a reasoned `DESIGN-TOKEN-EXCEPTION:` is present within the configured budget, and fails if authored CSS falls outside enforcement scope. |
 | Migrated components use generated variables. | Pass | Global styles, Button, TaskCreationForm, and task-detail modules import generated token CSS and use `var(--...)` values. TaskCreationForm and StageTransition preserve label/error associations required by `DESIGN.md`. |
-| Optional areas are implemented, explicitly N/A, or tracked as follow-up. | Pass | The optional area table above marks implemented, N/A, and follow-up items. |
+| Optional areas are implemented, explicitly N/A, or tracked as follow-up. | Pass | The optional area table above marks implemented, N/A, and smoke-backed items with reasons. |
 | Screenshot smoke tests cover at least the primary screen and migrated components. | Pass | `tests/browser/design-token-operationalization.browser.spec.ts` captures primary app, Button states, TaskCreationForm token output, task-detail state panels, and mobile task-detail layout. |
-| `make verify` passes. | Pass | Latest local verification passed with only the existing non-blocking maintainability warning on `dev-standards/templates/DESIGN.md`. |
+| `make verify` passes. | Pass | Local verification is the source of truth for DESIGN.md guarantees and runs token drift, token usage, generated audit, and design change guard checks before the rest of the repo verification. |
 
 ## Follow-Up Backlog
 
-- Keep `docs/design/DESIGN_MD_ADOPTION_AUDIT.md` and `docs/design/design-md-adoption.config.json` synchronized whenever a new authored UI CSS file is added.
+- Keep `docs/design/design-md-adoption.config.json` synchronized whenever a new authored UI CSS file is added; regenerate `docs/design/DESIGN_MD_ADOPTION_AUDIT.md` with `npm run design:audit`.
 - Add chart-specific `DESIGN.md` tokens before introducing richer charting or graph components.
 - Add duration/easing tokens before introducing reusable animation patterns.
 - Consider full screenshot baseline assertions if the product needs stronger visual regression guarantees than smoke screenshots.

--- a/docs/design/design-md-adoption.config.json
+++ b/docs/design/design-md-adoption.config.json
@@ -2,6 +2,11 @@
   "schema_version": "1.0",
   "source_of_truth": "DESIGN.md",
   "audit_document": "docs/design/DESIGN_MD_ADOPTION_AUDIT.md",
+  "audit": {
+    "date": "2026-05-09",
+    "summary": "`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual value enforcement for all authored UI CSS, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage."
+  },
+  "exceptionBudget": 0,
   "generated_outputs": [
     "src/app/design-tokens.css",
     "src/components/Button/Button.tokens.css",
@@ -30,19 +35,22 @@
       "area": "Global styles",
       "uses_design_tokens": "yes",
       "enforcement_covered": true,
-      "paths": ["src/app/styles.css"]
+      "paths": ["src/app/styles.css"],
+      "notes": "`src/app/styles.css` imports `src/app/design-tokens.css` and maps core colors, typography, radius, shadows, focus, navigation, panels, cards, status, table, and list tokens. The enforcement script scans this file."
     },
     {
       "area": "Button",
       "uses_design_tokens": "yes",
       "enforcement_covered": true,
-      "paths": ["src/components/Button/Button.module.css"]
+      "paths": ["src/components/Button/Button.module.css"],
+      "notes": "`src/components/Button/Button.module.css` imports `Button.tokens.css`; the generated token file is declared in `repo-contract.yaml`; enforcement scans the authored module."
     },
     {
       "area": "TaskCreationForm",
       "uses_design_tokens": "yes",
       "enforcement_covered": true,
-      "paths": ["src/features/task-creation/TaskCreationForm.module.css"]
+      "paths": ["src/features/task-creation/TaskCreationForm.module.css"],
+      "notes": "`src/features/task-creation/TaskCreationForm.module.css` imports `TaskCreationForm.tokens.css`; the generated token file is declared in `repo-contract.yaml`; enforcement scans the authored module."
     },
     {
       "area": "Task detail modules",
@@ -53,19 +61,133 @@
         "src/features/task-detail/TaskDetailActivityShell.module.css",
         "src/features/task-detail/TaskHistoryTimeline.module.css",
         "src/features/task-detail/TelemetrySummary.module.css"
-      ]
+      ],
+      "notes": "`StageTransition.module.css`, `TaskDetailActivityShell.module.css`, `TaskHistoryTimeline.module.css`, and `TelemetrySummary.module.css` import `TaskDetail.tokens.css`; enforcement scans every authored task-detail CSS module."
+    },
+    {
+      "area": "Inputs/forms",
+      "uses_design_tokens": "yes",
+      "enforcement_covered": true,
+      "paths": [],
+      "notes": "Global form controls, TaskCreationForm, task-detail filters, and stage-transition fields consume generated variables."
+    },
+    {
+      "area": "Links/nav",
+      "uses_design_tokens": "yes",
+      "enforcement_covered": true,
+      "paths": [],
+      "notes": "App navigation in `src/app/styles.css` consumes generated color, radius, border, and typography variables. Link semantics exist in `DESIGN.md`; no separate authored link module exists."
+    },
+    {
+      "area": "Panels/cards",
+      "uses_design_tokens": "yes",
+      "enforcement_covered": true,
+      "paths": [],
+      "notes": "App panels, cards, auth card, board cards, summary cards, task-detail panels, timeline cards, and telemetry cards use generated variables and are enforcement-covered."
+    },
+    {
+      "area": "Badges/status",
+      "uses_design_tokens": "yes",
+      "enforcement_covered": true,
+      "paths": [],
+      "notes": "Global task status pills, review badges, routing badges, status banners, timeline tones, telemetry tones, and task-detail notices use semantic generated variables."
+    },
+    {
+      "area": "Tables/lists",
+      "uses_design_tokens": "yes",
+      "enforcement_covered": true,
+      "paths": [],
+      "notes": "Global task list and board list styles use generated variables. Task history timeline uses generated `history-*` variables and is enforcement-covered."
     }
   ],
   "optional_areas": {
-    "accessibility": "implemented",
-    "iconography": "implemented",
-    "imagery": "not_applicable",
-    "content_tone": "implemented",
-    "localization": "not_applicable",
-    "navigation": "implemented",
-    "data_visualization": "implemented",
-    "multi_brand_theming": "not_applicable",
-    "motion": "implemented",
-    "visual_regression": "implemented_smoke"
-  }
+    "accessibility": {
+      "status": "implemented",
+      "reason": "`DESIGN.md` includes app-specific requirements for WCAG AA contrast, visible keyboard focus, touch target sizing, disabled/loading state legibility, label/error association, overflow behavior, text wrapping, and reduced motion."
+    },
+    "iconography": {
+      "status": "implemented",
+      "reason": "The product is text-first and has no shipped icon set. `DESIGN.md` allows lightweight status glyphs only as secondary decoration paired with visible text and semantic color, and records that any future icon library must use one consistent style and ADR-backed dependency."
+    },
+    "imagery": {
+      "status": "not_applicable",
+      "reason": "The product has no logo, illustration, or brand-image asset system. `DESIGN.md` directs operational screens toward real product state, tables, task records, charts, logs, and reviewed asset provenance if imagery is introduced."
+    },
+    "content_tone": {
+      "status": "implemented",
+      "reason": "`DESIGN.md` has app-specific UI copy guidance for task actions, empty states, errors, and workflow status labels."
+    },
+    "localization": {
+      "status": "not_applicable",
+      "reason": "Localization and RTL are explicitly not current requirements. `DESIGN.md` still defines text expansion, fixed-height avoidance, readable line length, and explicit RTL declaration expectations."
+    },
+    "navigation": {
+      "status": "implemented",
+      "reason": "`DESIGN.md` includes route and role-surface rules for task workspace, intake, PM overview, governance, deferred considerations, role inboxes, protected-route recovery, and permission-gated controls. Runtime nav styles consume generated variables in `src/app/styles.css`."
+    },
+    "data_visualization": {
+      "status": "implemented",
+      "reason": "`DESIGN.md` defines current telemetry-card, timeline, table, log, label, metadata, task-detail read-model, freshness, redaction, and no-hover-only rules. Rich charting remains blocked until chart-specific tokens are added."
+    },
+    "multi_brand_theming": {
+      "status": "not_applicable",
+      "reason": "The repo has one internal product identity: Engineering Team Software Factory Control Plane. No multi-brand or tenant-brand theming requirement is present. Add an ADR and token strategy before introducing multi-brand runtime theming."
+    },
+    "motion": {
+      "status": "implemented",
+      "reason": "`DESIGN.md` keeps motion intentionally limited: respect reduced motion, never use motion as the only state indicator, keep transitions local and short, and add duration/easing tokens before reusable animation patterns."
+    },
+    "visual_regression": {
+      "status": "implemented_smoke",
+      "reason": "Existing browser screenshots cover task detail. The design-token smoke spec covers the primary app screen, Button states, TaskCreationForm token output, task-detail states, and mobile task-detail layout. This is smoke coverage, not a full pixel-baseline system."
+    }
+  },
+  "acceptance_criteria": [
+    {
+      "criterion": "`DESIGN.md` is declared as source of truth.",
+      "status": "pass",
+      "evidence": "`DESIGN.md` source-of-truth decision and `repo-contract.yaml` `visual_identity.file: DESIGN.md`."
+    },
+    {
+      "criterion": "Generated token files are reproducible.",
+      "status": "pass",
+      "evidence": "`npm run design:tokens` regenerates committed outputs; `npm run design:tokens:check` compares generated content with committed files."
+    },
+    {
+      "criterion": "Drift check fails if generated files are stale.",
+      "status": "pass",
+      "evidence": "`scripts/generate-design-tokens.mjs --check` exits nonzero when an output differs or is missing."
+    },
+    {
+      "criterion": "Enforcement blocks new hard-coded visual values.",
+      "status": "pass",
+      "evidence": "`scripts/check-design-token-usage.mjs` scans all authored UI CSS listed in `docs/design/design-md-adoption.config.json`, rejects forbidden literals unless a reasoned `DESIGN-TOKEN-EXCEPTION:` is present within the configured budget, and fails if authored CSS falls outside enforcement scope."
+    },
+    {
+      "criterion": "Migrated components use generated variables.",
+      "status": "pass",
+      "evidence": "Global styles, Button, TaskCreationForm, and task-detail modules import generated token CSS and use `var(--...)` values. TaskCreationForm and StageTransition preserve label/error associations required by `DESIGN.md`."
+    },
+    {
+      "criterion": "Optional areas are implemented, explicitly N/A, or tracked as follow-up.",
+      "status": "pass",
+      "evidence": "The optional area table above marks implemented, N/A, and smoke-backed items with reasons."
+    },
+    {
+      "criterion": "Screenshot smoke tests cover at least the primary screen and migrated components.",
+      "status": "pass",
+      "evidence": "`tests/browser/design-token-operationalization.browser.spec.ts` captures primary app, Button states, TaskCreationForm token output, task-detail state panels, and mobile task-detail layout."
+    },
+    {
+      "criterion": "`make verify` passes.",
+      "status": "pass",
+      "evidence": "Local verification is the source of truth for DESIGN.md guarantees and runs token drift, token usage, generated audit, and design change guard checks before the rest of the repo verification."
+    }
+  ],
+  "follow_up_backlog": [
+    "Keep `docs/design/design-md-adoption.config.json` synchronized whenever a new authored UI CSS file is added; regenerate `docs/design/DESIGN_MD_ADOPTION_AUDIT.md` with `npm run design:audit`.",
+    "Add chart-specific `DESIGN.md` tokens before introducing richer charting or graph components.",
+    "Add duration/easing tokens before introducing reusable animation patterns.",
+    "Consider full screenshot baseline assertions if the product needs stronger visual regression guarantees than smoke screenshots."
+  ]
 }

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -8,16 +8,37 @@ Run the standards gate locally:
 make verify
 ```
 
+`make verify` is the local source of truth for DESIGN.md enforcement. GitHub Actions can repeat these checks, but it is not required for any DESIGN.md guarantee.
+
 For UI token work, run:
 
 ```bash
 npm run design:tokens
 npm run design:tokens:check
 npm run design:tokens:enforce
+npm run design:audit:check
+npm run design:change-guard
 make verify
 ```
 
 Read `DESIGN.md` before UI changes, change reusable visual semantics there first, and avoid hard-coded visual values in migrated CSS. A rare one-off must use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`; reusable exceptions must be promoted into `DESIGN.md`.
+
+Install local hooks once per clone:
+
+```bash
+scripts/setup-local-hooks.sh
+```
+
+This runs:
+
+```bash
+git config core.hooksPath scripts/hooks
+chmod +x scripts/hooks/pre-commit scripts/hooks/pre-push
+```
+
+The pre-commit hook runs token drift, token usage, generated audit, and design change guard checks. The pre-push hook runs `make verify`.
+
+If an authored UI file changes but there is truly no visual or UX impact, create `docs/design/no-design-impact.txt` with a short reason. Keep the marker local, do not use it for reusable visual decisions, and remove it after the change is complete.
 
 ## Operational Notes
 

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "design:tokens": "node scripts/generate-design-tokens.mjs",
     "design:tokens:check": "node scripts/generate-design-tokens.mjs --check",
     "design:tokens:enforce": "node scripts/check-design-token-usage.mjs",
+    "design:audit": "node scripts/generate-design-adoption-audit.mjs",
+    "design:audit:check": "node scripts/generate-design-adoption-audit.mjs --check",
+    "design:change-guard": "node scripts/check-design-change-guard.mjs",
     "design:lint": "design.md lint DESIGN.md"
   },
   "repository": {

--- a/scripts/check-design-change-guard.mjs
+++ b/scripts/check-design-change-guard.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONFIG_PATH = 'docs/design/design-md-adoption.config.json';
+const REPO_CONTRACT_PATH = 'repo-contract.yaml';
+const NO_DESIGN_IMPACT_MARKER = 'docs/design/no-design-impact.txt';
+const DESIGN_ARTIFACTS = [
+  'DESIGN.md',
+  CONFIG_PATH,
+  'docs/design/DESIGN_MD_ADOPTION_AUDIT.md',
+];
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+function runGit(args) {
+  try {
+    return execFileSync('git', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function gitList(args) {
+  const output = runGit(args);
+  return output ? output.split('\n').map((file) => normalizePath(file.trim())).filter(Boolean) : [];
+}
+
+function readConfig() {
+  if (!fs.existsSync(CONFIG_PATH)) return {};
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+}
+
+function generatedOutputsFromRepoContract() {
+  if (!fs.existsSync(REPO_CONTRACT_PATH)) return [];
+  const lines = fs.readFileSync(REPO_CONTRACT_PATH, 'utf8').split(/\r?\n/);
+  const outputs = [];
+  let inVisualIdentity = false;
+  let inGeneratedOutputs = false;
+  let inPaths = false;
+
+  for (const rawLine of lines) {
+    const indent = rawLine.match(/^\s*/)?.[0].length ?? 0;
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    if (indent === 0) {
+      inVisualIdentity = line === 'visual_identity:';
+      inGeneratedOutputs = false;
+      inPaths = false;
+      continue;
+    }
+
+    if (!inVisualIdentity) continue;
+    if (indent === 2) {
+      inGeneratedOutputs = line === 'generated_outputs:';
+      inPaths = false;
+      continue;
+    }
+    if (!inGeneratedOutputs) continue;
+    if (indent === 4) {
+      inPaths = line === 'paths:';
+      continue;
+    }
+    if (inPaths && indent >= 4 && line.startsWith('- ')) {
+      outputs.push(line.slice(2).trim().replace(/^['"]|['"]$/g, ''));
+    }
+  }
+
+  return outputs.map(normalizePath);
+}
+
+function mergeBaseFiles() {
+  const candidates = ['origin/main', 'main', 'refs/remotes/origin/main', 'refs/heads/main'];
+  for (const candidate of candidates) {
+    const base = runGit(['merge-base', 'HEAD', candidate]);
+    if (base) {
+      return gitList(['diff', '--name-only', `${base}...HEAD`]);
+    }
+  }
+  return [];
+}
+
+function changedFiles() {
+  return Array.from(new Set([
+    ...gitList(['diff', '--cached', '--name-only']),
+    ...gitList(['diff', '--name-only']),
+    ...gitList(['ls-files', '--others', '--exclude-standard']),
+    ...mergeBaseFiles(),
+  ])).sort();
+}
+
+function designArtifactSet(config) {
+  return new Set([
+    ...DESIGN_ARTIFACTS,
+    ...(config.generated_outputs || []),
+    ...(config.enforcement?.generated_allowlist || []),
+    ...generatedOutputsFromRepoContract(),
+  ].map(normalizePath));
+}
+
+function authoredUiFile(filePath, config, designArtifacts) {
+  const normalized = normalizePath(filePath);
+  if (designArtifacts.has(normalized)) return false;
+  if (normalized.endsWith('.tokens.css')) return false;
+  if ((config.enforcement?.paths || []).map(normalizePath).includes(normalized)) return true;
+  return /^src\/(?:app|components|features)\/.+\.(?:css|jsx|tsx)$/.test(normalized);
+}
+
+function markerReason() {
+  if (!fs.existsSync(NO_DESIGN_IMPACT_MARKER)) return '';
+  return fs.readFileSync(NO_DESIGN_IMPACT_MARKER, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .join(' ')
+    .trim();
+}
+
+function main() {
+  const config = readConfig();
+  const files = changedFiles();
+  const designArtifacts = designArtifactSet(config);
+  const uiFiles = files.filter((file) => authoredUiFile(file, config, designArtifacts));
+  const changedDesignArtifacts = files.filter((file) => designArtifacts.has(normalizePath(file)));
+
+  if (uiFiles.length === 0) {
+    process.stdout.write('design change guard passed: no authored UI files changed\n');
+    return;
+  }
+
+  if (changedDesignArtifacts.length > 0) {
+    process.stdout.write(`design change guard passed: ${uiFiles.length} UI file(s), ${changedDesignArtifacts.length} design artifact(s)\n`);
+    return;
+  }
+
+  const reason = markerReason();
+  if (reason) {
+    process.stdout.write(`design change guard passed with ${NO_DESIGN_IMPACT_MARKER}: ${reason}\n`);
+    return;
+  }
+
+  process.stderr.write('Design change guard failed.\n');
+  process.stderr.write('Authored UI files changed without a related DESIGN.md artifact:\n');
+  for (const file of uiFiles) {
+    process.stderr.write(`- ${file}\n`);
+  }
+  process.stderr.write('Update at least one related design artifact:\n');
+  for (const artifact of designArtifacts) {
+    process.stderr.write(`- ${artifact}\n`);
+  }
+  process.stderr.write(`If this truly has no design impact, create ${NO_DESIGN_IMPACT_MARKER} with a short reason, keep it local, and remove it after the change is complete.\n`);
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-design-change-guard.mjs
+++ b/scripts/check-design-change-guard.mjs
@@ -84,13 +84,23 @@ function mergeBaseFiles() {
   return [];
 }
 
-function changedFiles() {
-  return Array.from(new Set([
+function uniqueSorted(files) {
+  return Array.from(new Set(files)).sort();
+}
+
+function localFiles() {
+  return uniqueSorted([
     ...gitList(['diff', '--cached', '--name-only']),
     ...gitList(['diff', '--name-only']),
     ...gitList(['ls-files', '--others', '--exclude-standard']),
-    ...mergeBaseFiles(),
-  ])).sort();
+  ]);
+}
+
+function changedFileScopes() {
+  return [
+    { name: 'local', files: localFiles() },
+    { name: 'branch', files: mergeBaseFiles() },
+  ].filter((scope) => scope.files.length > 0);
 }
 
 function designArtifactSet(config) {
@@ -120,20 +130,45 @@ function markerReason() {
     .trim();
 }
 
+function scopeResult(scope, config, designArtifacts) {
+  const uiFiles = scope.files.filter((file) => authoredUiFile(file, config, designArtifacts));
+  const changedDesignArtifacts = scope.files.filter((file) => designArtifacts.has(normalizePath(file)));
+  return { ...scope, uiFiles, changedDesignArtifacts };
+}
+
+function passedScopeSummary(result) {
+  return `${result.name}: ${result.uiFiles.length} UI file(s), ${result.changedDesignArtifacts.length} design artifact(s)`;
+}
+
+function writeFailure(failingResults, designArtifacts) {
+  process.stderr.write('Design change guard failed.\n');
+  for (const result of failingResults) {
+    process.stderr.write(`${result.name} authored UI files changed without a related DESIGN.md artifact:\n`);
+    for (const file of result.uiFiles) {
+      process.stderr.write(`- ${file}\n`);
+    }
+  }
+  process.stderr.write('Update at least one related design artifact in the same local or branch scope:\n');
+  for (const artifact of designArtifacts) {
+    process.stderr.write(`- ${artifact}\n`);
+  }
+  process.stderr.write(`If this truly has no design impact, create ${NO_DESIGN_IMPACT_MARKER} with a short reason, keep it local, and remove it after the change is complete.\n`);
+}
+
 function main() {
   const config = readConfig();
-  const files = changedFiles();
   const designArtifacts = designArtifactSet(config);
-  const uiFiles = files.filter((file) => authoredUiFile(file, config, designArtifacts));
-  const changedDesignArtifacts = files.filter((file) => designArtifacts.has(normalizePath(file)));
+  const results = changedFileScopes().map((scope) => scopeResult(scope, config, designArtifacts));
+  const relevantResults = results.filter((result) => result.uiFiles.length > 0);
+  const failingResults = relevantResults.filter((result) => result.changedDesignArtifacts.length === 0);
 
-  if (uiFiles.length === 0) {
+  if (relevantResults.length === 0) {
     process.stdout.write('design change guard passed: no authored UI files changed\n');
     return;
   }
 
-  if (changedDesignArtifacts.length > 0) {
-    process.stdout.write(`design change guard passed: ${uiFiles.length} UI file(s), ${changedDesignArtifacts.length} design artifact(s)\n`);
+  if (failingResults.length === 0) {
+    process.stdout.write(`design change guard passed: ${relevantResults.map(passedScopeSummary).join('; ')}\n`);
     return;
   }
 
@@ -143,16 +178,7 @@ function main() {
     return;
   }
 
-  process.stderr.write('Design change guard failed.\n');
-  process.stderr.write('Authored UI files changed without a related DESIGN.md artifact:\n');
-  for (const file of uiFiles) {
-    process.stderr.write(`- ${file}\n`);
-  }
-  process.stderr.write('Update at least one related design artifact:\n');
-  for (const artifact of designArtifacts) {
-    process.stderr.write(`- ${artifact}\n`);
-  }
-  process.stderr.write(`If this truly has no design impact, create ${NO_DESIGN_IMPACT_MARKER} with a short reason, keep it local, and remove it after the change is complete.\n`);
+  writeFailure(failingResults, designArtifacts);
   process.exit(1);
 }
 

--- a/scripts/check-design-token-usage.mjs
+++ b/scripts/check-design-token-usage.mjs
@@ -141,7 +141,10 @@ function readAdoptionConfig() {
     : DEFAULT_SCAN_PATHS.map(normalizePath);
   const generatedAllowlist = Array.from(new Set([...DEFAULT_GENERATED_ALLOWLIST, ...configuredGeneratedAllowlist]));
   const componentCoverage = Array.isArray(config.component_coverage) ? config.component_coverage : [];
-  return { enforcementPaths, generatedAllowlist, componentCoverage };
+  const exceptionBudget = Number.isInteger(config.exceptionBudget) && config.exceptionBudget >= 0
+    ? config.exceptionBudget
+    : Number.POSITIVE_INFINITY;
+  return { enforcementPaths, generatedAllowlist, componentCoverage, exceptionBudget };
 }
 
 function listCssFiles(root = 'src') {
@@ -187,26 +190,49 @@ function validateAdoptionConfig(config, explicitScanPaths) {
   return findings;
 }
 
+function exceptionReasonFinding(filePath, lineNumber) {
+  return {
+    filePath,
+    lineNumber,
+    ruleId: 'exception-reason',
+    message: `${EXCEPTION_MARKER} requires a short reason`,
+    match: EXCEPTION_MARKER,
+  };
+}
+
+function ruleFinding(filePath, lineNumber, finding) {
+  return {
+    filePath,
+    lineNumber,
+    ruleId: finding.rule.id,
+    message: finding.rule.description,
+    match: finding.match,
+  };
+}
+
+function shouldClearPendingException(line) {
+  const trimmed = line.trim();
+  return trimmed && /[:;]/.test(trimmed) && !trimmed.startsWith('/*') && !trimmed.startsWith('*');
+}
+
 function scanFile(filePath, generatedAllowlist) {
   const normalized = normalizePath(filePath);
-  if (generatedAllowlist.has(normalized)) return [];
-  if (!fs.existsSync(filePath)) return [];
+  if (generatedAllowlist.has(normalized)) return { findings: [], exceptions: [] };
+  if (!fs.existsSync(filePath)) return { findings: [], exceptions: [] };
 
   const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
   const findings = [];
+  const exceptions = [];
   let pendingException = null;
 
   lines.forEach((line, index) => {
     const lineNumber = index + 1;
     const reason = parseExceptionReason(line);
     if (reason !== null && reason.length === 0) {
-      findings.push({
-        filePath,
-        lineNumber,
-        ruleId: 'exception-reason',
-        message: `${EXCEPTION_MARKER} requires a short reason`,
-        match: EXCEPTION_MARKER,
-      });
+      findings.push(exceptionReasonFinding(filePath, lineNumber));
+    }
+    if (reason !== null && reason.length > 0) {
+      exceptions.push({ filePath, lineNumber, reason });
     }
 
     const lineFindings = scanLine(line);
@@ -216,13 +242,7 @@ function scanFile(filePath, generatedAllowlist) {
     if (lineFindings.length > 0) {
       if (!activeException) {
         for (const finding of lineFindings) {
-          findings.push({
-            filePath,
-            lineNumber,
-            ruleId: finding.rule.id,
-            message: finding.rule.description,
-            match: finding.match,
-          });
+          findings.push(ruleFinding(filePath, lineNumber, finding));
         }
       }
       pendingException = null;
@@ -234,13 +254,12 @@ function scanFile(filePath, generatedAllowlist) {
       return;
     }
 
-    const trimmed = line.trim();
-    if (trimmed && /[:;]/.test(trimmed) && !trimmed.startsWith('/*') && !trimmed.startsWith('*')) {
+    if (shouldClearPendingException(line)) {
       pendingException = null;
     }
   });
 
-  return findings;
+  return { findings, exceptions };
 }
 
 function formatFinding(finding) {
@@ -252,11 +271,35 @@ const explicitScanPaths = process.argv.slice(2).length > 0;
 const scanPaths = explicitScanPaths ? process.argv.slice(2).map(normalizePath) : config.enforcementPaths;
 const generatedAllowlist = new Set(config.generatedAllowlist);
 const configFindings = validateAdoptionConfig(config, explicitScanPaths);
-const findings = scanPaths.flatMap((filePath) => scanFile(filePath, generatedAllowlist));
+const scanResults = scanPaths.map((filePath) => scanFile(filePath, generatedAllowlist));
+const findings = scanResults.flatMap((result) => result.findings);
+const exceptions = scanResults.flatMap((result) => result.exceptions);
+const budgetFindings = [];
+const exceptionsByReason = new Map();
 
-if (configFindings.length > 0 || findings.length > 0) {
+if (exceptions.length > config.exceptionBudget) {
+  budgetFindings.push(`exception budget exceeded: ${exceptions.length} exception(s), budget ${config.exceptionBudget}`);
+}
+
+for (const exception of exceptions) {
+  const existing = exceptionsByReason.get(exception.reason) || [];
+  existing.push(exception);
+  exceptionsByReason.set(exception.reason, existing);
+}
+
+for (const [reason, matches] of exceptionsByReason.entries()) {
+  if (matches.length <= 1) continue;
+  budgetFindings.push(
+    `duplicate DESIGN-TOKEN-EXCEPTION reason "${reason}" at ${matches.map((match) => `${match.filePath}:${match.lineNumber}`).join(', ')}`,
+  );
+}
+
+if (configFindings.length > 0 || budgetFindings.length > 0 || findings.length > 0) {
   process.stderr.write('Design token usage enforcement failed:\n');
   for (const finding of configFindings) {
+    process.stderr.write(`- ${finding}\n`);
+  }
+  for (const finding of budgetFindings) {
     process.stderr.write(`- ${finding}\n`);
   }
   for (const finding of findings) {

--- a/scripts/finish-ui-change.sh
+++ b/scripts/finish-ui-change.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm run design:tokens
+npm run design:tokens:check
+npm run design:tokens:enforce
+npm run design:audit:check
+npm run design:change-guard
+npm run build:browser
+make verify

--- a/scripts/generate-design-adoption-audit.mjs
+++ b/scripts/generate-design-adoption-audit.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONFIG_PATH = 'docs/design/design-md-adoption.config.json';
+const DEFAULT_AUDIT_PATH = 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md';
+const STATUS_LABELS = {
+  implemented: 'Implemented',
+  implemented_smoke: 'Implemented Smoke',
+  not_applicable: 'N/A',
+  needs_work: 'Needs Work',
+  backlog: 'Backlog',
+  pass: 'Pass',
+  fail: 'Fail',
+};
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function escapeTableCell(value) {
+  return String(value ?? '')
+    .replace(/\r?\n/g, '<br>')
+    .replace(/\|/g, '\\|');
+}
+
+function sentence(value) {
+  return String(value ?? '').trim();
+}
+
+function titleizeKey(key) {
+  return key
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function statusLabel(value) {
+  return STATUS_LABELS[value] || String(value ?? '').replace(/_/g, ' ');
+}
+
+function yesNo(value) {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (String(value).toLowerCase() === 'yes') return 'Yes';
+  if (String(value).toLowerCase() === 'no') return 'No';
+  return String(value ?? 'N/A');
+}
+
+function validateOptionalAreas(optionalAreas) {
+  const failures = [];
+  if (!optionalAreas || typeof optionalAreas !== 'object' || Array.isArray(optionalAreas)) {
+    return ['optional_areas must be an object with status and reason entries'];
+  }
+
+  for (const [area, entry] of Object.entries(optionalAreas)) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+      failures.push(`optional_areas.${area} must include status and reason`);
+      continue;
+    }
+    if (!sentence(entry.status)) {
+      failures.push(`optional_areas.${area}.status is required`);
+    }
+    if (!sentence(entry.reason)) {
+      failures.push(`optional_areas.${area}.reason is required`);
+    }
+  }
+
+  return failures;
+}
+
+function validateConfig(config) {
+  const failures = validateOptionalAreas(config.optional_areas);
+  for (const [index, entry] of (config.component_coverage || []).entries()) {
+    if (!sentence(entry.area)) failures.push(`component_coverage[${index}].area is required`);
+    if (!sentence(entry.uses_design_tokens)) failures.push(`component_coverage[${index}].uses_design_tokens is required`);
+    if (typeof entry.enforcement_covered !== 'boolean') {
+      failures.push(`component_coverage[${index}].enforcement_covered must be true or false`);
+    }
+    if (!sentence(entry.notes)) failures.push(`component_coverage[${index}].notes is required`);
+  }
+  return failures;
+}
+
+function componentRows(config) {
+  return (config.component_coverage || []).map((entry) => (
+    `| ${escapeTableCell(entry.area)} | ${escapeTableCell(yesNo(entry.uses_design_tokens))} | ${escapeTableCell(yesNo(entry.enforcement_covered))} | ${escapeTableCell(entry.notes)} |`
+  ));
+}
+
+function optionalAreaRows(config) {
+  return Object.entries(config.optional_areas || {}).map(([area, entry]) => (
+    `| ${escapeTableCell(titleizeKey(area))} | ${escapeTableCell(statusLabel(entry.status))} | ${escapeTableCell(entry.reason)} |`
+  ));
+}
+
+function acceptanceRows(config) {
+  return (config.acceptance_criteria || []).map((entry) => (
+    `| ${escapeTableCell(entry.criterion)} | ${escapeTableCell(statusLabel(entry.status))} | ${escapeTableCell(entry.evidence)} |`
+  ));
+}
+
+function generateAuditMarkdown(config) {
+  const auditPath = config.audit_document || DEFAULT_AUDIT_PATH;
+  const lines = [
+    '# DESIGN.md Adoption Audit',
+    '',
+    `Generated from: \`${CONFIG_PATH}\``,
+  ];
+
+  if (config.audit?.date) {
+    lines.push(`Date: ${config.audit.date}`);
+  }
+
+  lines.push(
+    '',
+    '## Summary',
+    '',
+    sentence(config.audit?.summary) || '`DESIGN.md` is the authoritative visual design source of truth for this repo.',
+    '',
+    `Machine-readable audit config: \`${CONFIG_PATH}\``,
+    `Generated audit document: \`${auditPath}\``,
+    '',
+    '## Component Coverage',
+    '',
+    '| Component / Area | Uses DESIGN.md Tokens? | Enforcement Covered? | Notes |',
+    '| --- | --- | --- | --- |',
+    ...componentRows(config),
+    '',
+    '## Optional DESIGN.md Area Audit',
+    '',
+    '| Area | Status | Reason |',
+    '| --- | --- | --- |',
+    ...optionalAreaRows(config),
+    '',
+    '## Acceptance Criteria Status',
+    '',
+    '| Criterion | Status | Evidence |',
+    '| --- | --- | --- |',
+    ...acceptanceRows(config),
+    '',
+    '## Follow-Up Backlog',
+    '',
+  );
+
+  for (const item of config.follow_up_backlog || []) {
+    lines.push(`- ${item}`);
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}`;
+}
+
+function main() {
+  const checkMode = process.argv.includes('--check');
+  const config = readJson(CONFIG_PATH);
+  const failures = validateConfig(config);
+  if (failures.length > 0) {
+    process.stderr.write(`Design adoption audit config is invalid:\n${failures.map((failure) => `- ${failure}`).join('\n')}\n`);
+    process.exit(1);
+  }
+
+  const auditPath = config.audit_document || DEFAULT_AUDIT_PATH;
+  const generated = generateAuditMarkdown(config);
+  const existing = fs.existsSync(auditPath) ? fs.readFileSync(auditPath, 'utf8') : '';
+
+  if (checkMode) {
+    if (existing !== generated) {
+      process.stderr.write(`Design adoption audit is stale. Run node scripts/generate-design-adoption-audit.mjs to update ${auditPath}.\n`);
+      process.exit(1);
+    }
+    process.stdout.write(`design adoption audit is up to date: ${auditPath}\n`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(auditPath), { recursive: true });
+  fs.writeFileSync(auditPath, generated);
+  process.stdout.write(`design adoption audit generated: ${auditPath}\n`);
+}
+
+main();

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm run design:tokens:check
+npm run design:tokens:enforce
+npm run design:audit:check
+npm run design:change-guard

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+make verify

--- a/scripts/setup-local-hooks.sh
+++ b/scripts/setup-local-hooks.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git config core.hooksPath scripts/hooks
+chmod +x scripts/hooks/pre-commit scripts/hooks/pre-push
+
+echo "Local git hooks installed from scripts/hooks"

--- a/tests/unit/governance/check-design-token-usage.test.js
+++ b/tests/unit/governance/check-design-token-usage.test.js
@@ -79,6 +79,57 @@ test('check-design-token-usage rejects exception comments without reasons', () =
   assert.match(result.stderr, /requires a short reason/);
 });
 
+test('check-design-token-usage fails when exception budget is exceeded', () => {
+  const root = makeTempDir('governance-token-usage-budget-');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify({
+    schema_version: '1.0',
+    exceptionBudget: 0,
+    enforcement: {
+      paths: ['src/app/styles.css'],
+      generated_allowlist: [],
+    },
+    component_coverage: [],
+  }));
+  writeFile(root, 'src/app/styles.css', `
+/* DESIGN-TOKEN-EXCEPTION: legacy vendor white border until iframe wrapper is removed */
+.vendor-frame {
+  color: #fff;
+}
+`);
+
+  const result = runScriptWithArgs('check-design-token-usage.mjs', [], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /exception budget exceeded: 1 exception\(s\), budget 0/);
+});
+
+test('check-design-token-usage fails duplicate exception reasons', () => {
+  const root = makeTempDir('governance-token-usage-duplicate-exception-');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify({
+    schema_version: '1.0',
+    exceptionBudget: 2,
+    enforcement: {
+      paths: ['src/app/styles.css'],
+      generated_allowlist: [],
+    },
+    component_coverage: [],
+  }));
+  writeFile(root, 'src/app/styles.css', `
+/* DESIGN-TOKEN-EXCEPTION: legacy vendor white border until iframe wrapper is removed */
+.vendor-frame {
+  color: #fff;
+}
+
+/* DESIGN-TOKEN-EXCEPTION: legacy vendor white border until iframe wrapper is removed */
+.vendor-frame-secondary {
+  border-color: #fff;
+}
+`);
+
+  const result = runScriptWithArgs('check-design-token-usage.mjs', [], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /duplicate DESIGN-TOKEN-EXCEPTION reason/);
+});
+
 test('check-design-token-usage skips generated token outputs', () => {
   const root = makeTempDir('governance-token-usage-generated-');
   writeFile(root, 'src/app/design-tokens.css', `

--- a/tests/unit/governance/design-operationalization.test.js
+++ b/tests/unit/governance/design-operationalization.test.js
@@ -1,0 +1,141 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  commitAll,
+  git,
+  initGitRepo,
+  makeTempDir,
+  runScriptWithArgs,
+  writeFile,
+} = require('./helpers');
+
+function minimalAuditConfig(overrides = {}) {
+  return {
+    schema_version: '1.0',
+    source_of_truth: 'DESIGN.md',
+    audit_document: 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md',
+    audit: {
+      date: '2026-05-09',
+      summary: '`DESIGN.md` is authoritative.',
+    },
+    generated_outputs: ['src/app/design-tokens.css'],
+    enforcement: {
+      paths: ['src/app/styles.css'],
+      generated_allowlist: ['src/app/design-tokens.css'],
+    },
+    component_coverage: [
+      {
+        area: 'Global styles',
+        uses_design_tokens: 'yes',
+        enforcement_covered: true,
+        paths: ['src/app/styles.css'],
+        notes: '`src/app/styles.css` consumes generated variables.',
+      },
+    ],
+    optional_areas: {
+      accessibility: {
+        status: 'implemented',
+        reason: '`DESIGN.md` defines keyboard and contrast rules.',
+      },
+    },
+    acceptance_criteria: [
+      {
+        criterion: '`DESIGN.md` is declared as source of truth.',
+        status: 'pass',
+        evidence: '`DESIGN.md` exists.',
+      },
+    ],
+    follow_up_backlog: ['Keep generated audit docs current.'],
+    ...overrides,
+  };
+}
+
+function writeMinimalDesignRepo(root) {
+  writeFile(root, 'DESIGN.md', '# Design\n');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify(minimalAuditConfig(), null, 2));
+  writeFile(root, 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md', '# stale\n');
+  writeFile(root, 'repo-contract.yaml', `
+visual_identity:
+  generated_outputs:
+    paths:
+    - src/app/design-tokens.css
+`);
+  writeFile(root, 'src/app/styles.css', '.app { color: var(--color-on-surface); }\n');
+  writeFile(root, 'src/app/design-tokens.css', ':root { --color-on-surface: #111827; }\n');
+}
+
+test('generate-design-adoption-audit is deterministic', () => {
+  const root = makeTempDir('governance-design-audit-deterministic-');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify(minimalAuditConfig(), null, 2));
+
+  const first = runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  assert.equal(first.status, 0, first.stderr);
+  const firstOutput = fs.readFileSync(path.join(root, 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md'), 'utf8');
+
+  const second = runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  assert.equal(second.status, 0, second.stderr);
+  const secondOutput = fs.readFileSync(path.join(root, 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md'), 'utf8');
+
+  assert.equal(secondOutput, firstOutput);
+  assert.match(firstOutput, /Generated from: `docs\/design\/design-md-adoption\.config\.json`/);
+});
+
+test('generate-design-adoption-audit --check fails stale audit docs', () => {
+  const root = makeTempDir('governance-design-audit-stale-');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify(minimalAuditConfig(), null, 2));
+  writeFile(root, 'docs/design/DESIGN_MD_ADOPTION_AUDIT.md', '# stale\n');
+
+  const result = runScriptWithArgs('generate-design-adoption-audit.mjs', ['--check'], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Design adoption audit is stale/);
+});
+
+test('generate-design-adoption-audit fails optional areas missing reason', () => {
+  const root = makeTempDir('governance-design-audit-missing-reason-');
+  writeFile(root, 'docs/design/design-md-adoption.config.json', JSON.stringify(minimalAuditConfig({
+    optional_areas: {
+      accessibility: {
+        status: 'implemented',
+      },
+    },
+  }), null, 2));
+
+  const result = runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /optional_areas\.accessibility\.reason is required/);
+});
+
+test('check-design-change-guard fails UI changes without design artifacts', () => {
+  const root = makeTempDir('governance-design-change-guard-fail-');
+  initGitRepo(root);
+  git(root, ['branch', '-M', 'main']);
+  writeMinimalDesignRepo(root);
+  runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  commitAll(root, 'baseline');
+
+  writeFile(root, 'src/app/styles.css', '.app { color: var(--color-primary); }\n');
+
+  const result = runScriptWithArgs('check-design-change-guard.mjs', [], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Authored UI files changed without a related DESIGN\.md artifact/);
+  assert.match(result.stderr, /src\/app\/styles\.css/);
+});
+
+test('check-design-change-guard passes UI changes with design artifacts', () => {
+  const root = makeTempDir('governance-design-change-guard-pass-');
+  initGitRepo(root);
+  git(root, ['branch', '-M', 'main']);
+  writeMinimalDesignRepo(root);
+  runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  commitAll(root, 'baseline');
+
+  writeFile(root, 'src/app/styles.css', '.app { color: var(--color-primary); }\n');
+  writeFile(root, 'DESIGN.md', '# Design\n\nChanged visual semantics.\n');
+
+  const result = runScriptWithArgs('check-design-change-guard.mjs', [], root);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /design change guard passed/);
+});

--- a/tests/unit/governance/design-operationalization.test.js
+++ b/tests/unit/governance/design-operationalization.test.js
@@ -120,8 +120,26 @@ test('check-design-change-guard fails UI changes without design artifacts', () =
 
   const result = runScriptWithArgs('check-design-change-guard.mjs', [], root);
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Authored UI files changed without a related DESIGN\.md artifact/);
+  assert.match(result.stderr, /authored UI files changed without a related DESIGN\.md artifact/);
   assert.match(result.stderr, /src\/app\/styles\.css/);
+});
+
+test('check-design-change-guard fails local UI changes even when branch has design artifacts', () => {
+  const root = makeTempDir('governance-design-change-guard-local-scope-');
+  initGitRepo(root);
+  git(root, ['branch', '-M', 'main']);
+  writeMinimalDesignRepo(root);
+  runScriptWithArgs('generate-design-adoption-audit.mjs', [], root);
+  commitAll(root, 'baseline');
+  git(root, ['switch', '-c', 'feature']);
+  writeFile(root, 'DESIGN.md', '# Design\n\nBranch design artifact changed.\n');
+  commitAll(root, 'design artifact');
+
+  writeFile(root, 'src/app/styles.css', '.app { color: var(--color-primary); }\n');
+
+  const result = runScriptWithArgs('check-design-change-guard.mjs', [], root);
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /local authored UI files changed without a related DESIGN\.md artifact/);
 });
 
 test('check-design-change-guard passes UI changes with design artifacts', () => {


### PR DESCRIPTION
## Summary
- Add local-first DESIGN.md operational automation so design guarantees do not depend on GitHub Actions or paid CI minutes.
- Generate `docs/design/DESIGN_MD_ADOPTION_AUDIT.md` deterministically from `docs/design/design-md-adoption.config.json`.
- Add a local design change guard that blocks authored UI changes unless DESIGN.md/token/audit artifacts also changed, with a temporary local no-design-impact marker escape hatch.
- Strengthen token exception enforcement with required reasons, duplicate reason rejection, and an `exceptionBudget`.
- Add tracked local hooks, hook setup, and a finish script for UI changes.
- Tighten the design change guard so local staged, unstaged, or untracked UI edits cannot borrow older branch-wide design artifact changes to pass.

## Linked Task
- Task: LOCAL-DESIGN-GATES

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/design/DESIGN_MD_ADOPTION_AUDIT.md
- Relevant standards areas: architecture and design; coding and code quality; testing and quality assurance; team and process
- Standards gaps or exceptions: No unresolved DESIGN.md enforcement gap remains for local verification; GitHub Actions is no longer required for DESIGN.md guarantees.
- [x] UI changes use generated DESIGN.md tokens.
- [x] `npm run design:tokens:check` passed.
- [x] `npm run design:tokens:enforce` passed.
- [x] `DESIGN.md` was updated when visual semantics changed.
- [x] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: `npm run standards:check` passed.
- Lint result: `npm run design:tokens:enforce`; `npm run ownership:lint`; `npm run change:check` passed.
- Tests: `node --test tests/unit/governance/*.test.js`; `npm run build:browser`; `make verify` passed.
- Test evidence paths: tests/unit/governance/check-design-token-usage.test.js, tests/unit/governance/design-operationalization.test.js
- Docs updated: yes
- Doc evidence paths: README.md, agents/README.md, docs/runbook.md, docs/design/DESIGN_MD_ADOPTION_AUDIT.md, docs/design/design-md-adoption.config.json

## Risk and Rollback
- Risk level: high
- Rollback path: Revert this PR to restore the previous DESIGN.md local verification behavior; generated audit and hook files are additive and can be removed without changing runtime app behavior.

## Verification
- `npm run design:tokens`
- `npm run design:tokens:check`
- `npm run design:tokens:enforce`
- `npm run design:audit`
- `npm run design:audit:check`
- `npm run design:change-guard`
- `node --test tests/unit/governance/*.test.js`
- `npm run build:browser`
- `npm run standards:check`
- `npm run ownership:lint`
- `npm run change:check`
- `make verify`

## Negative Test Evidence
- Token drift probe failed on stale `src/app/design-tokens.css`, then the file was restored.
- Hard-coded visual literal probe failed on `#ff0000` in `src/app/styles.css`, then the file was restored.
- Stale audit probe failed on manual `docs/design/DESIGN_MD_ADOPTION_AUDIT.md` edit, then the file was restored.
- UI change guard probe failed on local UI-only `src/app/styles.css` edit after the guard was tightened, then the file was restored.
- Local hooks installed successfully; `git config core.hooksPath` returns `scripts/hooks`.
