### PR TITLE
Highlight active workspace nav route

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -526,7 +526,7 @@ Component rules reflect the current React/Vite app and the Button component ADR.
 - Inputs and selects: use `surface`, `border`, `8px` radius, and nearby helper or error text.
 - Task creation forms: use generated `task-creation-*` tokens for form panels, labels, inputs, helper text, and error states.
 - Task detail shells, filters, timelines, telemetry cards, and stage transitions: use generated `task-detail-*`, `stage-transition-*`, `history-*`, and `telemetry-*` tokens. Keep activity history and telemetry adjacent but visually distinct.
-- App nav: persistent desktop left rail with compact stacked route groups, a primary create action, role inbox control, and muted session controls. On mobile it collapses back into a horizontally scrollable top navigation strip.
+- App nav: persistent desktop left rail with compact stacked route groups, visible selected state for the active Task workspace or Kanban board route, a primary create action, role inbox control, and muted session controls. On mobile it collapses back into a horizontally scrollable top navigation strip.
 - Board columns and task cards: keep text readable, allow wrapping, preserve stable widths, and expose owner/status metadata without hover-only access.
 - Badges: use semantic status text plus color. Do not rely on color alone.
 - Review-question and QA/SRE panels: use status banners and summary grids to show route, risk, evidence, and required next action.

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -303,6 +303,16 @@ button {
   box-shadow: none;
 }
 
+.app-nav__primary button[aria-pressed='true']:not(.button-secondary, .app-nav__primary-action) {
+  border-color: color-mix(in srgb, var(--primary) 32%, transparent);
+  border-left-color: var(--primary);
+  border-left-width: 3px;
+  padding-left: 6px;
+  background: var(--surface-muted);
+  color: var(--text);
+  box-shadow: none;
+}
+
 .app-nav__secondary button,
 .app-nav__role-select {
   font-size: var(--design-component-app-nav-font-size);

--- a/tests/browser/task-workspace.browser.spec.ts
+++ b/tests/browser/task-workspace.browser.spec.ts
@@ -259,6 +259,27 @@ async function readNavigationStyles(page) {
   });
 }
 
+async function readPrimaryWorkspaceButtonStyles(page) {
+  return page.getByRole('group', { name: 'Primary task navigation' }).evaluate((nav) => {
+    const buttons = [...nav.querySelectorAll('button')];
+    const taskWorkspace = buttons.find((button) => button.textContent?.trim() === 'Task workspace');
+    const kanbanBoard = buttons.find((button) => button.textContent?.trim() === 'Kanban board');
+    const taskWorkspaceStyle = taskWorkspace ? window.getComputedStyle(taskWorkspace) : null;
+    const kanbanBoardStyle = kanbanBoard ? window.getComputedStyle(kanbanBoard) : null;
+
+    return {
+      taskWorkspaceBackground: taskWorkspaceStyle?.backgroundColor || '',
+      taskWorkspaceBorderLeftColor: taskWorkspaceStyle?.borderLeftColor || '',
+      taskWorkspaceBorderLeftWidth: taskWorkspaceStyle?.borderLeftWidth || '',
+      taskWorkspacePressed: taskWorkspace?.getAttribute('aria-pressed') || '',
+      kanbanBoardBackground: kanbanBoardStyle?.backgroundColor || '',
+      kanbanBoardBorderLeftColor: kanbanBoardStyle?.borderLeftColor || '',
+      kanbanBoardBorderLeftWidth: kanbanBoardStyle?.borderLeftWidth || '',
+      kanbanBoardPressed: kanbanBoard?.getAttribute('aria-pressed') || '',
+    };
+  });
+}
+
 async function assertOwnerFilterEmptyState(page) {
   await page.getByLabel('Owner filter').selectOption('pm');
   await expect(page.getByText('1 cards shown for PM · PM.')).toBeVisible();
@@ -325,12 +346,25 @@ test('switches from task workspace list into the Kanban board with selected rout
   await expect(page.getByRole('table')).toBeVisible();
 
   const primaryNav = page.getByRole('group', { name: 'Primary task navigation' });
+  const listButtonStyles = await readPrimaryWorkspaceButtonStyles(page);
+  expect(listButtonStyles.taskWorkspacePressed).toBe('true');
+  expect(listButtonStyles.kanbanBoardPressed).toBe('false');
+  expect(listButtonStyles.taskWorkspaceBackground).not.toBe(listButtonStyles.kanbanBoardBackground);
+  expect(listButtonStyles.taskWorkspaceBorderLeftColor).not.toBe(listButtonStyles.kanbanBoardBorderLeftColor);
+  expect(listButtonStyles.taskWorkspaceBorderLeftWidth).toBe('3px');
+
   await primaryNav.getByRole('button', { name: 'Kanban board' }).click();
 
   await expect(page).toHaveURL(/\/tasks\?view=board$/);
   await assertWorkspaceBoard(page);
   await expect(page.getByRole('tab', { name: 'Kanban board' })).toHaveAttribute('aria-selected', 'true');
   await expect(primaryNav.getByRole('button', { name: 'Kanban board' })).toHaveAttribute('aria-pressed', 'true');
+  const boardButtonStyles = await readPrimaryWorkspaceButtonStyles(page);
+  expect(boardButtonStyles.taskWorkspacePressed).toBe('false');
+  expect(boardButtonStyles.kanbanBoardPressed).toBe('true');
+  expect(boardButtonStyles.kanbanBoardBackground).not.toBe(boardButtonStyles.taskWorkspaceBackground);
+  expect(boardButtonStyles.kanbanBoardBorderLeftColor).not.toBe(boardButtonStyles.taskWorkspaceBorderLeftColor);
+  expect(boardButtonStyles.kanbanBoardBorderLeftWidth).toBe('3px');
 });
 
 test('creates an intake draft from the workspace and opens the created task with recovery actions', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a visible active state for the primary Task workspace and Kanban board nav buttons
- document the app-nav selected-state rule in DESIGN.md
- extend browser coverage to assert selected button styles before and after switching to Kanban

## Tests
- npm run design:tokens:enforce
- npm run design:change-guard
- npm run lint
- npx vitest run src/app/AppNavigation.test.tsx
- npx playwright test tests/browser/task-workspace.browser.spec.ts --project=chromium
- npm test

Refs #179