### PR TITLE
Align governance gates with runtime workflow

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -10,6 +10,7 @@ Require these exact GitHub Actions job names before merge:
 - `Pull request metadata`
 - `Repo validation`
 - `Browser validation`
+- `verify`
 - `Merge readiness`
 
 Require this job if governance drift is treated as blocking in your environment:
@@ -23,11 +24,14 @@ Require this job if governance drift is treated as blocking in your environment:
 - Restrict direct pushes to the protected branch.
 
 ## Mapping To Workflow Files
-- `.github/workflows/validation.yml`
-- `.github/workflows/governance-drift.yml`
+- `Pull request metadata` in `.github/workflows/validation.yml` runs `npm run pr:check`, `npm run change:check`, and `npm run ownership:lint`.
+- `Repo validation` in `.github/workflows/validation.yml` runs `npm run coverage`, `npm run standards:check`, `npm run ownership:lint`, `npm run test:unit`, and the non-browser Node suites.
+- `Browser validation` in `.github/workflows/validation.yml` runs `npm run test:browser`.
+- `verify` in `.github/workflows/verify.yml` runs `make verify`, which aggregates DESIGN.md gates, standards policy validators, `npm run lint`, `npm run typecheck`, `npm run test:unit`, `npm run test:browser`, `npm run build`, `npm run standards:check`, and artifact validators.
+- `Merge readiness` is emitted by the task-platform merge-readiness GitHub check integration from the structured review source of truth.
+- `Governance drift report` in `.github/workflows/governance-drift.yml` runs `npm run governance:drift:check`.
 
 ## Maintainer Notes
 - If a workflow job name changes, update this file and any downstream org policy that references the old status name.
 - Do not mark a status as required unless the corresponding workflow runs on pull requests for the protected branch.
-- The control plane may represent Merge readiness as enforced only after default-branch protection requires `Merge readiness`.
 - If governance drift should be advisory only, leave `Governance drift report` out of the required-check list but keep the scheduled workflow enabled.

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -25,6 +25,18 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-standards.txt
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CHANGE_COMMANDS ?= make verify
 CHANGE_EVIDENCE ?= local-verify
 RELEASE_ENV ?= dev
 
-.PHONY: design-local-gates lint typecheck test build verify
+.PHONY: design-local-gates standards-policy-gates standards-python-typecheck standards-python-test standards-python-build lint typecheck test build verify
 
 design-local-gates:
 	npm run design:tokens:check
@@ -22,7 +22,7 @@ design-local-gates:
 	npm run design:audit:check
 	npm run design:change-guard
 
-lint:
+standards-policy-gates:
 	$(PYTHON) dev-standards/tooling/validate_policy_files.py --repo-root $(REPO_ROOT)
 	$(PYTHON) dev-standards/tooling/validate_waivers.py --repo-root $(REPO_ROOT)
 	CHANGE_KIND=$(CHANGE_KIND) CHANGE_REFERENCE=$(CHANGE_REFERENCE) $(PYTHON) dev-standards/tooling/validate_approval_proof.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))
@@ -38,15 +38,29 @@ lint:
 	CHANGE_KIND=$(CHANGE_KIND) CHANGE_REVERSIBILITY=$(CHANGE_REVERSIBILITY) $(PYTHON) dev-standards/tooling/validate_release_evidence.py --repo-root $(REPO_ROOT) --environment $(RELEASE_ENV)
 	$(PYTHON) dev-standards/tooling/check_maintainability.py --repo-root $(REPO_ROOT)
 
-typecheck:
+standards-python-typecheck:
 	@if [ -n "$(PY_FILES)" ]; then PYTHONPYCACHEPREFIX=$(PYCACHE_PREFIX) $(PYTHON) -m py_compile $(PY_FILES); fi
 
-test:
+standards-python-test:
 	$(PYTHON) dev-standards/tooling/run_python_tests.py
 
-build:
+standards-python-build:
 	PYTHONPYCACHEPREFIX=$(PYCACHE_PREFIX) $(PYTHON) -m compileall tests dev-standards
 
+lint: standards-policy-gates
+	npm run lint
+
+typecheck: standards-python-typecheck
+	npm run typecheck
+
+test: standards-python-test
+	npm run test:unit
+	npm run test:browser
+
+build: standards-python-build
+	npm run build
+
 verify: design-local-gates lint typecheck test build
+	npm run standards:check
 	$(PYTHON) dev-standards/tooling/validate_artifact_provenance.py --repo-root $(REPO_ROOT)
 	CHANGE_KIND=$(CHANGE_KIND) $(PYTHON) dev-standards/tooling/validate_test_policy.py --repo-root $(REPO_ROOT) $(if $(BASE_REF),--base-ref $(BASE_REF))

--- a/README.md
+++ b/README.md
@@ -16,9 +16,18 @@ This repo now includes a standards enforcement baseline for task planning and ch
 - reusable review template: `docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md`
 - PR gate: `.github/PULL_REQUEST_TEMPLATE.md`
 - CI presence check: `npm run standards:check`
+- full local ship gate: `make verify`
+- standards-only local gate: `make standards-policy-gates`
 - branch protection policy: `.github/BRANCH_PROTECTION.md`
 
 Every task file under `tasks/` is expected to carry `## Standards Alignment` and `## Required Evidence` so the repo has a durable record of which standards applied, what evidence was produced, and which gaps remain.
+
+`make verify` is the aggregate local gate for this React/Vite/Node/PostgreSQL
+application. It runs DESIGN.md gates, standards policy validators, `npm run
+lint`, `npm run typecheck`, `npm run test:unit`, `npm run test:browser`, `npm
+run build`, `npm run standards:check`, and Python standards test/artifact
+validators. Use `make standards-policy-gates` only when you need the
+standards-policy slice without the runtime app checks.
 
 ## Visual Design Tokens
 

--- a/check-manifest.yaml
+++ b/check-manifest.yaml
@@ -2,23 +2,31 @@ schema_version: "1.0"
 standards_version: "0.1.0"
 merge_checks:
   - id: lint
-    description: formatting and policy gate
+    description: standards policy validators plus repository lint gate
     command: make lint
     required: true
   - id: typecheck
-    description: static verification gate
+    description: TypeScript typecheck plus Python standards compile gate
     command: make typecheck
     required: true
   - id: test
-    description: automated test suite
+    description: Python standards tests, Node unit/UI tests, and Playwright browser suite
     command: make test
     required: true
   - id: build
-    description: reproducible build gate
+    description: Vite application build plus Python standards compile gate
     command: make build
     required: true
+  - id: design
+    description: DESIGN.md token drift, token usage, audit, and change guard
+    command: make design-local-gates
+    required: true
+  - id: standards
+    description: standards governance, maintainability, and coverage policy gate
+    command: npm run standards:check
+    required: true
   - id: verify
-    description: aggregate merge-readiness gate
+    description: aggregate local ship gate for runtime, design, and standards governance
     command: make verify
     required: true
 release_checks:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,25 @@ Compose stack for PostgreSQL, Pushgateway, audit API, and audit workers.
 | Design-token enforcement | `DESIGN.md`, token-generated CSS, migrated CSS modules | `npm run design:tokens:check`, `npm run design:tokens:enforce`, `npm run design:audit:check`, `npm run design:change-guard` |
 | Governance/protected paths | `repo-contract.yaml`, `agent-policy.yaml`, `check-manifest.yaml`, `dev-standards/`, `.github/workflows/`, `Makefile`, `DESIGN.md` | `make verify`, `npm run standards:check`, change metadata, approval proof, traceability, docs freshness |
 
+## Governance Runtime Contract
+
+The governance contract is intentionally aligned to the application runtime, not
+only to the Python standards tooling. `repo-contract.yaml` declares the
+JavaScript/TypeScript/Node/Vite/React/PostgreSQL and Python standards runtime,
+the owned app/API/auth/audit/task-platform/browser/monitoring paths, and the
+source files that can drift when runtime gates change.
+
+`check-manifest.yaml` declares the merge-check command set. The Makefile maps
+those checks to the real local commands:
+
+| Make target | Runtime and standards gates |
+|---|---|
+| `make lint` | standards policy validators and `npm run lint` |
+| `make typecheck` | Python standards compile check and `npm run typecheck` |
+| `make test` | Python standards tests, `npm run test:unit`, and `npm run test:browser` |
+| `make build` | Python standards compile check and `npm run build` |
+| `make verify` | design gates, lint, typecheck, test, build, `npm run standards:check`, artifact provenance, and test policy |
+
 ## External Systems
 
 | System | Used by | Failure posture |
@@ -124,10 +143,13 @@ Use `docs/runbook.md` for exact operator commands. At the architecture level:
 - `npm run test:browser` runs Playwright browser coverage.
 - `npm test` runs the full Node/browser quality suite.
 - `npm run standards:check` runs standards, maintainability, and coverage policy checks.
-- `make verify` runs the standards governance gate and DESIGN.md local gates.
+- `make standards-policy-gates` runs the standards-only policy validators.
+- `make verify` runs the aggregate local ship gate for design, standards, Node/Vite/browser, and Python standards evidence.
 
 ## Diagrams
 
 - Workflow: `docs/diagrams/workflow-architecture-runbooks.mmd`
 - Container architecture: `docs/diagrams/architecture-architecture-runbooks.mmd`
+- Governance runtime workflow: `docs/diagrams/workflow-governance-runtime-gates.mmd`
+- Governance runtime architecture: `docs/diagrams/architecture-governance-runtime-gates.mmd`
 - Existing domain diagrams: `docs/diagrams/`

--- a/docs/diagrams/architecture-governance-runtime-gates.mmd
+++ b/docs/diagrams/architecture-governance-runtime-gates.mmd
@@ -1,0 +1,16 @@
+flowchart LR
+  Browser[Browser app<br/>src/app src/features src/components] --> API[Vercel API adapters<br/>api]
+  API --> Services[Node services<br/>lib/auth lib/audit lib/task-platform]
+  Services --> Postgres[PostgreSQL migrations<br/>db/migrations]
+  Services --> Monitoring[Monitoring assets<br/>monitoring observability]
+
+  Contract[repo-contract.yaml] --> Runtime[Runtime declarations<br/>Node Vite React TypeScript PostgreSQL Python]
+  Contract --> Ownership[Architecture ownership<br/>app API auth audit task-platform scripts monitoring]
+  Manifest[check-manifest.yaml] --> Makefile[Makefile]
+  Package[package.json] --> Makefile
+  Makefile --> RuntimeGates[Runtime gates<br/>lint typecheck unit browser build]
+  Makefile --> StandardsGates[Standards gates<br/>policy design standards check]
+  RuntimeGates --> Verify[make verify]
+  StandardsGates --> Verify
+  Verify --> Workflows[GitHub Actions<br/>validation and verify]
+  Workflows --> Protection[Branch protection]

--- a/docs/diagrams/workflow-governance-runtime-gates.mmd
+++ b/docs/diagrams/workflow-governance-runtime-gates.mmd
@@ -1,0 +1,25 @@
+flowchart TD
+  Change[Code or policy change] --> Contract[repo-contract.yaml runtime metadata]
+  Change --> Manifest[check-manifest.yaml merge checks]
+  Contract --> Makefile[Makefile gate targets]
+  Manifest --> Makefile
+  Makefile --> Design[DESIGN.md local gates]
+  Makefile --> Standards[standards policy validators]
+  Makefile --> AppLint[npm run lint]
+  Makefile --> Typecheck[npm run typecheck]
+  Makefile --> Unit[npm run test:unit]
+  Makefile --> Browser[npm run test:browser]
+  Makefile --> Build[npm run build]
+  Makefile --> StandardsCheck[npm run standards:check]
+  Design --> Verify[make verify]
+  Standards --> Verify
+  AppLint --> Verify
+  Typecheck --> Verify
+  Unit --> Verify
+  Browser --> Verify
+  Build --> Verify
+  StandardsCheck --> Verify
+  Verify --> Evidence[artifact provenance and test-policy evidence]
+  Evidence --> PR[Pull request merge readiness]
+  PR --> Vercel[Vercel deployment preview]
+  Vercel --> Merge[Protected branch merge]

--- a/docs/reports/ISSUE-194_STANDARDS_COMPLIANCE_CHECKLIST.md
+++ b/docs/reports/ISSUE-194_STANDARDS_COMPLIANCE_CHECKLIST.md
@@ -1,0 +1,71 @@
+# Standards Compliance Checklist
+
+## Linked Standards
+
+- Standards document: `docs/standards/software-development-standards.md`
+- Required gap statement format: `Gap observed: X. Documented rationale: Y (source Z).`
+
+## Change Metadata
+
+- Change or task ID: `ISSUE-194`
+- Owner: `wiinc1`
+- Date: 2026-05-14
+- Scope summary: Align governance metadata and verification commands with the real React/Vite/Node/PostgreSQL runtime, update CI setup, document gate mapping, and add regression tests.
+
+## Standards Alignment
+
+- Applicable standards areas: architecture and design, coding and code quality, testing and quality assurance, deployment and release, observability and monitoring, team and process.
+- Evidence expected for this change: updated repo contract, check manifest, Makefile runtime gates, verify workflow dependency setup, architecture/runbook/branch-protection mapping, Mermaid diagrams, and focused governance tests.
+- Gap observed: None. Documented rationale: issue #194 requested that repo governance and verification gates reflect the actual runtime instead of only Python standards tooling (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Architecture and Design
+
+- Applicable: yes
+- Evidence in this change: `repo-contract.yaml`, `docs/architecture.md`, `docs/diagrams/workflow-governance-runtime-gates.mmd`, and `docs/diagrams/architecture-governance-runtime-gates.mmd` describe runtime layers, state ownership, and gate flow.
+- Gap observed: None. Documented rationale: architecture metadata now covers app, API, auth, audit, task-platform, browser feature modules, monitoring, scripts, standards, and deployment sources (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Coding and Code Quality
+
+- Applicable: yes
+- Evidence in this change: `Makefile`, `package.json`, `.github/workflows/verify.yml`, and `tests/unit/governance/runtime-gates-contract.test.js` keep the command contract executable and regression-tested.
+- Gap observed: None. Documented rationale: the implementation reuses existing Makefile, npm, and GitHub Actions entrypoints instead of adding a parallel verification framework (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Testing and Quality Assurance
+
+- Applicable: yes
+- Evidence in this change: the new governance test asserts runtime declarations, Makefile command wiring, manifest mapping, verify workflow setup, docs, branch-protection mapping, and diagrams.
+- Gap observed: None. Documented rationale: focused tests guard against stale or missing runtime declarations and command drift (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Deployment and Release
+
+- Applicable: yes
+- Evidence in this change: `.github/workflows/verify.yml` installs Node dependencies and Playwright browsers before running `make verify`; `.github/BRANCH_PROTECTION.md` maps required status checks to their local commands.
+- Gap observed: None. Documented rationale: the verify workflow now has the dependencies required by the expanded local ship gate (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Observability and Monitoring
+
+- Applicable: yes
+- Evidence in this change: `repo-contract.yaml` declares monitoring and observability ownership; docs link governance gates to runtime evidence and deployment previews.
+- Gap observed: None. Documented rationale: monitoring assets and redacted diagnostics are part of the runtime governance contract, but no production monitoring behavior changed (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Authentication and Secret Handling
+
+- Applicable: yes
+- AuthN/AuthZ surfaces changed: no auth runtime behavior changed.
+- Secret, token, cookie, password, or PII redaction evidence: the build gate writes non-secret auth diagnostics only; new docs and diagrams avoid secret assignments and private key material.
+- Abuse-control or rate-limit evidence: not applicable because no auth request behavior changed.
+- Rollback or removal impact: revert the governance wiring commit if the expanded local ship gate creates an unintended blocker, then restore the prior Makefile and workflow dependency setup.
+- Gap observed: None. Documented rationale: local builds default the auth config check to a development target unless `AUTH_CONFIG_TARGET` or `VERCEL_ENV` selects another target, preserving production enforcement on Vercel while allowing local verification (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Team and Process
+
+- Applicable: yes
+- Evidence in this change: `README.md`, `docs/runbook.md`, and `.github/BRANCH_PROTECTION.md` distinguish standards-only checks from the full local ship gate and map local commands to CI checks.
+- Gap observed: None. Documented rationale: maintainers now have one documented aggregate gate for runtime plus standards, and a separate standards-only slice for narrow policy work (source https://github.com/wiinc1/engineering-team/issues/194).
+
+## Required Evidence
+
+- Commands run: `npm run build` before the change failed because missing production auth variables; after the change `python3 dev-standards/tooling/validate_policy_files.py --repo-root .`, `node --test tests/unit/governance/runtime-gates-contract.test.js`, `npm run lint`, `npm run typecheck`, `npm run standards:check`, `npm run test:unit`, `npm run test:browser`, `npm run build`, `make verify`, and `git diff --check` passed. The first `make verify` attempt hit an existing flaky Vitest board-owner timeout; the immediate rerun passed.
+- Tests added or updated: `tests/unit/governance/runtime-gates-contract.test.js`.
+- Rollout or rollback notes: no production rollout required; rollback by reverting the contract, Makefile, package build target default, workflow, docs, diagrams, and governance test.
+- Docs updated: `README.md`; `docs/architecture.md`; `docs/runbook.md`; `.github/BRANCH_PROTECTION.md`; `docs/diagrams/workflow-governance-runtime-gates.mmd`; `docs/diagrams/architecture-governance-runtime-gates.mmd`; `docs/reports/ISSUE-194_STANDARDS_COMPLIANCE_CHECKLIST.md`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -20,13 +20,28 @@ Detailed domain runbooks remain authoritative for their domains:
 
 ## Verification
 
+### Full local ship gate
+
+`make verify` is the canonical local merge-readiness command for the real
+application runtime and the standards system. It runs DESIGN.md gates,
+standards policy validators, `npm run lint`, `npm run typecheck`, `npm run
+test:unit`, `npm run test:browser`, `npm run build`, `npm run
+standards:check`, Python standards tests, artifact provenance, and test-policy
+validation.
+
+```bash
+make verify
+```
+
+Use this before protected-path, runtime, broad product, deployment, or release
+work. The pre-push hook also runs `make verify`.
+
 ### Fast local checks
 
 Run these before small documentation or governance changes:
 
 ```bash
-npm run lint
-npm run typecheck
+make standards-policy-gates
 npm run standards:check
 ```
 
@@ -49,7 +64,7 @@ npm run build
 ```
 
 Run the complete Node/browser suite before merging broad product or platform
-changes:
+changes, or run `make verify` when you also need standards and design evidence:
 
 ```bash
 npm test
@@ -57,12 +72,13 @@ npm test
 
 ### Standards and DESIGN.md checks
 
-`make verify` is the local source of truth for standards governance and
-DESIGN.md enforcement. GitHub Actions can repeat these checks, but local
-evidence should still be captured for protected-path work.
+`make standards-policy-gates` is the standards-only policy slice. `npm run
+standards:check` is the Node standards, maintainability, and coverage-policy
+slice. `make verify` runs both of those plus the application runtime gates.
 
 ```bash
-make verify
+make standards-policy-gates
+npm run standards:check
 ```
 
 For UI token work, run:
@@ -75,6 +91,16 @@ npm run design:audit:check
 npm run design:change-guard
 make verify
 ```
+
+### CI mapping
+
+| Local command | GitHub Actions job or step |
+|---|---|
+| `npm run pr:check`, `npm run change:check`, `npm run ownership:lint` | `Pull request metadata` in `.github/workflows/validation.yml` |
+| `npm run coverage`, `npm run standards:check`, `npm run test:unit` | `Repo validation` in `.github/workflows/validation.yml` |
+| `npm run test:browser` | `Browser validation` in `.github/workflows/validation.yml` |
+| `make verify` | `verify` in `.github/workflows/verify.yml` |
+| `npm run governance:drift:check` | `Governance drift report` in `.github/workflows/governance-drift.yml` |
 
 Read `DESIGN.md` before UI changes, change reusable visual semantics there
 first, and avoid hard-coded visual values in migrated CSS. A rare one-off must

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "auth:registration:production-smoke": "node scripts/verify-registration-production.js",
     "auth:oidc:production-smoke": "node scripts/verify-oidc-production-smoke.js",
     "auth:status:check": "node scripts/verify-production-auth-status.js",
-    "build": "npm run auth:deploy:bootstrap && node scripts/check-auth-config.js --write-artifact && vite build",
+    "build": "npm run auth:deploy:bootstrap && node scripts/check-auth-config.js --target ${AUTH_CONFIG_TARGET:-${VERCEL_ENV:-development}} --write-artifact && vite build",
     "build:browser": "vite build",
     "build:browser:registration": "VITE_AUTH_PRODUCTION_AUTH_STRATEGY=registration VITE_AUTH_INTERNAL_BOOTSTRAP_ENABLED=false VITE_TASK_API_BASE_URL=/backend vite build",
     "preview": "vite preview --host 127.0.0.1 --port 4174 --strictPort",

--- a/repo-contract.yaml
+++ b/repo-contract.yaml
@@ -13,10 +13,16 @@ ownership:
   backup_owner: wiinc1
 runtime:
   languages:
+  - name: javascript
+    version: Node.js 22 runtime
+  - name: typescript
+    version: '5.9'
   - name: python
     version: '3.12'
-  toolchains: [python3, unittest, make, git]
-  package_managers: [pip]
+  - name: sql
+    version: PostgreSQL-compatible migrations
+  toolchains: [node, npm, vite, react, typescript, vitest, playwright, python3, unittest, make, git, docker, postgresql]
+  package_managers: [npm, pip]
 commands:
   lint: make lint
   typecheck: make typecheck
@@ -24,26 +30,105 @@ commands:
   build: make build
   verify: make verify
 directories:
-  reserved_paths: [src/, tests/, docs/, scripts/, config/, generated/, third_party/, .artifacts/]
+  reserved_paths: [src/, api/, lib/, db/, tests/, docs/, scripts/, monitoring/, observability/, config/, generated/, third_party/, .github/, .artifacts/]
   classifications:
     src/: authored
+    api/: authored
+    lib/: authored
+    db/: authored
     tests/: authored
     docs/: authored
+    scripts/: authored
+    monitoring/: authored
+    observability/: artifacts
     dev-standards/: authored
+    .github/: authored
     generated/: generated
     third_party/: third_party
     .artifacts/: artifacts
   protected_paths: [repo-contract.yaml, agent-policy.yaml, check-manifest.yaml, dev-standards/, .github/workflows/, Makefile, DESIGN.md]
 architecture:
-  reference_scan_globs: [src/**/*.py, tests/**/*.py, dev-standards/**/*.py, dev-standards/**/*.md, dev-standards/**/*.yaml, dev-standards/**/*.yml]
-  internal_layout: [src/, tests/, docs/, dev-standards/]
+  reference_scan_globs:
+  - src/**/*.js
+  - src/**/*.jsx
+  - src/**/*.ts
+  - src/**/*.tsx
+  - api/**/*.js
+  - lib/**/*.js
+  - db/migrations/**/*.sql
+  - scripts/**/*.js
+  - scripts/**/*.mjs
+  - tests/**/*.js
+  - tests/**/*.ts
+  - tests/**/*.tsx
+  - tests/**/*.py
+  - monitoring/**/*.json
+  - monitoring/**/*.yml
+  - docs/**/*.md
+  - docs/diagrams/*.mmd
+  - dev-standards/**/*.py
+  - dev-standards/**/*.md
+  - dev-standards/**/*.yaml
+  - dev-standards/**/*.yml
+  - .github/workflows/*.yml
+  - package.json
+  - vite.config.js
+  - playwright.config.ts
+  - vercel.json
+  - Makefile
+  - repo-contract.yaml
+  - check-manifest.yaml
+  internal_layout: [src/app/, src/components/, src/features/, api/, lib/auth/, lib/audit/, lib/http/, lib/task-platform/, lib/software-factory/, db/migrations/, scripts/, monitoring/, tests/, docs/, dev-standards/, .github/workflows/]
   dependency_rules:
   - standards tooling depends on the repo contract, not ad hoc conventions
-  boundary_map: []
+  - browser feature modules depend on route adapters and browser session utilities instead of server-only state
+  - API adapters delegate to shared lib handlers and preserve Vercel rewrite boundaries
+  - auth, audit, task-platform, and software-factory modules own their runtime state transitions
+  - monitoring and observability assets describe runtime behavior but must not contain secrets
+  - workflow and standards gates are declared in Makefile, package.json, check-manifest.yaml, and GitHub Actions
+  boundary_map:
+  - from: src/app/
+    to: src/features/
+    rule: allow
+  - from: src/features/
+    to: src/components/
+    rule: allow
+  - from: api/
+    to: lib/
+    rule: allow
+  - from: scripts/
+    to: lib/
+    rule: allow
+  - from: dev-standards/
+    to: repo-contract.yaml
+    rule: allow
+  - from: .github/workflows/
+    to: Makefile
+    rule: allow
   state_ownership:
   - resource: standards-policy
     owner: dev-standards
-  source_of_truth: [repo-contract.yaml, agent-policy.yaml, check-manifest.yaml, docs/architecture.md, DESIGN.md]
+  - resource: browser-session-config
+    owner: src/app/
+  - resource: browser-feature-routes
+    owner: src/features/
+  - resource: serverless-api-routing
+    owner: api/
+  - resource: auth-state
+    owner: lib/auth/
+  - resource: workflow-audit-events
+    owner: lib/audit/
+  - resource: canonical-task-records
+    owner: lib/task-platform/
+  - resource: specialist-delegation-routing
+    owner: lib/software-factory/
+  - resource: database-migrations
+    owner: db/migrations/
+  - resource: runtime-monitoring-assets
+    owner: monitoring/
+  - resource: generated-runtime-evidence
+    owner: observability/
+  source_of_truth: [repo-contract.yaml, agent-policy.yaml, check-manifest.yaml, package.json, Makefile, .github/workflows/validation.yml, .github/workflows/verify.yml, docs/architecture.md, docs/runbook.md, vercel.json, DESIGN.md]
   python_layers:
   - name: standards_tooling
     paths: [dev-standards/tooling/**/*.py]
@@ -66,14 +151,26 @@ architecture:
   banned_patterns: []
 critical_paths:
 - name: standards-enforcement
-  description: repo-local standards and maintainability enforcement entrypoints
-  stronger_controls: [protected path policy, deterministic make targets]
+  description: repo-local standards, documentation, maintainability, and change-evidence enforcement entrypoints
+  stronger_controls: [protected path policy, deterministic make targets, npm standards checks]
+- name: browser-runtime
+  description: Vite and React browser routes for sign-in, task workspace, detail, role inbox, and task creation flows
+  stronger_controls: [TypeScript checks, Vitest UI tests, Playwright browser tests, Vite build]
+- name: serverless-api-runtime
+  description: Vercel Node API adapters for auth, audit, and task-platform request paths
+  stronger_controls: [Node unit tests, contract tests, security tests, deployment build]
+- name: auth-audit-task-platform-state
+  description: PostgreSQL-backed auth, audit, task-platform, and merge-readiness state transitions
+  stronger_controls: [migration tests, rollout scripts, smoke diagnostics, monitoring alerts]
+- name: deployment-and-observability
+  description: Vercel deployment config, monitoring dashboards, alerts, and redacted runtime evidence
+  stronger_controls: [npm build, auth config diagnostics, monitoring docs, artifact provenance]
 quality_gates:
   risk_taxonomy: [low, medium, high, critical]
   review_modes: [automated-only, human-approve, human-plus-evidence]
   stop_the_line: [broken required verification, secret exposure, protected path violation, expired waiver]
-  test_layers: [unit]
-  documentation_requirements: [standards changes require changelog or runbook updates]
+  test_layers: [unit, ui, browser, contract, integration, e2e, property, performance, security, chaos, standards]
+  documentation_requirements: [standards changes require changelog or runbook updates, runtime changes require architecture or runbook updates, deployment changes require release evidence]
   coverage_policy:
     strategy: risk-based
     global_floor: 0.8
@@ -227,11 +324,11 @@ testing:
     contract_report: .artifacts/contract-test-report.json
   layers:
     unit:
-      paths: [tests/test_*.py]
-      file_patterns: [test_*.py]
+      paths: [tests/test_*.py, tests/unit/**/*.test.js, tests/unit/**/*.test.ts, tests/unit/**/*.test.tsx, src/**/*.test.js, src/**/*.test.ts, src/**/*.test.tsx]
+      file_patterns: [test_*.py, '*.test.js', '*.test.ts', '*.test.tsx']
     contract:
-      paths: [tests/contract/**/*.py]
-      file_patterns: [test_*.py]
+      paths: [tests/contract/**/*.py, tests/contract/**/*.test.js]
+      file_patterns: [test_*.py, '*.test.js']
   hermeticity:
     unit:
       paths: [tests/test_*.py]
@@ -240,10 +337,10 @@ testing:
   coverage:
     global_floor: 0.8
     changed_lines_floor: 0.8
-    governed_paths: [tests/**/*.py]
+    governed_paths: [src/**, api/**, lib/**, scripts/**, tests/**, dev-standards/**]
   regression_requirements:
     change_kinds: [bugfix, security-fix]
-    test_paths: [tests/**/*.py]
+    test_paths: [tests/**/*.py, tests/**/*.js, tests/**/*.ts, tests/**/*.tsx, src/**/*.test.js, src/**/*.test.tsx]
   layer_requirements:
   - when_paths: [repo-contract.yaml, agent-policy.yaml, check-manifest.yaml, dev-standards/**]
     required_layers: [unit]
@@ -265,13 +362,16 @@ compatibility:
   matrix:
   - {os: linux, runtime: local-operator}
   - {os: macos, runtime: local-operator}
+  - {os: linux, runtime: node-22-vite-vercel}
+  - {os: linux, runtime: python-3.12-standards}
+  - {os: linux, runtime: postgres-compatible}
   deprecation_policy:
     minimum_notice_days: 30
 nfrs:
   reliability:
     availability_target: 99.9%
   latency:
-    verify_runtime_seconds_p95: 60
+    verify_runtime_seconds_p95: 900
   throughput:
     concurrent_change_validations_supported: 1
   security:

--- a/tests/unit/governance/runtime-gates-contract.test.js
+++ b/tests/unit/governance/runtime-gates-contract.test.js
@@ -1,0 +1,110 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function assertIncludesAll(text, values) {
+  for (const value of values) {
+    assert.ok(text.includes(value), `missing ${value}`);
+  }
+}
+
+test('repo contract declares the application runtime and owned runtime modules', () => {
+  const contract = read('repo-contract.yaml');
+
+  assertIncludesAll(contract, [
+    'name: javascript',
+    'Node.js 22 runtime',
+    'name: typescript',
+    'version: PostgreSQL-compatible migrations',
+    'toolchains: [node, npm, vite, react, typescript, vitest, playwright',
+    'package_managers: [npm, pip]',
+    'src/features/',
+    'api/',
+    'lib/auth/',
+    'lib/audit/',
+    'lib/task-platform/',
+    'lib/software-factory/',
+    'db/migrations/',
+    'monitoring/',
+    'observability/',
+    'package.json',
+    '.github/workflows/verify.yml',
+  ]);
+});
+
+test('check manifest and Makefile map merge gates to real runtime commands', () => {
+  const manifest = read('check-manifest.yaml');
+  const makefile = read('Makefile');
+
+  assertIncludesAll(manifest, [
+    'command: make lint',
+    'command: make typecheck',
+    'command: make test',
+    'command: make build',
+    'command: make design-local-gates',
+    'command: npm run standards:check',
+    'command: make verify',
+  ]);
+
+  assert.match(makefile, /^lint: standards-policy-gates$/m);
+  assert.match(makefile, /^typecheck: standards-python-typecheck$/m);
+  assert.match(makefile, /^test: standards-python-test$/m);
+  assert.match(makefile, /^build: standards-python-build$/m);
+  assert.match(makefile, /^verify: design-local-gates lint typecheck test build$/m);
+  assertIncludesAll(makefile, [
+    '\tnpm run lint',
+    '\tnpm run typecheck',
+    '\tnpm run test:unit',
+    '\tnpm run test:browser',
+    '\tnpm run build',
+    '\tnpm run standards:check',
+    'validate_artifact_provenance.py',
+    'validate_test_policy.py',
+  ]);
+});
+
+test('local build script remains runnable without production auth secrets', () => {
+  const packageJson = JSON.parse(read('package.json'));
+
+  assertIncludesAll(packageJson.scripts.build, [
+    'npm run auth:deploy:bootstrap',
+    'node scripts/check-auth-config.js',
+    '--target ${AUTH_CONFIG_TARGET:-${VERCEL_ENV:-development}}',
+    '--write-artifact',
+    'vite build',
+  ]);
+});
+
+test('verify workflow installs the runtime dependencies required by make verify', () => {
+  const workflow = read('.github/workflows/verify.yml');
+
+  assertIncludesAll(workflow, [
+    'node-version: 22',
+    'run: npm ci',
+    'run: npx playwright install --with-deps chromium firefox',
+    'make verify',
+  ]);
+});
+
+test('runtime governance docs and diagrams publish the gate mapping', () => {
+  const architecture = read('docs/architecture.md');
+  const runbook = read('docs/runbook.md');
+  const branchProtection = read('.github/BRANCH_PROTECTION.md');
+  const workflow = read('docs/diagrams/workflow-governance-runtime-gates.mmd');
+  const architectureDiagram = read('docs/diagrams/architecture-governance-runtime-gates.mmd');
+
+  assertIncludesAll(architecture, ['Governance Runtime Contract', 'make standards-policy-gates', 'npm run test:browser']);
+  assertIncludesAll(runbook, ['Full local ship gate', 'make verify', 'CI mapping']);
+  assertIncludesAll(branchProtection, ['Repo validation', 'Browser validation', '`verify`', 'npm run standards:check']);
+  assert.match(workflow, /^flowchart\s+TD/m);
+  assert.match(architectureDiagram, /^flowchart\s+LR/m);
+  assertIncludesAll(workflow, ['npm run build', 'Vercel deployment preview']);
+  assertIncludesAll(architectureDiagram, ['Node Vite React TypeScript PostgreSQL Python', 'Branch protection']);
+});


### PR DESCRIPTION
## Summary

- Align repo governance metadata with the React/Vite/Node/PostgreSQL runtime and Python standards tooling.
- Wire Makefile merge gates to real app commands: lint, typecheck, unit/UI tests, Playwright browser tests, build, design gates, and standards checks.
- Update verify CI setup, branch-protection mapping, runbook/architecture docs, diagrams, and focused regression coverage.
- Closes #194

## Linked Task
- Task: https://github.com/wiinc1/engineering-team/issues/194

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/reports/ISSUE-194_STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: architecture and design, coding and code quality, testing and quality assurance, deployment and release, observability and monitoring, team and process
- Standards gaps or exceptions: No gaps or exceptions.
- [ ] UI changes use generated DESIGN.md tokens.
- [x] `npm run design:tokens:check` passed.
- [x] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: `npm run standards:check` passed
- Lint result: `npm run lint` passed
- Tests: `python3 dev-standards/tooling/validate_policy_files.py --repo-root .`, `node --test tests/unit/governance/runtime-gates-contract.test.js`, `npm run typecheck`, `npm run test:unit`, `npm run test:browser`, `npm run build`, `make verify`, and `git diff --check` passed. First `make verify` attempt hit an existing flaky Vitest board-owner timeout; immediate rerun passed.
- Test evidence paths: tests/unit/governance/runtime-gates-contract.test.js
- Docs updated: README, architecture, runbook, branch protection, diagrams, standards checklist
- Doc evidence paths: README.md, docs/architecture.md, docs/runbook.md, .github/BRANCH_PROTECTION.md, docs/diagrams/architecture-governance-runtime-gates.mmd, docs/diagrams/workflow-governance-runtime-gates.mmd, docs/reports/ISSUE-194_STANDARDS_COMPLIANCE_CHECKLIST.md

## Risk and Rollback
- Risk level: high because protected governance, CI, and local verification gates changed.
- Rollback path: revert commit c7f0d4e and restore the prior Makefile, package build command, repo contract, check manifest, verify workflow, docs, diagrams, and governance test.

## Notes

- `make verify` now warns that `repo-contract.yaml` exceeds the maintainability warning threshold, but it remains below the hard-fail threshold and the gate passes.
