### PR TITLE
Improve DESIGN.md compliance coverage

### DIFF
--- a/docs/design/DESIGN_MD_ADOPTION_AUDIT.md
+++ b/docs/design/DESIGN_MD_ADOPTION_AUDIT.md
@@ -5,7 +5,7 @@ Date: 2026-05-09
 
 ## Summary
 
-`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual value enforcement for all authored UI CSS, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage.
+`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual, typography, and motion value enforcement for all authored UI CSS, semantic token contrast regression coverage, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage.
 
 Machine-readable audit config: `docs/design/design-md-adoption.config.json`
 Generated audit document: `docs/design/DESIGN_MD_ADOPTION_AUDIT.md`

--- a/docs/design/design-md-adoption.config.json
+++ b/docs/design/design-md-adoption.config.json
@@ -4,7 +4,7 @@
   "audit_document": "docs/design/DESIGN_MD_ADOPTION_AUDIT.md",
   "audit": {
     "date": "2026-05-09",
-    "summary": "`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual value enforcement for all authored UI CSS, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage."
+    "summary": "`DESIGN.md` is declared as the authoritative visual design source of truth for this repo. Runtime CSS and generated token files are derived consumers. Current operationalization covers generated global tokens, Button tokens, TaskCreationForm tokens, TaskDetail tokens, app-specific route/state/data-semantics UX rules, drift checking, hard-coded visual, typography, and motion value enforcement for all authored UI CSS, semantic token contrast regression coverage, PR guidance, agent guidance, machine-readable audit config, local git hooks, local design change guards, and screenshot smoke coverage."
   },
   "exceptionBudget": 0,
   "generated_outputs": [

--- a/scripts/check-design-token-usage.mjs
+++ b/scripts/check-design-token-usage.mjs
@@ -68,6 +68,39 @@ const RULES = [
     },
   },
   {
+    id: 'font-family',
+    description: 'font-family literal',
+    check(line) {
+      const match = line.match(/\bfont-family\s*:\s*([^;]+)/i);
+      if (!match) return [];
+      const value = match[1].trim().toLowerCase();
+      if (/^(?:var\(|inherit\b|initial\b|unset\b)/i.test(value)) return [];
+      return [{ match: match[0].trim() }];
+    },
+  },
+  {
+    id: 'font-weight',
+    description: 'font-weight literal',
+    check(line) {
+      const match = line.match(/\bfont-weight\s*:\s*([^;]+)/i);
+      if (!match) return [];
+      const value = match[1].trim().toLowerCase();
+      if (/^(?:var\(|inherit\b|initial\b|unset\b)/i.test(value)) return [];
+      return [{ match: match[0].trim() }];
+    },
+  },
+  {
+    id: 'line-height',
+    description: 'line-height literal',
+    check(line) {
+      const match = line.match(/\bline-height\s*:\s*([^;]+)/i);
+      if (!match) return [];
+      const value = match[1].trim().toLowerCase();
+      if (/^(?:var\(|normal\b|inherit\b|initial\b|unset\b)/i.test(value)) return [];
+      return [{ match: match[0].trim() }];
+    },
+  },
+  {
     id: 'letter-spacing',
     description: 'letter-spacing literal',
     check(line) {
@@ -75,6 +108,28 @@ const RULES = [
       if (!match) return [];
       const value = match[1].trim().toLowerCase();
       if (/^(?:var\(|normal\b|inherit\b|initial\b|unset\b)/i.test(value)) return [];
+      return [{ match: match[0].trim() }];
+    },
+  },
+  {
+    id: 'transition',
+    description: 'transition literal',
+    check(line) {
+      const match = line.match(/\btransition\s*:\s*([^;]+)/i);
+      if (!match) return [];
+      const value = match[1].trim().toLowerCase();
+      if (/^(?:var\(|none\b|inherit\b|initial\b|unset\b)/i.test(value)) return [];
+      return [{ match: match[0].trim() }];
+    },
+  },
+  {
+    id: 'animation',
+    description: 'animation literal',
+    check(line) {
+      const match = line.match(/\banimation\s*:\s*([^;]+)/i);
+      if (!match) return [];
+      const value = match[1].trim().toLowerCase();
+      if (/^(?:var\(|none\b|inherit\b|initial\b|unset\b)/i.test(value)) return [];
       return [{ match: match[0].trim() }];
     },
   },

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -386,7 +386,7 @@ button {
 .page-header h1 {
   margin: 0;
   font-size: var(--design-typography-headline-fluid-font-size);
-  line-height: 1.08;
+  line-height: var(--design-typography-headline-fluid-line-height);
 }
 
 .eyebrow {
@@ -457,7 +457,7 @@ button {
   padding: 10px 14px;
   background: var(--primary);
   color: var(--color-surface);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 .button-secondary {
@@ -520,7 +520,7 @@ button {
 .session-meta dd {
   margin: 0;
   color: var(--text);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
   overflow-wrap: anywhere;
 }
 
@@ -703,6 +703,12 @@ button {
   box-shadow: var(--shadow-sm);
 }
 
+.detail-card .summary-grid article {
+  background: var(--surface-muted);
+  border-color: transparent;
+  box-shadow: none;
+}
+
 .summary-grid span {
   display: block;
   margin-bottom: 6px;
@@ -815,7 +821,7 @@ button {
   padding: 10px 14px;
   background: var(--primary);
   color: var(--color-surface);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 .review-question-status {
@@ -940,7 +946,7 @@ button {
 .review-question-meta dd {
   margin: 0;
   color: var(--text);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
   overflow-wrap: anywhere;
 }
 
@@ -974,7 +980,7 @@ button {
   border: 0;
   background: transparent;
   color: var(--primary);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
   padding: 0;
 }
 
@@ -1087,7 +1093,7 @@ button {
 }
 
 .implementation-reference--mono {
-  font-family: "SFMono-Regular", SFMono-Regular, ui-monospace, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-family: var(--design-typography-code-md-font-family);
   overflow-wrap: anywhere;
 }
 
@@ -1108,7 +1114,7 @@ button {
   padding: 10px 14px;
   background: var(--primary);
   color: var(--color-surface);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 .assignment-form button:disabled {
@@ -1201,7 +1207,7 @@ button {
 .task-create-page__intake-summary dt {
   color: var(--color-success-text);
   font-size: var(--design-typography-label-sm-font-size);
-  font-weight: 750;
+  font-weight: var(--design-typography-label-sm-font-weight);
   text-transform: uppercase;
 }
 
@@ -1282,7 +1288,7 @@ button {
   padding: 10px 14px;
   background: var(--surface-subtle);
   color: var(--text);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 .task-list-results {
@@ -1387,7 +1393,7 @@ button {
   padding: 8px 12px;
   background: transparent;
   color: var(--text);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 .view-toggle button[aria-pressed='true'],
@@ -1476,7 +1482,7 @@ button {
   max-width: 28ch;
   color: var(--muted);
   font-size: var(--design-typography-label-sm-font-size);
-  line-height: 1.25;
+  line-height: var(--design-typography-label-sm-line-height);
 }
 
 .task-board__column-body {
@@ -1507,7 +1513,7 @@ button {
 .task-board__card a {
   color: var(--text);
   font-weight: var(--design-typography-label-sm-font-weight);
-  line-height: 1.25;
+  line-height: var(--design-typography-label-sm-line-height);
   overflow-wrap: anywhere;
 }
 
@@ -1556,7 +1562,7 @@ button {
   color: var(--color-on-muted-strong);
   font-size: var(--design-typography-label-sm-font-size);
   font-weight: var(--design-typography-label-md-font-weight);
-  line-height: 1.35;
+  line-height: var(--design-typography-body-sm-line-height);
 }
 
 .task-list-table-wrap {
@@ -1612,7 +1618,7 @@ button {
   padding: 4px 10px;
   border-radius: var(--radius-pill);
   font-size: var(--design-typography-body-sm-font-size);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
   border: 1px solid transparent;
 }
 
@@ -1622,7 +1628,7 @@ button {
   white-space: normal;
   overflow-wrap: anywhere;
   text-align: right;
-  line-height: 1.3;
+  line-height: var(--design-typography-label-md-line-height);
   -webkit-line-clamp: 2;
   line-clamp: 2;
   display: -webkit-inline-box;
@@ -1667,7 +1673,7 @@ button {
   padding: 10px 14px;
   background: var(--primary);
   color: var(--color-surface);
-  font-weight: 600;
+  font-weight: var(--design-typography-label-md-font-weight);
 }
 
 @media (max-width: 960px) {

--- a/src/components/Button/Button.module.css
+++ b/src/components/Button/Button.module.css
@@ -11,7 +11,6 @@
   font-family: var(--button-font-family);
   font-weight: var(--button-font-weight);
   cursor: pointer;
-  transition: all 0.15s ease-in-out;
   position: relative;
   white-space: nowrap;
 }
@@ -135,26 +134,20 @@
 
 /* Loading spinner */
 .spinner {
-  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
-  animation: spin 1s linear infinite;
+  flex: 0 0 auto;
 }
 
 .spinner svg {
   display: block;
 }
 
-@keyframes spin {
-  from {
-    transform: rotate(0deg);
+@media (prefers-reduced-motion: reduce) {
+  .button,
+  .spinner {
+    transition: none;
+    animation: none;
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-.textHidden {
-  visibility: hidden;
 }

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,1 +1,162 @@
-import{jsx as n}from"react/jsx-runtime";import{render as e,screen as o,fireEvent as s}from"@testing-library/react";import{Button as i}from"./Button";jest.mock("./Button.module.css",()=>({button:"button",primary:"primary",secondary:"secondary",outline:"outline",ghost:"ghost",destructive:"destructive",sm:"sm",md:"md",lg:"lg",loading:"loading",disabled:"disabled",spinner:"spinner",textHidden:"textHidden"})),describe("Button",()=>{describe("Rendering",()=>{it("renders with children",()=>{e(n(i,{children:"Click me"})),expect(o.getByText("Click me")).toBeInTheDocument()}),it("renders as a button element",()=>{e(n(i,{children:"Test"})),expect(o.getByRole("button")).toBeInTheDocument()})}),describe("Variants",()=>{it("applies primary variant by default",()=>{const{container:t}=e(n(i,{children:"Primary"}));expect(t.firstChild).toHaveClass("primary")}),it("applies secondary variant",()=>{const{container:t}=e(n(i,{variant:"secondary",children:"Secondary"}));expect(t.firstChild).toHaveClass("secondary")}),it("applies outline variant",()=>{const{container:t}=e(n(i,{variant:"outline",children:"Outline"}));expect(t.firstChild).toHaveClass("outline")}),it("applies ghost variant",()=>{const{container:t}=e(n(i,{variant:"ghost",children:"Ghost"}));expect(t.firstChild).toHaveClass("ghost")}),it("applies destructive variant",()=>{const{container:t}=e(n(i,{variant:"destructive",children:"Delete"}));expect(t.firstChild).toHaveClass("destructive")})}),describe("Sizes",()=>{it("applies md size by default",()=>{const{container:t}=e(n(i,{children:"Medium"}));expect(t.firstChild).toHaveClass("md")}),it("applies sm size",()=>{const{container:t}=e(n(i,{size:"sm",children:"Small"}));expect(t.firstChild).toHaveClass("sm")}),it("applies lg size",()=>{const{container:t}=e(n(i,{size:"lg",children:"Large"}));expect(t.firstChild).toHaveClass("lg")})}),describe("States",()=>{it("handles click events",()=>{const t=jest.fn();e(n(i,{onClick:t,children:"Click"})),s.click(o.getByRole("button")),expect(t).toHaveBeenCalledTimes(1)}),it("does not call onClick when disabled",()=>{const t=jest.fn();e(n(i,{disabled:!0,onClick:t,children:"Disabled"})),s.click(o.getByRole("button")),expect(t).not.toHaveBeenCalled()}),it("does not call onClick when loading",()=>{const t=jest.fn();e(n(i,{loading:!0,onClick:t,children:"Loading"})),s.click(o.getByRole("button")),expect(t).not.toHaveBeenCalled()}),it("sets disabled attribute when disabled",()=>{e(n(i,{disabled:!0,children:"Disabled"})),expect(o.getByRole("button")).toBeDisabled()}),it("sets aria-disabled when disabled",()=>{e(n(i,{disabled:!0,children:"Disabled"})),expect(o.getByRole("button")).toHaveAttribute("aria-disabled","true")}),it("sets aria-busy when loading",()=>{e(n(i,{loading:!0,children:"Loading"})),expect(o.getByRole("button")).toHaveAttribute("aria-busy","true")})}),describe("Loading State",()=>{it("shows spinner when loading",()=>{e(n(i,{loading:!0,children:"Loading"})),expect(o.getByRole("button")).toHaveAttribute("aria-busy","true")}),it("hides text content when loading",()=>{const{container:t}=e(n(i,{loading:!0,children:"Loading"})),a=t.querySelector(".textHidden");expect(a).toBeInTheDocument()})}),describe("Type Attribute",()=>{it("defaults to type=button",()=>{e(n(i,{children:"Button"})),expect(o.getByRole("button")).toHaveAttribute("type","button")}),it("accepts submit type",()=>{e(n(i,{type:"submit",children:"Submit"})),expect(o.getByRole("button")).toHaveAttribute("type","submit")}),it("accepts reset type",()=>{e(n(i,{type:"reset",children:"Reset"})),expect(o.getByRole("button")).toHaveAttribute("type","reset")})}),describe("ClassName Prop",()=>{it("applies additional className",()=>{const{container:t}=e(n(i,{className:"custom-class",children:"Custom"}));expect(t.firstChild).toHaveClass("custom-class")})})});
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Button } from './Button';
+
+vi.mock('./Button.module.css', () => ({
+  default: {
+    button: 'button',
+    primary: 'primary',
+    secondary: 'secondary',
+    outline: 'outline',
+    ghost: 'ghost',
+    destructive: 'destructive',
+    sm: 'sm',
+    md: 'md',
+    lg: 'lg',
+    loading: 'loading',
+    disabled: 'disabled',
+    spinner: 'spinner',
+  },
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Button rendering', () => {
+  it('renders with children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+
+  it('renders as a button element', () => {
+    render(<Button>Test</Button>);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+});
+
+describe('Button variants', () => {
+  it('applies primary variant by default', () => {
+    const { container } = render(<Button>Primary</Button>);
+    expect(container.firstChild).toHaveClass('primary');
+  });
+
+  it('applies secondary variant', () => {
+    const { container } = render(<Button variant="secondary">Secondary</Button>);
+    expect(container.firstChild).toHaveClass('secondary');
+  });
+
+  it('applies outline variant', () => {
+    const { container } = render(<Button variant="outline">Outline</Button>);
+    expect(container.firstChild).toHaveClass('outline');
+  });
+
+  it('applies ghost variant', () => {
+    const { container } = render(<Button variant="ghost">Ghost</Button>);
+    expect(container.firstChild).toHaveClass('ghost');
+  });
+
+  it('applies destructive variant', () => {
+    const { container } = render(<Button variant="destructive">Delete</Button>);
+    expect(container.firstChild).toHaveClass('destructive');
+  });
+});
+
+describe('Button sizes', () => {
+  it('applies md size by default', () => {
+    const { container } = render(<Button>Medium</Button>);
+    expect(container.firstChild).toHaveClass('md');
+  });
+
+  it('applies sm size', () => {
+    const { container } = render(<Button size="sm">Small</Button>);
+    expect(container.firstChild).toHaveClass('sm');
+  });
+
+  it('applies lg size', () => {
+    const { container } = render(<Button size="lg">Large</Button>);
+    expect(container.firstChild).toHaveClass('lg');
+  });
+});
+
+describe('Button states', () => {
+  it('handles click events', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>Click</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        Disabled
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('does not call onClick when loading', () => {
+    const onClick = vi.fn();
+    render(
+      <Button loading onClick={onClick}>
+        Loading
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('sets disabled attribute when disabled', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('sets aria-disabled when disabled', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('sets aria-busy when loading', () => {
+    render(<Button loading>Loading</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-busy', 'true');
+  });
+});
+
+describe('Button loading state', () => {
+  it('shows spinner when loading', () => {
+    const { container } = render(<Button loading>Loading</Button>);
+    expect(container.querySelector('.spinner')).toBeInTheDocument();
+  });
+
+  it('keeps the loading text visible', () => {
+    render(<Button loading>Loading</Button>);
+    expect(screen.getByRole('button', { name: 'Loading' })).toBeVisible();
+  });
+});
+
+describe('Button type attribute', () => {
+  it('defaults to type=button', () => {
+    render(<Button>Button</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('accepts submit type', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+  });
+
+  it('accepts reset type', () => {
+    render(<Button type="reset">Reset</Button>);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'reset');
+  });
+});
+
+describe('Button className prop', () => {
+  it('applies additional className', () => {
+    const { container } = render(<Button className="custom-class">Custom</Button>);
+    expect(container.firstChild).toHaveClass('custom-class');
+  });
+});

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,1 +1,56 @@
-import{jsx as e,jsxs as l}from"react/jsx-runtime";import t from"./Button.module.css";export type{ButtonProps}from"./types";export function Button({variant:r="primary",size:a="md",disabled:o=!1,loading:s=!1,onClick:n,children:p,className:i="",type:u="button"}){const c=[t.button,t[r],t[a],s?t.loading:"",o?t.disabled:"",i].filter(Boolean).join(" ");return l("button",{type:u,className:c,disabled:o||s,onClick:n,"aria-disabled":o||s,"aria-busy":s,children:[s&&e("span",{className:t.spinner,"aria-hidden":"true",children:e("svg",{width:"16",height:"16",viewBox:"0 0 16 16",fill:"none",xmlns:"http://www.w3.org/2000/svg",children:e("circle",{cx:"8",cy:"8",r:"6",stroke:"currentColor",strokeWidth:"2",strokeLinecap:"round",strokeDasharray:"32",strokeDashoffset:"12"})})}),e("span",{className:s?t.textHidden:"",children:p})]})}export default Button;
+import styles from './Button.module.css';
+import type { ButtonProps } from './types';
+
+export type { ButtonProps } from './types';
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  loading = false,
+  onClick,
+  children,
+  className = '',
+  type = 'button',
+}: ButtonProps) {
+  const classNames = [
+    styles.button,
+    styles[variant],
+    styles[size],
+    loading ? styles.loading : '',
+    disabled ? styles.disabled : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type={type}
+      className={classNames}
+      disabled={disabled || loading}
+      onClick={onClick}
+      aria-disabled={disabled || loading}
+      aria-busy={loading}
+    >
+      {loading ? (
+        <span className={styles.spinner} aria-hidden="true">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle
+              cx="8"
+              cy="8"
+              r="6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeDasharray="24 12"
+            />
+          </svg>
+        </span>
+      ) : null}
+      <span>{children}</span>
+    </button>
+  );
+}
+
+export default Button;

--- a/src/features/task-detail/TaskDetailActivityShell.module.css
+++ b/src/features/task-detail/TaskDetailActivityShell.module.css
@@ -55,7 +55,7 @@
   background: transparent;
   color: var(--task-detail-tab-text);
   font: inherit;
-  font-weight: 600;
+  font-weight: var(--task-detail-label-font-weight);
   cursor: pointer;
 }
 
@@ -121,7 +121,7 @@
   background: var(--task-detail-panel-bg);
   color: inherit;
   font: inherit;
-  font-weight: 600;
+  font-weight: var(--task-detail-label-font-weight);
   cursor: pointer;
 }
 

--- a/tests/browser/design-token-operationalization.browser.spec.ts
+++ b/tests/browser/design-token-operationalization.browser.spec.ts
@@ -41,6 +41,187 @@ function readCss(relativePath: string) {
   return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
 }
 
+function withCss(template: string, css: string) {
+  return template.split('/* CSS_PLACEHOLDER */').join(css);
+}
+
+const COMPONENT_SMOKE_HTML = `
+  <html>
+    <head>
+      <style>/* CSS_PLACEHOLDER */</style>
+      <style>
+        body {
+          margin: 0;
+          padding: var(--design-spacing-6);
+          background: var(--color-page-bg);
+          color: var(--color-on-surface);
+          font-family: var(--design-typography-body-md-font-family);
+        }
+
+        .visual-smoke {
+          display: grid;
+          gap: var(--design-spacing-6);
+          max-width: 760px;
+        }
+
+        .button-row {
+          display: flex;
+          gap: var(--design-spacing-3);
+          flex-wrap: wrap;
+          padding: var(--design-spacing-4);
+          background: var(--color-surface);
+          border: var(--design-border-soft);
+          border-radius: var(--design-radius-panel);
+        }
+      </style>
+    </head>
+    <body>
+      <main class="visual-smoke">
+        <section class="button-row" aria-label="Button states">
+          <button class="button primary md">Primary</button>
+          <button class="button secondary md">Secondary</button>
+          <button class="button outline md">Outline</button>
+          <button class="button destructive md">Destructive</button>
+          <button class="button primary md disabled" disabled>Disabled</button>
+        </section>
+
+        <form class="form" aria-label="Task creation form token smoke">
+          <div class="field">
+            <label for="title">Title</label>
+            <input id="title" value="Tokenized task intake" />
+          </div>
+          <div class="field">
+            <label for="requirements">Requirements *</label>
+            <textarea id="requirements">Capture the operator request and acceptance notes.</textarea>
+            <p class="help">Include request, acceptance notes, links, risks, and known constraints.</p>
+          </div>
+          <ul class="validationErrors">
+            <li>Example validation message</li>
+          </ul>
+          <p class="error">Example service error message</p>
+          <div class="actions">
+            <button class="button primary md" type="button">Create task draft</button>
+          </div>
+        </form>
+
+        <section class="detail-card" aria-label="Flattened nested summary card smoke">
+          <h2>Summary metrics</h2>
+          <div class="summary-grid">
+            <article data-testid="flattened-summary-card">
+              <span>Open risks</span>
+              <strong>2</strong>
+            </article>
+          </div>
+        </section>
+      </main>
+    </body>
+  </html>
+`;
+
+const TASK_DETAIL_SMOKE_HTML = `
+  <html>
+    <head>
+      <style>/* CSS_PLACEHOLDER */</style>
+      <style>
+        body {
+          margin: 0;
+          padding: var(--design-spacing-6);
+          background: var(--color-page-bg);
+          color: var(--color-on-surface);
+          font-family: var(--design-typography-body-md-font-family);
+        }
+
+        .task-detail-smoke {
+          max-width: 920px;
+        }
+      </style>
+    </head>
+    <body>
+      <main class="task-detail-smoke">
+        <section class="shell" aria-label="Task detail token smoke">
+          <header class="header">
+            <div class="titleBlock">
+              <span class="eyebrow">Task activity</span>
+              <h2 class="title">History and telemetry</h2>
+              <p class="subtitle">History remains distinct from telemetry so operators can audit workflow state quickly.</p>
+            </div>
+            <div class="tabs" role="tablist" aria-label="Task activity views">
+              <button class="tab tabActive" role="tab" aria-selected="true">History</button>
+              <button class="tab" role="tab" aria-selected="false">Telemetry</button>
+            </div>
+          </header>
+          <div class="panel">
+            <section class="filters" aria-label="History filters">
+              <label class="filterField">
+                <span class="filterLabel">Event type</span>
+                <input class="filterInput" value="assignment" />
+              </label>
+              <label class="filterField">
+                <span class="filterLabel">Actor</span>
+                <input class="filterInput" value="pm-1" />
+              </label>
+            </section>
+            <section class="notice noticeWarning" role="status">
+              <h3 class="noticeTitle">Partial data</h3>
+              <p class="noticeBody">Telemetry freshness is degraded.</p>
+              <p class="noticeDetail">Last updated 2026-04-01T15:00:00Z.</p>
+            </section>
+            <ol class="timeline">
+              <li class="item">
+                <div class="rail"><span class="dot tone_success"></span></div>
+                <article class="card">
+                  <div class="header">
+                    <div>
+                      <h3 class="title">Task assigned</h3>
+                      <p class="meta">PM - 2026-04-01T15:00:00Z</p>
+                    </div>
+                  </div>
+                  <p class="detail">Assigned to engineering for implementation.</p>
+                  <dl class="metadata">
+                    <div class="metadataItem">
+                      <dt>Event</dt>
+                      <dd>task.assigned</dd>
+                    </div>
+                    <div class="metadataItem">
+                      <dt>Source</dt>
+                      <dd>audit projection</dd>
+                    </div>
+                  </dl>
+                </article>
+              </li>
+            </ol>
+            <section class="grid" aria-label="Telemetry cards">
+              <article class="card tone_info">
+                <p class="label">Status</p>
+                <p class="value">fresh</p>
+                <p class="hint">Telemetry remains adjacent to the audit stream.</p>
+              </article>
+              <article class="card tone_warning">
+                <p class="label">Event count</p>
+                <p class="value">12</p>
+                <p class="hint">Review linked correlations before release.</p>
+              </article>
+            </section>
+            <section class="container" aria-label="Stage transition state">
+              <div class="header">
+                <span class="title">Workflow Transition</span>
+                <span class="current-stage">TODO</span>
+              </div>
+              <div class="form">
+                <label class="field">
+                  <span class="label">Target Stage</span>
+                  <input class="input" value="TECHNICAL_SPEC" />
+                </label>
+                <p class="error">Example transition validation error</p>
+              </div>
+            </section>
+          </div>
+        </section>
+      </main>
+    </body>
+  </html>
+`;
+
 async function installPrimaryAppFixture(page) {
   await page.addInitScript(() => {
     const claims = {
@@ -80,220 +261,62 @@ async function installPrimaryAppFixture(page) {
   });
 }
 
-test.describe('DESIGN.md token operationalization visual smoke', () => {
-  test('captures primary app, migrated component states, and responsive task detail token output', async ({ page }, testInfo) => {
-    await installPrimaryAppFixture(page);
-    await page.setViewportSize({ width: 1280, height: 900 });
-    await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: 'Task workspace' })).toBeVisible();
+test('captures primary app token output', async ({ page }, testInfo) => {
+  await installPrimaryAppFixture(page);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/tasks', { waitUntil: 'domcontentloaded' });
+  await expect(page.getByRole('heading', { name: 'Task workspace' })).toBeVisible();
 
-    const appShot = await page.screenshot({ path: testInfo.outputPath('design-token-primary-app.png') });
-    expect(appShot.byteLength).toBeGreaterThan(10_000);
+  const appShot = await page.screenshot({ path: testInfo.outputPath('design-token-primary-app.png') });
+  expect(appShot.byteLength).toBeGreaterThan(10_000);
+});
 
-    const css = [
-      readCss('src/app/design-tokens.css'),
-      readCss('src/components/Button/Button.tokens.css'),
-      readCss('src/components/Button/Button.module.css'),
-      readCss('src/features/task-creation/TaskCreationForm.tokens.css'),
-      readCss('src/features/task-creation/TaskCreationForm.module.css'),
-    ].join('\n');
+test('captures migrated component states and flattened summary cards', async ({ page }, testInfo) => {
+  const css = [
+    readCss('src/app/design-tokens.css'),
+    readCss('src/app/styles.css'),
+    readCss('src/components/Button/Button.tokens.css'),
+    readCss('src/components/Button/Button.module.css'),
+    readCss('src/features/task-creation/TaskCreationForm.tokens.css'),
+    readCss('src/features/task-creation/TaskCreationForm.module.css'),
+  ].join('\n');
 
-    await page.setContent(`
-      <html>
-        <head>
-          <style>${css}</style>
-          <style>
-            body {
-              margin: 0;
-              padding: var(--design-spacing-6);
-              background: var(--color-page-bg);
-              color: var(--color-on-surface);
-              font-family: var(--design-typography-body-md-font-family);
-            }
+  await page.setContent(withCss(COMPONENT_SMOKE_HTML, css));
 
-            .visual-smoke {
-              display: grid;
-              gap: var(--design-spacing-6);
-              max-width: 760px;
-            }
-
-            .button-row {
-              display: flex;
-              gap: var(--design-spacing-3);
-              flex-wrap: wrap;
-              padding: var(--design-spacing-4);
-              background: var(--color-surface);
-              border: var(--design-border-soft);
-              border-radius: var(--design-radius-panel);
-            }
-          </style>
-        </head>
-        <body>
-          <main class="visual-smoke">
-            <section class="button-row" aria-label="Button states">
-              <button class="button primary md">Primary</button>
-              <button class="button secondary md">Secondary</button>
-              <button class="button outline md">Outline</button>
-              <button class="button destructive md">Destructive</button>
-              <button class="button primary md disabled" disabled>Disabled</button>
-            </section>
-
-            <form class="form" aria-label="Task creation form token smoke">
-              <div class="field">
-                <label for="title">Title</label>
-                <input id="title" value="Tokenized task intake" />
-              </div>
-              <div class="field">
-                <label for="requirements">Requirements *</label>
-                <textarea id="requirements">Capture the operator request and acceptance notes.</textarea>
-                <p class="help">Include request, acceptance notes, links, risks, and known constraints.</p>
-              </div>
-              <ul class="validationErrors">
-                <li>Example validation message</li>
-              </ul>
-              <p class="error">Example service error message</p>
-              <div class="actions">
-                <button class="button primary md" type="button">Create task draft</button>
-              </div>
-            </form>
-          </main>
-        </body>
-      </html>
-    `);
-
-    const buttonShot = await page.getByLabel('Button states').screenshot({
-      path: testInfo.outputPath('design-token-button-states.png'),
-    });
-    const formShot = await page.getByLabel('Task creation form token smoke').screenshot({
-      path: testInfo.outputPath('design-token-task-creation-form.png'),
-    });
-
-    expect(buttonShot.byteLength).toBeGreaterThan(4_000);
-    expect(formShot.byteLength).toBeGreaterThan(8_000);
-
-    const taskDetailCss = [
-      readCss('src/app/design-tokens.css'),
-      readCss('src/features/task-detail/TaskDetail.tokens.css'),
-      readCss('src/features/task-detail/TaskDetailActivityShell.module.css'),
-      readCss('src/features/task-detail/TaskHistoryTimeline.module.css'),
-      readCss('src/features/task-detail/TelemetrySummary.module.css'),
-      readCss('src/features/task-detail/StageTransition.module.css'),
-    ].join('\n');
-
-    await page.setViewportSize({ width: 1024, height: 860 });
-    await page.setContent(`
-      <html>
-        <head>
-          <style>${taskDetailCss}</style>
-          <style>
-            body {
-              margin: 0;
-              padding: var(--design-spacing-6);
-              background: var(--color-page-bg);
-              color: var(--color-on-surface);
-              font-family: var(--design-typography-body-md-font-family);
-            }
-
-            .task-detail-smoke {
-              max-width: 920px;
-            }
-          </style>
-        </head>
-        <body>
-          <main class="task-detail-smoke">
-            <section class="shell" aria-label="Task detail token smoke">
-              <header class="header">
-                <div class="titleBlock">
-                  <span class="eyebrow">Task activity</span>
-                  <h2 class="title">History and telemetry</h2>
-                  <p class="subtitle">History remains distinct from telemetry so operators can audit workflow state quickly.</p>
-                </div>
-                <div class="tabs" role="tablist" aria-label="Task activity views">
-                  <button class="tab tabActive" role="tab" aria-selected="true">History</button>
-                  <button class="tab" role="tab" aria-selected="false">Telemetry</button>
-                </div>
-              </header>
-              <div class="panel">
-                <section class="filters" aria-label="History filters">
-                  <label class="filterField">
-                    <span class="filterLabel">Event type</span>
-                    <input class="filterInput" value="assignment" />
-                  </label>
-                  <label class="filterField">
-                    <span class="filterLabel">Actor</span>
-                    <input class="filterInput" value="pm-1" />
-                  </label>
-                </section>
-                <section class="notice noticeWarning" role="status">
-                  <h3 class="noticeTitle">Partial data</h3>
-                  <p class="noticeBody">Telemetry freshness is degraded.</p>
-                  <p class="noticeDetail">Last updated 2026-04-01T15:00:00Z.</p>
-                </section>
-                <ol class="timeline">
-                  <li class="item">
-                    <div class="rail"><span class="dot tone_success"></span></div>
-                    <article class="card">
-                      <div class="header">
-                        <div>
-                          <h3 class="title">Task assigned</h3>
-                          <p class="meta">PM - 2026-04-01T15:00:00Z</p>
-                        </div>
-                      </div>
-                      <p class="detail">Assigned to engineering for implementation.</p>
-                      <dl class="metadata">
-                        <div class="metadataItem">
-                          <dt>Event</dt>
-                          <dd>task.assigned</dd>
-                        </div>
-                        <div class="metadataItem">
-                          <dt>Source</dt>
-                          <dd>audit projection</dd>
-                        </div>
-                      </dl>
-                    </article>
-                  </li>
-                </ol>
-                <section class="grid" aria-label="Telemetry cards">
-                  <article class="card tone_info">
-                    <p class="label">Status</p>
-                    <p class="value">fresh</p>
-                    <p class="hint">Telemetry remains adjacent to the audit stream.</p>
-                  </article>
-                  <article class="card tone_warning">
-                    <p class="label">Event count</p>
-                    <p class="value">12</p>
-                    <p class="hint">Review linked correlations before release.</p>
-                  </article>
-                </section>
-                <section class="container" aria-label="Stage transition state">
-                  <div class="header">
-                    <span class="title">Workflow Transition</span>
-                    <span class="current-stage">TODO</span>
-                  </div>
-                  <div class="form">
-                    <label class="field">
-                      <span class="label">Target Stage</span>
-                      <input class="input" value="TECHNICAL_SPEC" />
-                    </label>
-                    <p class="error">Example transition validation error</p>
-                  </div>
-                </section>
-              </div>
-            </section>
-          </main>
-        </body>
-      </html>
-    `);
-
-    const detailShot = await page.getByLabel('Task detail token smoke').screenshot({
-      path: testInfo.outputPath('design-token-task-detail-states.png'),
-    });
-    expect(detailShot.byteLength).toBeGreaterThan(12_000);
-
-    await page.setViewportSize({ width: 390, height: 900 });
-    const mobileShot = await page.getByLabel('Task detail token smoke').screenshot({
-      path: testInfo.outputPath('design-token-task-detail-mobile.png'),
-    });
-    expect(mobileShot.byteLength).toBeGreaterThan(10_000);
+  const buttonShot = await page.getByLabel('Button states').screenshot({
+    path: testInfo.outputPath('design-token-button-states.png'),
   });
+  const formShot = await page.getByLabel('Task creation form token smoke').screenshot({
+    path: testInfo.outputPath('design-token-task-creation-form.png'),
+  });
+
+  expect(buttonShot.byteLength).toBeGreaterThan(4_000);
+  expect(formShot.byteLength).toBeGreaterThan(8_000);
+  await expect(page.getByTestId('flattened-summary-card')).toHaveCSS('box-shadow', 'none');
+});
+
+test('captures responsive task detail token output', async ({ page }, testInfo) => {
+  const taskDetailCss = [
+    readCss('src/app/design-tokens.css'),
+    readCss('src/features/task-detail/TaskDetail.tokens.css'),
+    readCss('src/features/task-detail/TaskDetailActivityShell.module.css'),
+    readCss('src/features/task-detail/TaskHistoryTimeline.module.css'),
+    readCss('src/features/task-detail/TelemetrySummary.module.css'),
+    readCss('src/features/task-detail/StageTransition.module.css'),
+  ].join('\n');
+
+  await page.setViewportSize({ width: 1024, height: 860 });
+  await page.setContent(withCss(TASK_DETAIL_SMOKE_HTML, taskDetailCss));
+
+  const detailShot = await page.getByLabel('Task detail token smoke').screenshot({
+    path: testInfo.outputPath('design-token-task-detail-states.png'),
+  });
+  expect(detailShot.byteLength).toBeGreaterThan(12_000);
+  await expect(page.getByRole('tab', { name: 'History' })).toHaveCSS('font-weight', '700');
+
+  await page.setViewportSize({ width: 390, height: 900 });
+  const mobileShot = await page.getByLabel('Task detail token smoke').screenshot({
+    path: testInfo.outputPath('design-token-task-detail-mobile.png'),
+  });
+  expect(mobileShot.byteLength).toBeGreaterThan(10_000);
 });

--- a/tests/unit/governance/check-design-token-usage.test.js
+++ b/tests/unit/governance/check-design-token-usage.test.js
@@ -18,7 +18,12 @@ test('check-design-token-usage passes tokenized CSS', () => {
   color: var(--color-on-surface);
   border-radius: var(--design-radius-panel);
   box-shadow: var(--design-shadow-sm);
+  font-family: var(--design-typography-body-md-font-family);
   font-size: var(--design-typography-body-md-font-size);
+  font-weight: var(--design-typography-body-md-font-weight);
+  line-height: var(--design-typography-body-md-line-height);
+  transition: none;
+  animation: none;
 }
 `);
 
@@ -35,8 +40,13 @@ test('check-design-token-usage fails forbidden visual literals', () => {
   background: rgba(15, 23, 42, 0.08);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  font-family: Arial, sans-serif;
   font-size: 14px;
+  font-weight: 600;
+  line-height: 1.25;
   letter-spacing: 0;
+  transition: all 0.15s ease-in-out;
+  animation: spin 1s linear infinite;
   opacity: 0.5;
 }
 `);
@@ -47,8 +57,13 @@ test('check-design-token-usage fails forbidden visual literals', () => {
   assert.match(result.stderr, /rgb\(\)\/rgba\(\)\/hsl\(\)\/hsla\(\) color literal/);
   assert.match(result.stderr, /border-radius size literal/);
   assert.match(result.stderr, /box-shadow literal/);
+  assert.match(result.stderr, /font-family literal/);
   assert.match(result.stderr, /font-size literal/);
+  assert.match(result.stderr, /font-weight literal/);
+  assert.match(result.stderr, /line-height literal/);
   assert.match(result.stderr, /letter-spacing literal/);
+  assert.match(result.stderr, /transition literal/);
+  assert.match(result.stderr, /animation literal/);
   assert.match(result.stderr, /opacity literal/);
 });
 

--- a/tests/unit/governance/design-token-contrast.test.js
+++ b/tests/unit/governance/design-token-contrast.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '../../..');
+const TOKEN_PATH = path.join(ROOT, 'src/app/design-tokens.css');
+const MIN_NORMAL_TEXT_CONTRAST = 4.5;
+
+function readTokenColors() {
+  const css = fs.readFileSync(TOKEN_PATH, 'utf8');
+  const tokens = new Map();
+  const pattern = /--([a-z0-9-]+):\s*(#[0-9a-fA-F]{6})\s*;/g;
+  for (const match of css.matchAll(pattern)) {
+    tokens.set(match[1], match[2]);
+  }
+  return tokens;
+}
+
+function relativeLuminance(hex) {
+  const normalized = hex.replace('#', '');
+  const [red, green, blue] = [0, 2, 4].map((offset) => parseInt(normalized.slice(offset, offset + 2), 16) / 255);
+  const [r, g, b] = [red, green, blue].map((channel) => (
+    channel <= 0.03928 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  ));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foreground, background) {
+  const foregroundLum = relativeLuminance(foreground);
+  const backgroundLum = relativeLuminance(background);
+  const lighter = Math.max(foregroundLum, backgroundLum);
+  const darker = Math.min(foregroundLum, backgroundLum);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+test('semantic DESIGN.md token text/background pairs meet WCAG AA contrast', () => {
+  const tokens = readTokenColors();
+  const pairs = [
+    ['color-on-surface', 'color-surface'],
+    ['color-on-heading', 'color-page-bg'],
+    ['color-on-muted', 'color-surface'],
+    ['color-on-muted-strong', 'color-surface-muted'],
+    ['color-primary', 'color-surface'],
+    ['color-surface', 'color-primary'],
+    ['color-primary-strong', 'color-primary-soft'],
+    ['color-success-text', 'color-success-soft'],
+    ['color-warning-text', 'color-warning-soft'],
+    ['color-danger-text', 'color-danger-soft'],
+    ['color-info', 'color-info-soft'],
+    ['color-review', 'color-review-soft'],
+    ['color-surface', 'color-success'],
+    ['color-surface', 'color-warning'],
+    ['color-surface', 'color-danger'],
+  ];
+
+  for (const [foregroundToken, backgroundToken] of pairs) {
+    const foreground = tokens.get(foregroundToken);
+    const background = tokens.get(backgroundToken);
+    assert.ok(foreground, `missing ${foregroundToken}`);
+    assert.ok(background, `missing ${backgroundToken}`);
+    assert.ok(
+      contrastRatio(foreground, background) >= MIN_NORMAL_TEXT_CONTRAST,
+      `${foregroundToken} on ${backgroundToken} must meet WCAG AA contrast`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Improves DESIGN.md compliance by tightening token enforcement, preserving visible Button loading text, reducing motion exposure, flattening nested summary-card styling, and adding contrast regression coverage for semantic token pairs.

## Linked Task
- Task: User-requested DESIGN.md compliance execution

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: DESIGN.md source-of-truth, tokenized UI CSS, reduced motion, accessibility contrast, visual governance
- Standards gaps or exceptions: No unresolved standards gaps; DESIGN-TOKEN-EXCEPTION budget remains 0.
- [x] UI changes use generated DESIGN.md tokens.
- [x] `npm run design:tokens:check` passed.
- [x] `npm run design:tokens:enforce` passed.
- [x] `DESIGN.md` was updated when visual semantics changed.
- [x] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: `npm run standards:check` passed locally after the Button test maintainability split.
- Lint result: `npm run design:tokens:enforce` passed; pre-push policy validators passed.
- Tests: `npm run design:tokens:check`; `npm run design:tokens:enforce`; `npm run design:audit:check`; `node --test tests/unit/governance/check-design-token-usage.test.js tests/unit/governance/design-token-contrast.test.js`; `npm run typecheck`; `npx vitest run src/components/Button/Button.test.tsx`; `npm run change:check`; `npx playwright test tests/browser/design-token-operationalization.browser.spec.ts --project=chromium`; pre-push validation suite passed.
- Test evidence paths: src/components/Button/Button.test.tsx, tests/browser/design-token-operationalization.browser.spec.ts, tests/unit/governance/check-design-token-usage.test.js, tests/unit/governance/design-token-contrast.test.js
- Docs updated: Design adoption audit config and generated audit summary updated to document broader typography, motion, and contrast coverage.
- Doc evidence paths: docs/design/design-md-adoption.config.json, docs/design/DESIGN_MD_ADOPTION_AUDIT.md

## Risk and Rollback
- Risk level: low
- Rollback path: Revert this PR commit to restore the prior Button loading behavior, CSS literals, and narrower design-token enforcement.

## Notes

CI initially flagged the PR body metadata, an oversized Button test callback, and missing browser-shell/task-detail UI evidence. The branch now includes the test-structure fix, browser evidence, and required PR metadata fields.
