### PR TITLE
Enforce autonomous merge readiness

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -31,6 +31,19 @@ Require this job if governance drift is treated as blocking in your environment:
 - `Merge readiness` is emitted by the task-platform merge-readiness GitHub check integration from the structured review source of truth.
 - `Governance drift report` in `.github/workflows/governance-drift.yml` runs `npm run governance:drift:check`.
 
+## Merge Readiness Enforcement Verification
+
+Run this read-only verifier before enabling `MERGE_READINESS_ENFORCEMENT_TARGET=all`:
+
+```bash
+GITHUB_TOKEN=<repo-read-token> npm run task-platform:verify-branch-protection -- wiinc1/engineering-team main
+```
+
+The control plane may only report merge-readiness enforcement as active when the default
+branch requires the exact `Merge readiness` check. If the check is absent from branch
+protection, merge-readiness review creation records `policy_blocked` rather than treating
+the gate as enforced.
+
 ## Maintainer Notes
 - If a workflow job name changes, update this file and any downstream org policy that references the old status name.
 - Do not mark a status as required unless the corresponding workflow runs on pull requests for the protected branch.

--- a/docs/api/task-platform-openapi.yml
+++ b/docs/api/task-platform-openapi.yml
@@ -589,7 +589,7 @@ components:
       enum: [pending, passed, blocked, stale, error]
     MergeReadinessReviewJsonValue:
       nullable: true
-      description: Evolving JSONB payload. Source logs must be linked from this record, not copied inline. Merge-readiness source inventory is evaluated under `merge-readiness-source-inventory.v1`; branch-protection enforcement is evaluated under `merge-readiness-branch-protection.v1` when verification evidence is supplied. Human-facing PR summaries are derived from this structured review under `merge-readiness-pr-summary.v1`; comment text is never the source of truth. Cross-cutting reusable gate checks are exercised under `merge-readiness-gate.v1`.
+      description: Evolving JSONB payload. Source logs must be linked from this record, not copied inline. Merge-readiness source inventory is evaluated under `merge-readiness-source-inventory.v1`; branch-protection enforcement is evaluated under `merge-readiness-branch-protection.v1` when verification evidence is supplied or when `ff_merge_readiness_enforcement` targets the PR. Human-facing PR summaries are derived from this structured review under `merge-readiness-pr-summary.v1`; comment text is never the source of truth. Cross-cutting reusable gate checks, including `finding_deferral_policy`, are exercised under `merge-readiness-gate.v1`.
       oneOf:
         - type: object
           additionalProperties: true
@@ -653,7 +653,7 @@ components:
           description: Structured findings used by check-run evaluation and by the derived PR summary. PR comments may render blocking findings, non-blocking findings with rationale, and deferred blockers with approvals, but must not include full logs. Gate-level finding policy distinguishes blocking versus non-blocking findings and requires ownership plus rationale for non-blocking findings.
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
         classification:
-          description: Includes `branch_protection_policy` when default-branch required status checks are verified. `enforced=true` is valid only when branch protection requires `Merge readiness`; otherwise the policy reports `policy_blocked` or `error`.
+          description: Includes `branch_protection_policy` when default-branch required status checks are verified. `enforced=true` is valid only when branch protection requires `Merge readiness`; otherwise the policy reports `policy_blocked` or `error`. Includes `finding_deferral_policy` when blocking findings or proposed deferrals are present.
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
         owner:
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
@@ -666,7 +666,7 @@ components:
           description: Structured approvals that may be rendered only for deferred blocking findings in the derived PR summary. Blocking-finding deferral validation requires Product Manager risk acceptance, technical-owner risk acceptance, a follow-up link, explicit deferral policy permission, and Principal/SRE approval for high-risk findings.
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
         metadata:
-          description: Includes `github_merge_readiness_gate` metadata with `policy_version=merge-readiness-github-check.v1`, evidence fingerprint, check-run id, and invalidation details when the PR commit SHA or evidence changes. Includes `github_merge_readiness_branch_protection` with `policy_version=merge-readiness-branch-protection.v1`, status, branch, required check name, and `enforced` when branch-protection verification runs. May include a structured review URL for PR summary rendering; merge readiness evaluation still reads this review record, not comment text.
+          description: Includes `github_merge_readiness_gate` metadata with `policy_version=merge-readiness-github-check.v1`, evidence fingerprint, check-run id, and invalidation details when the PR commit SHA or evidence changes. Includes `github_merge_readiness_branch_protection` with `policy_version=merge-readiness-branch-protection.v1`, status, branch, required check name, and `enforced` when branch-protection verification runs. Includes `merge_readiness_enforcement` when `ff_merge_readiness_enforcement` activates enforcement for an autonomous workflow PR or all PRs. May include a Structured MergeReadinessReview URL for PR summary rendering; merge readiness evaluation still reads this review record, not comment text.
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
         reviewerActorId:
           type: string
@@ -873,6 +873,12 @@ components:
           type: object
           description: Default-branch protection evidence from GitHub. Required status checks must include `Merge readiness` before the control plane represents the gate as enforced. Missing or unreadable evidence reports `policy_blocked` or `error`; this field is verification evidence only and does not mutate GitHub settings.
           additionalProperties: true
+        autonomousWorkflowPr:
+          type: boolean
+          description: Marks this review as an autonomous workflow PR. When `ff_merge_readiness_enforcement` is enabled and the target is autonomous PRs, branch-protection verification is required before merge readiness can pass.
+        enforceMergeReadiness:
+          type: boolean
+          description: Explicit per-review enforcement override. When true and the feature flag is enabled, branch-protection verification is required even if the PR is not tagged as autonomous.
         sourceInventory:
           $ref: '#/components/schemas/MergeReadinessReviewJsonValue'
         requiredCheckInventory:

--- a/docs/diagrams/workflow-autonomous-merge-readiness-enforcement.mmd
+++ b/docs/diagrams/workflow-autonomous-merge-readiness-enforcement.mmd
@@ -1,0 +1,20 @@
+flowchart TD
+  PREvent[GitHub PR, check, workflow, status, or deployment event] --> Derive[Derive merge-readiness refresh event]
+  Derive --> Inventory[Enumerate required checks and policy-selected evidence for HEAD SHA]
+  Inventory --> Access{Required evidence accessible?}
+  Access -- No --> Error[Record MergeReadinessReview status error and policy_blocked when config or permission caused access failure]
+  Access -- Yes --> Findings[Classify findings and validate blocking-finding deferrals]
+  Findings --> Deferral{Blocking finding unresolved or invalid deferral?}
+  Deferral -- Yes --> Blocked[Record blocked structured review]
+  Deferral -- No --> Branch[Verify default-branch protection]
+  Branch --> Required{Branch protection requires Merge readiness?}
+  Required -- No --> PolicyBlocked[Record policy_blocked branch-protection exception]
+  Required -- Yes --> Record[Persist current MergeReadinessReview for exact commit SHA and evidence fingerprint]
+  Error --> Check[Emit non-passing Merge readiness check]
+  Blocked --> Check
+  PolicyBlocked --> Check
+  Record --> Check
+  Check --> Summary[Render allowlisted PR summary linking to structured review]
+  Derive --> Changed{New commit or evidence fingerprint changed?}
+  Changed -- Yes --> Stale[Mark prior review stale and emit pending Merge readiness check]
+  Stale --> Inventory

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -32,6 +32,30 @@ Behavior:
   remediation steps for missing checkpoints, version mismatches, stale
   projection sequences, and failed sync status.
 
+## Merge Readiness Enforcement
+
+- `FF_MERGE_READINESS_ENFORCEMENT`
+  Controls the structured merge-readiness enforcement layer for autonomous workflow PRs.
+  Default: enabled when unset.
+
+- `MERGE_READINESS_ENFORCEMENT_TARGET`
+  Controls rollout targeting. Use `autonomous` for autonomous workflow PRs only, or `all`
+  after branch protection is verified for the default branch.
+  Default: `autonomous`.
+
+Behavior:
+
+- Reviews marked `autonomousWorkflowPr: true`, carrying an autonomous workflow label, or
+  carrying autonomous workflow metadata require branch-protection verification before
+  merge readiness can pass.
+- Branch protection must require the exact GitHub check name `Merge readiness`; missing
+  required-check configuration records `policy_blocked`.
+- Proposed deferrals for blocking findings remain blocked unless policy permission,
+  follow-up links, Product Manager risk acceptance, technical-owner risk acceptance, and
+  Principal/SRE approval for high-risk findings are present.
+- The PR summary remains derived output from the structured `MergeReadinessReview`; it
+  is never used as the source of truth.
+
 ## Task Assignment
 
 - `FF_ASSIGN_AI_AGENT_TO_TASK`

--- a/docs/reports/ISSUE-212_STANDARDS_COMPLIANCE_CHECKLIST.md
+++ b/docs/reports/ISSUE-212_STANDARDS_COMPLIANCE_CHECKLIST.md
@@ -1,0 +1,79 @@
+# Standards Compliance Checklist
+
+## Linked Standards
+
+- Standards document: `docs/standards/software-development-standards.md`
+- Required gap statement format: `Gap observed: X. Documented rationale: Y (source Z).`
+
+## Change Metadata
+
+- Change or task ID: GitHub issue #212
+- Owner: Codex implementation agent
+- Date: 2026-05-17
+- Scope summary: Enforce structured merge readiness for autonomous workflow PRs using feature-flag targeting, branch-protection verification, blocking-finding deferral policy, GitHub check projection, PR summary safety, and runbook evidence.
+
+## Standards Alignment
+
+- Applicable standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; observability and monitoring; authentication and secret handling; team and process.
+- Evidence expected for this change: GitHub check-run behavior, branch-protection verification, evidence inventory policy tests, invalidation tests, PR summary tests, deferral policy tests, workflow diagram, runbook, and API documentation.
+- Gap observed: autonomous workflow readiness could still be treated as advisory unless enforcement targeting and deferral policy were applied to persisted reviews. Documented rationale: issue #212 requires a structured gate that blocks stale, inaccessible, incomplete, or policy-unverified evidence before merge (source https://github.com/wiinc1/engineering-team/issues/212).
+
+## Architecture and Design
+
+- Applicable: Yes
+- Evidence in this change: `lib/task-platform/merge-readiness-enforcement.js`, `lib/task-platform/merge-readiness-gate.js`, `lib/task-platform/index.js`, and `docs/diagrams/workflow-autonomous-merge-readiness-enforcement.mmd`.
+- Gap observed: enforcement targeting was not explicit for autonomous workflow PR rollout.
+- Documented rationale and source: feature-flagged rollout lets autonomous PRs enforce first, then all PRs after branch protection is confirmed (source issue #212).
+
+## Coding and Code Quality
+
+- Applicable: Yes
+- Evidence in this change: scoped helper modules and task-platform wrapper integration, with existing source-policy, branch-protection, GitHub-check, and PR-summary components reused.
+- Gap observed: deferral policy was reusable but not applied to persisted review status before check-run emission.
+- Documented rationale and source: merge readiness must remain blocked when blocking finding deferrals lack policy permission or approvals (source issue #212 acceptance criteria).
+
+## Testing and Quality Assurance
+
+- Applicable: Yes
+- Evidence in this change: unit coverage for enforcement targeting and deferral blocking, contract coverage for API shape, security coverage for token/config failure and no log-copy leakage, and e2e workflow coverage for PR synchronize invalidation.
+- Gap observed: None for the newly enforced behavior.
+- Documented rationale and source: automated tests now cover the behavior required by issue #212.
+
+## Deployment and Release
+
+- Applicable: Yes
+- Evidence in this change: `FF_MERGE_READINESS_ENFORCEMENT`, `MERGE_READINESS_ENFORCEMENT_TARGET`, branch-protection verifier guidance, and rollback notes.
+- Gap observed: live branch protection could not be verified from this local environment because no GitHub OAuth token or `GITHUB_TOKEN` is configured.
+- Documented rationale and source: the verifier fails closed with `GITHUB_TOKEN is required`, while automated tests cover enforced and `policy_blocked` branch-protection states; issue #212 requires the control plane to report `policy_blocked` instead of claiming enforcement when branch protection does not require `Merge readiness` (source https://github.com/wiinc1/engineering-team/issues/212).
+
+## Observability and Monitoring
+
+- Applicable: Yes
+- Evidence in this change: persisted metadata includes `merge_readiness_enforcement`, `merge_readiness_finding_policy`, `github_merge_readiness_gate`, and branch-protection policy state for inspection.
+- Gap observed: dashboard metrics remain existing task-platform evidence artifacts in this slice.
+- Documented rationale and source: issue #212 names target counters; this implementation records the structured states those counters aggregate from.
+
+## Authentication and Secret Handling
+
+- Applicable: Yes
+- AuthN/AuthZ surfaces changed: No new public route is added; existing merge-readiness review mutation authorization remains in place.
+- Secret, token, cookie, password, or PII redaction evidence: GitHub clients fail closed when tokens are missing; PR summaries use allowlisted fields and do not paste raw logs or token-like metadata.
+- Abuse-control or rate-limit evidence: Existing authenticated task-platform API controls apply.
+- Rollback or removal impact: Disable `FF_MERGE_READINESS_ENFORCEMENT` or GitHub check-run client configuration without deleting historical reviews.
+- Gap observed: None for this scope.
+- Documented rationale and source: issue #212 requires inaccessible evidence and token/config failures to stay non-passing.
+
+## Team and Process
+
+- Applicable: Yes
+- Evidence in this change: branch protection documentation, runbook, API docs, workflow diagram, and this checklist.
+- Gap observed: None for handoff artifacts.
+- Documented rationale and source: documentation-as-code is required by the repo standards baseline.
+
+## Required Evidence
+
+- Commands run: `node --check lib/task-platform/merge-readiness-enforcement.js` (pass); `node --check lib/task-platform/merge-readiness-gate.js` (pass); `node --check lib/task-platform/index.js` (pass); `node --test tests/unit/task-platform-merge-readiness-gate.test.js tests/unit/task-platform-source-policy.test.js tests/unit/task-platform-github-check.test.js tests/unit/task-platform-branch-protection.test.js tests/unit/task-platform-pr-summary.test.js` (pass, 32 tests); `node --test tests/security/merge-readiness-enforcement.security.test.js tests/e2e/merge-readiness-enforcement.e2e.test.js tests/contract/projects-openapi.contract.test.js` (pass, 5 tests); `node --test tests/unit/task-platform-api.test.js tests/unit/task-platform-merge-readiness-gate.test.js tests/integration/task-platform-pr-summary.integration.test.js` (pass, 18 tests after final wrapper hardening); `npm run test:unit` (pass); `npm run test:integration:api` (pass, 30 tests); `npm run test:contract` (pass, 22 tests); `npm run test:security` (pass, 40 tests); `npm test` (pass, including Playwright 169 passed and 23 skipped); `npm run standards:check` (pass).
+- Live branch-protection verifier: `npm run task-platform:verify-branch-protection -- wiinc1/engineering-team main` was attempted and failed closed because this environment has no GitHub OAuth token or `GITHUB_TOKEN`; no repository settings were mutated.
+- Tests added or updated: `tests/unit/task-platform-merge-readiness-gate.test.js`, `tests/security/merge-readiness-enforcement.security.test.js`, `tests/e2e/merge-readiness-enforcement.e2e.test.js`, `tests/contract/projects-openapi.contract.test.js`.
+- Rollout or rollback notes: See `docs/runbooks/merge-readiness-enforcement.md`, `.github/BRANCH_PROTECTION.md`, and `docs/feature-flags.md`.
+- Docs updated: `docs/api/task-platform-openapi.yml`, `docs/diagrams/workflow-autonomous-merge-readiness-enforcement.mmd`, `docs/runbooks/merge-readiness-enforcement.md`, `.github/BRANCH_PROTECTION.md`, and `docs/feature-flags.md`.

--- a/docs/runbooks/merge-readiness-enforcement.md
+++ b/docs/runbooks/merge-readiness-enforcement.md
@@ -1,0 +1,58 @@
+# Merge Readiness Enforcement Runbook
+
+## Purpose
+
+Use this runbook when enabling or debugging the structured `Merge readiness` gate for autonomous workflow pull requests.
+
+## Preconditions
+
+- `FF_MERGE_READINESS_ENFORCEMENT` is enabled.
+- `MERGE_READINESS_ENFORCEMENT_TARGET=autonomous` until the default branch is verified.
+- GitHub credentials can create or update check runs and read branch protection.
+- Branch protection requires the exact check name `Merge readiness` before expanding to all PRs.
+
+## Evaluation Flow
+
+1. A PR, check, workflow, status, preview, or deployment event triggers merge-readiness refresh.
+2. Required checks and policy-selected evidence are evaluated for the exact PR HEAD SHA.
+3. Missing required evidence records `blocked`; inaccessible required evidence records `error`.
+4. Configuration or permission failures create a `policy_blocked` exception.
+5. Blocking findings remain blocked unless an explicit deferral policy, follow-up link, Product Manager risk acceptance, technical-owner risk acceptance, and Principal/SRE high-risk approval are present.
+6. Branch protection must require `Merge readiness`; otherwise the control plane records `policy_blocked`.
+7. The GitHub check uses the structured review only. PR comments are summaries and cannot make readiness pass.
+
+## Verification
+
+```bash
+npm run task-platform:verify-branch-protection -- wiinc1/engineering-team main
+```
+
+Expected enforced output includes:
+
+```json
+{
+  "status": "enforced",
+  "enforced": true,
+  "requiredCheckName": "Merge readiness"
+}
+```
+
+Expected missing-policy output includes `status: "policy_blocked"` and `owner: "repo-admin"` in exceptions.
+
+## Rollback
+
+1. Set `FF_MERGE_READINESS_ENFORCEMENT=0`.
+2. Keep historical `MergeReadinessReview` records readable.
+3. Stop GitHub check-run emission by removing the check-run client configuration if needed.
+4. Keep branch-protection changes in place unless a repo admin explicitly approves changing required checks.
+
+## Standards Alignment
+
+- Applicable standards areas: deployment and release, testing and quality assurance, observability and monitoring, security and compliance, team and process.
+- Gap observed: autonomous workflow PRs could previously rely on humans interpreting logs and comments before merge. Documented rationale: issue #212 requires an authoritative structured gate for the reviewed commit and evidence fingerprint.
+
+## Required Evidence
+
+- Commands run: `npm run test:unit`, `npm run test:integration:api`, `npm run test:contract`, `npm run test:security`, `npm test`, `npm run standards:check`.
+- Tests added or updated: merge-readiness gate, branch-protection enforcement, security, contract, and workflow tests.
+- Docs updated: this runbook, branch protection guide, feature flag docs, API docs, and Mermaid workflow diagram.

--- a/docs/runbooks/task-platform-rollout.md
+++ b/docs/runbooks/task-platform-rollout.md
@@ -225,6 +225,8 @@ Verify:
 - default-branch protection requires the exact status check `Merge readiness` before `classification.branch_protection_policy.enforced=true` appears on a review
 - missing or unreadable default-branch protection evidence reports `classification.branch_protection_policy.status=policy_blocked` or `error`, with repo-admin ownership for follow-up
 - `npm run task-platform:verify-branch-protection -- <owner/repo> <branch>` exits non-zero until GitHub branch protection requires `Merge readiness`
+- when `FF_MERGE_READINESS_ENFORCEMENT` is enabled for autonomous workflow PRs, reviews carrying autonomous workflow labels, flags, or metadata require branch-protection verification before passing
+- the dedicated [merge readiness enforcement runbook](merge-readiness-enforcement.md) stays current with rollout target, rollback, and required evidence guidance
 - rendered PR summaries include only review status, commit SHA, required sources reviewed, blocking findings, non-blocking findings with rationale, deferred blocking findings with approvals, inaccessible evidence, follow-up links, and the structured `MergeReadinessReview` link
 - PR summary comments never include full logs and never override the structured `MergeReadinessReview` for check-run or ship decisions
 - `tests/unit/task-platform-merge-readiness-gate.test.js` covers the reusable gate across source selectors, status transitions, SHA invalidation, inaccessible evidence, finding classification, deferral approvals, GitHub check-run emission, branch protection, and PR summary rendering
@@ -243,6 +245,7 @@ Verify:
 - investigate any merge-readiness `policy_blocked` exception before retrying ship. Permission or missing-configuration failures are owned by repo admins unless the source is deployment/runtime evidence, which is owned by SRE.
 - confirm `metadata.github_merge_readiness_gate.policy_version=merge-readiness-github-check.v1` and `githubCheckRunId` are present after check-run emission
 - confirm `metadata.github_merge_readiness_branch_protection.policy_version=merge-readiness-branch-protection.v1` and `enforced=true` only after GitHub branch protection requires `Merge readiness`
+- confirm `metadata.merge_readiness_enforcement.flag=ff_merge_readiness_enforcement` only appears on targeted autonomous workflow PRs or after `MERGE_READINESS_ENFORCEMENT_TARGET=all` rollout approval
 - investigate any stale review with `metadata.github_merge_readiness_gate.invalidated_reason` before attempting to ship the PR
 - treat conflicts between a PR comment summary and the stored `MergeReadinessReview` as stale comment content; the structured review remains authoritative
 
@@ -257,7 +260,8 @@ This rollout is additive. The first rollback action is operational containment, 
 6. Disable the GitHub check-run client configuration to stop new `Merge readiness` check-run writes while keeping review storage readable.
 7. Leave branch-protection settings unchanged unless an operator or repo admin explicitly approves a settings change; the verifier is read-only.
 8. Stop posting derived PR summaries if comment rendering is noisy; do not change structured review evaluation to read comment text.
-9. Investigate backfill errors or canonical drift before rerunning backfill.
+9. Disable `FF_MERGE_READINESS_ENFORCEMENT` if autonomous workflow PR enforcement needs immediate containment; keep historical structured reviews readable.
+10. Investigate backfill errors or canonical drift before rerunning backfill.
 
 If assignment behavior is part of the incident, use [task-assignment-emergency.md](/Users/wiinc2/.openclaw/workspace/engineering-team/docs/runbooks/task-assignment-emergency.md).
 

--- a/lib/task-platform/index.js
+++ b/lib/task-platform/index.js
@@ -2,10 +2,13 @@ const { resolveAuditBackend } = require('../audit/config');
 const { createFileTaskPlatformService } = require('./service');
 const { createPostgresTaskPlatformService } = require('./postgres');
 const { withProjects } = require('./projects');
+const { applyMergeReadinessEnforcementInput } = require('./merge-readiness-enforcement');
 const { applyMergeReadinessBranchProtectionPolicy } = require('./merge-readiness-branch-protection');
 const {
+  applyMergeReadinessFindingPolicy,
   classifyMergeReadinessFinding,
   evaluateBlockingFindingDeferral,
+  evaluateMergeReadinessDeferralPolicy,
   evaluateMergeReadinessFindingPolicy,
   evaluateMergeReadinessGate,
 } = require('./merge-readiness-gate');
@@ -45,12 +48,14 @@ function sourcePolicyReview(input = {}) {
   };
 }
 
-function applySourcePolicyToCreateInput(input = {}) {
-  const review = sourcePolicyReview(input);
-  applyMergeReadinessSourcePolicy(review, input);
-  applyMergeReadinessBranchProtectionPolicy(review, input);
+function applySourcePolicyToCreateInput(input = {}, options = {}) {
+  const policyInput = applyMergeReadinessEnforcementInput(input, options);
+  const review = sourcePolicyReview(policyInput);
+  applyMergeReadinessSourcePolicy(review, policyInput);
+  applyMergeReadinessBranchProtectionPolicy(review, policyInput);
+  applyMergeReadinessFindingPolicy(review);
   return {
-    ...input,
+    ...policyInput,
     reviewStatus: review.review_status,
     sourceInventory: review.source_inventory,
     requiredCheckInventory: review.required_check_inventory,
@@ -61,14 +66,45 @@ function applySourcePolicyToCreateInput(input = {}) {
   };
 }
 
-function withMergeReadinessSourcePolicy(service) {
+function applyFindingPolicyToRecord(service, review) {
+  if (!review || typeof review !== 'object') return review;
+  const policyReview = sourcePolicyReview(review);
+  applyMergeReadinessFindingPolicy(policyReview);
+  if (policyReview.review_status === review.reviewStatus
+    && JSON.stringify(policyReview.classification) === JSON.stringify(review.classification)
+    && JSON.stringify(policyReview.metadata) === JSON.stringify(review.metadata)) {
+    return review;
+  }
+  return service.updateMergeReadinessReview({
+    tenantId: review.tenantId,
+    taskId: review.taskId,
+    reviewId: review.reviewId,
+    recordVersion: review.recordVersion,
+    reviewStatus: policyReview.review_status,
+    classification: policyReview.classification,
+    metadata: policyReview.metadata,
+    findings: policyReview.findings,
+  });
+}
+
+function withMergeReadinessSourcePolicy(service, options = {}) {
   if (!service || typeof service.createMergeReadinessReview !== 'function') return service;
-  return {
+  const wrapped = {
     ...service,
     createMergeReadinessReview(input = {}) {
-      return service.createMergeReadinessReview(applySourcePolicyToCreateInput(input));
+      return service.createMergeReadinessReview(applySourcePolicyToCreateInput(input, options));
     },
   };
+  if (typeof service.updateMergeReadinessReview === 'function') {
+    wrapped.updateMergeReadinessReview = function updateMergeReadinessReview(input = {}) {
+      const review = service.updateMergeReadinessReview(input);
+      if (review && typeof review.then === 'function') {
+        return review.then(record => applyFindingPolicyToRecord(service, record));
+      }
+      return applyFindingPolicyToRecord(service, review);
+    };
+  }
+  return wrapped;
 }
 
 function resolveCheckRunClient(options = {}) {
@@ -138,7 +174,7 @@ function withMergeReadinessGitHubChecks(service, options = {}) {
 
 function createTaskPlatformService(options = {}) {
   const backend = options.taskPlatformBackend || resolveAuditBackend(options);
-  const wrap = service => withProjects(withMergeReadinessGitHubChecks(withMergeReadinessSourcePolicy(service), options), options);
+  const wrap = service => withProjects(withMergeReadinessGitHubChecks(withMergeReadinessSourcePolicy(service, options), options), options);
   if (backend === 'postgres') {
     return wrap(createPostgresTaskPlatformService(options));
   }
@@ -147,9 +183,11 @@ function createTaskPlatformService(options = {}) {
 
 module.exports = {
   applySourcePolicyToCreateInput,
+  applyMergeReadinessFindingPolicy,
   classifyMergeReadinessFinding,
   createTaskPlatformService,
   evaluateBlockingFindingDeferral,
+  evaluateMergeReadinessDeferralPolicy,
   evaluateMergeReadinessFindingPolicy,
   evaluateMergeReadinessGate,
   evaluateMergeReadinessSummaryPrecedence,

--- a/lib/task-platform/merge-readiness-enforcement.js
+++ b/lib/task-platform/merge-readiness-enforcement.js
@@ -1,0 +1,109 @@
+const MERGE_READINESS_ENFORCEMENT_FLAG = 'ff_merge_readiness_enforcement';
+const DEFAULT_ENFORCEMENT_TARGET = 'autonomous';
+const DISABLED_VALUES = new Set(['0', 'false', 'off', 'disabled', 'no']);
+
+function readAny(input, ...keys) {
+  for (const key of keys) {
+    if (Object.prototype.hasOwnProperty.call(input || {}, key)) return input[key];
+  }
+  return undefined;
+}
+
+function toArray(value) {
+  if (value == null) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === 'string') return value.split(',').map(item => item.trim()).filter(Boolean);
+  return [value];
+}
+
+function normalized(value) {
+  return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+}
+
+function cloneObject(value, fallback = {}) {
+  if (value === undefined) return fallback;
+  if (value === null) return null;
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isMergeReadinessEnforcementEnabled(options = {}) {
+  if (typeof options.mergeReadinessEnforcementEnabled === 'boolean') {
+    return options.mergeReadinessEnforcementEnabled;
+  }
+  const configured = options.ffMergeReadinessEnforcement
+    ?? options.ff_merge_readiness_enforcement
+    ?? process.env.FF_MERGE_READINESS_ENFORCEMENT;
+  return configured == null || configured === ''
+    ? true
+    : !DISABLED_VALUES.has(String(configured).trim().toLowerCase());
+}
+
+function mergeReadinessEnforcementTarget(options = {}) {
+  return normalized(
+    options.mergeReadinessEnforcementTarget
+      ?? options.merge_readiness_enforcement_target
+      ?? process.env.MERGE_READINESS_ENFORCEMENT_TARGET
+      ?? DEFAULT_ENFORCEMENT_TARGET
+  );
+}
+
+function truthy(value) {
+  if (typeof value === 'boolean') return value;
+  return ['1', 'true', 'on', 'enabled', 'yes'].includes(String(value || '').trim().toLowerCase());
+}
+
+function labelNames(input = {}) {
+  return toArray(readAny(input, 'labels', 'labelNames', 'label_names')).map(label => {
+    if (label && typeof label === 'object') return readAny(label, 'name', 'label') || '';
+    return label;
+  }).map(normalized);
+}
+
+function isAutonomousWorkflowPullRequest(input = {}) {
+  const metadata = readAny(input, 'metadata') || {};
+  const explicit = [
+    readAny(input, 'autonomousWorkflowPr', 'autonomousWorkflowPR', 'autonomous_workflow_pr'),
+    readAny(input, 'autonomousWorkflow', 'autonomous_workflow'),
+    readAny(metadata, 'autonomousWorkflowPr', 'autonomousWorkflowPR', 'autonomous_workflow_pr'),
+    readAny(metadata, 'autonomousWorkflow', 'autonomous_workflow'),
+  ];
+  if (explicit.some(truthy)) return true;
+  const workflow = normalized(
+    readAny(input, 'workflow', 'workflowType', 'workflow_type')
+      ?? readAny(metadata, 'workflow', 'workflowType', 'workflow_type')
+  );
+  return workflow.includes('autonomous') || labelNames(input).some(label => label.includes('autonomous'));
+}
+
+function shouldEnforceMergeReadiness(input = {}, options = {}) {
+  if (!isMergeReadinessEnforcementEnabled(options)) return false;
+  if (truthy(readAny(input, 'enforceMergeReadiness', 'enforce_merge_readiness'))) return true;
+  const target = mergeReadinessEnforcementTarget(options);
+  if (target === 'all' || target === 'all_prs') return true;
+  return isAutonomousWorkflowPullRequest(input);
+}
+
+function applyMergeReadinessEnforcementInput(input = {}, options = {}) {
+  if (!shouldEnforceMergeReadiness(input, options)) return input;
+  const metadata = cloneObject(readAny(input, 'metadata'), {});
+  metadata.merge_readiness_enforcement = {
+    flag: MERGE_READINESS_ENFORCEMENT_FLAG,
+    enabled: true,
+    target: mergeReadinessEnforcementTarget(options),
+    scope: isAutonomousWorkflowPullRequest(input) ? 'autonomous_workflow_pr' : 'all_prs',
+  };
+  return {
+    ...input,
+    verifyBranchProtection: readAny(input, 'verifyBranchProtection', 'verify_branch_protection') ?? true,
+    metadata,
+  };
+}
+
+module.exports = {
+  MERGE_READINESS_ENFORCEMENT_FLAG,
+  applyMergeReadinessEnforcementInput,
+  isAutonomousWorkflowPullRequest,
+  isMergeReadinessEnforcementEnabled,
+  mergeReadinessEnforcementTarget,
+  shouldEnforceMergeReadiness,
+};

--- a/lib/task-platform/merge-readiness-gate.js
+++ b/lib/task-platform/merge-readiness-gate.js
@@ -49,6 +49,10 @@ function findingRationale(finding = {}) {
   return text(readAny(finding, 'rationale', 'reason', 'reasonCode', 'reason_code'));
 }
 
+function findingStatus(finding = {}) {
+  return normalizedRole(readAny(finding, 'status', 'state', 'resolution'));
+}
+
 function isBlockingMergeReadinessFinding(finding = {}) {
   return readAny(finding, 'blocking') === true || BLOCKING_SEVERITIES.has(findingSeverity(finding));
 }
@@ -153,6 +157,73 @@ function evaluateBlockingFindingDeferral(finding = {}, review = {}) {
   };
 }
 
+function deferralProposed(finding = {}) {
+  return readAny(finding, 'deferred', 'deferralRequested', 'deferral_requested') === true
+    || ['deferred', 'approved_deferred', 'waived', 'risk_accepted'].includes(findingStatus(finding))
+    || readAny(finding, 'deferralAllowed', 'deferral_allowed', 'deferralPolicy', 'deferral_policy') != null;
+}
+
+function compactFinding(finding = {}) {
+  return {
+    id: findingId(finding),
+    severity: findingSeverity(finding),
+    owner: findingOwner(finding) || null,
+    summary: text(readAny(finding, 'summary', 'title', 'reason', 'reasonCode', 'reason_code')) || null,
+  };
+}
+
+function evaluateMergeReadinessDeferralPolicy(review = {}) {
+  const findings = toArray(readAny(review, 'findings')).filter(finding => finding && typeof finding === 'object');
+  const blockingFindings = findings.filter(isBlockingMergeReadinessFinding);
+  const deferralResults = blockingFindings
+    .filter(deferralProposed)
+    .map(finding => evaluateBlockingFindingDeferral(finding, review));
+  const invalidDeferralIds = new Set(deferralResults.filter(result => !result.valid).map(result => result.findingId));
+  const unresolvedBlockingFindings = blockingFindings.filter(finding => deferralProposed(finding)
+    && invalidDeferralIds.has(findingId(finding)));
+  return {
+    policyVersion: MERGE_READINESS_GATE_VERSION,
+    active: deferralResults.length > 0,
+    status: unresolvedBlockingFindings.length ? 'blocked' : 'satisfied',
+    blockingFindings: blockingFindings.map(compactFinding),
+    unresolvedBlockingFindings: unresolvedBlockingFindings.map(compactFinding),
+    deferrals: deferralResults,
+    invalidDeferrals: deferralResults.filter(result => !result.valid),
+  };
+}
+
+function mergeObject(base, additions) {
+  return base && typeof base === 'object' && !Array.isArray(base) ? { ...base, ...additions } : additions;
+}
+
+function applyMergeReadinessFindingPolicy(review = {}) {
+  const policy = evaluateMergeReadinessDeferralPolicy(review);
+  if (!policy.active) return review;
+  review.classification = mergeObject(review.classification, {
+    finding_deferral_policy: {
+      version: policy.policyVersion,
+      status: policy.status,
+      unresolved_blocking_finding_ids: policy.unresolvedBlockingFindings.map(finding => finding.id).filter(Boolean),
+      invalid_deferrals: policy.invalidDeferrals.map(result => ({
+        finding_id: result.findingId,
+        missing_requirements: result.missingRequirements,
+      })),
+    },
+  });
+  review.metadata = mergeObject(review.metadata, {
+    merge_readiness_finding_policy: {
+      policy_version: policy.policyVersion,
+      status: policy.status,
+      blocking_finding_count: policy.blockingFindings.length,
+      invalid_deferral_count: policy.invalidDeferrals.length,
+    },
+  });
+  if (policy.status === 'blocked' && readAny(review, 'review_status', 'reviewStatus') !== 'error') {
+    review.review_status = 'blocked';
+  }
+  return review;
+}
+
 function evaluateMergeReadinessGate(review = {}, context = {}) {
   return {
     policyVersion: MERGE_READINESS_GATE_VERSION,
@@ -167,8 +238,10 @@ function evaluateMergeReadinessGate(review = {}, context = {}) {
 
 module.exports = {
   MERGE_READINESS_GATE_VERSION,
+  applyMergeReadinessFindingPolicy,
   classifyMergeReadinessFinding,
   evaluateBlockingFindingDeferral,
+  evaluateMergeReadinessDeferralPolicy,
   evaluateMergeReadinessFindingPolicy,
   evaluateMergeReadinessGate,
   isBlockingMergeReadinessFinding,

--- a/tests/contract/projects-openapi.contract.test.js
+++ b/tests/contract/projects-openapi.contract.test.js
@@ -35,3 +35,22 @@ test('task platform OpenAPI documents Projects planning containers', () => {
     assert.match(migration, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
 });
+
+test('task platform OpenAPI documents merge-readiness enforcement contract shape', () => {
+  const root = path.join(__dirname, '../..');
+  const openapi = fs.readFileSync(path.join(root, 'docs/api/task-platform-openapi.yml'), 'utf8');
+
+  for (const expected of [
+    'ff_merge_readiness_enforcement',
+    'autonomousWorkflowPr',
+    'enforceMergeReadiness',
+    'branchProtection',
+    'policy_blocked',
+    'github_merge_readiness_gate',
+    'merge_readiness_enforcement',
+    'finding_deferral_policy',
+    'Structured MergeReadinessReview',
+  ]) {
+    assert.match(openapi, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});

--- a/tests/e2e/merge-readiness-enforcement.e2e.test.js
+++ b/tests/e2e/merge-readiness-enforcement.e2e.test.js
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { createTaskPlatformService } = require('../../lib/task-platform');
+const { refreshMergeReadinessForEvent } = require('../../lib/task-platform/merge-readiness-github-check');
+
+function fakeCheckRunClient() {
+  const calls = [];
+  return {
+    calls,
+    async createCheckRun(call) {
+      calls.push(call);
+      return { id: 21200 + calls.length };
+    },
+  };
+}
+
+test('e2e: autonomous merge-readiness refresh invalidates stale review and keeps check pending', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-readiness-enforcement-e2e-'));
+  const github = fakeCheckRunClient();
+  const service = createTaskPlatformService({
+    baseDir,
+    mergeReadinessCheckRunClient: github,
+    mergeReadinessEnforcementEnabled: true,
+  });
+  const task = service.createTask({
+    tenantId: 'engineering-team',
+    actorId: 'pm-1',
+    title: 'Autonomous merge readiness e2e',
+    status: 'READY_FOR_REVIEW',
+  });
+
+  await service.createMergeReadinessReview({
+    tenantId: 'engineering-team',
+    taskId: task.taskId,
+    repository: 'wiinc1/engineering-team',
+    pullRequestNumber: 212,
+    commitSha: 'abc2120',
+    reviewStatus: 'passed',
+    autonomousWorkflowPr: true,
+    branchProtection: { required_status_checks: { checks: [{ context: 'Merge readiness' }] } },
+  });
+
+  await refreshMergeReadinessForEvent({
+    taskPlatform: service,
+    github,
+    taskRefs: [{ tenantId: 'engineering-team', taskId: task.taskId }],
+    eventName: 'pull_request',
+    payload: {
+      action: 'synchronize',
+      repository: { full_name: 'wiinc1/engineering-team' },
+      pull_request: { number: 212, head: { sha: 'def2120' } },
+    },
+  });
+
+  const [review] = service.listMergeReadinessReviews({
+    tenantId: 'engineering-team',
+    taskId: task.taskId,
+    repository: 'wiinc1/engineering-team',
+    pullRequestNumber: 212,
+  });
+  assert.equal(review.reviewStatus, 'stale');
+  assert.equal(github.calls.at(-1).payload.head_sha, 'def2120');
+  assert.equal(github.calls.at(-1).payload.status, 'in_progress');
+  assert.equal(github.calls.at(-1).payload.conclusion, undefined);
+});

--- a/tests/security/merge-readiness-enforcement.security.test.js
+++ b/tests/security/merge-readiness-enforcement.security.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  createGitHubCheckRunClient,
+} = require('../../lib/task-platform/merge-readiness-github-check');
+const {
+  createGitHubBranchProtectionClient,
+} = require('../../lib/task-platform/merge-readiness-branch-protection');
+const {
+  renderMergeReadinessPrSummary,
+} = require('../../lib/task-platform/merge-readiness-pr-summary');
+
+test('merge-readiness GitHub clients fail closed when tokens are missing', () => {
+  const token = process.env.GITHUB_TOKEN;
+  delete process.env.GITHUB_TOKEN;
+  try {
+    assert.throws(() => createGitHubCheckRunClient({ fetch: async () => ({ ok: true }) }), /GITHUB_TOKEN is required/);
+    assert.throws(() => createGitHubBranchProtectionClient({ fetch: async () => ({ ok: true }) }), /GITHUB_TOKEN is required/);
+  } finally {
+    if (token === undefined) delete process.env.GITHUB_TOKEN;
+    else process.env.GITHUB_TOKEN = token;
+  }
+});
+
+test('merge-readiness PR summaries do not leak raw logs or token-like evidence fields', () => {
+  const summary = renderMergeReadinessPrSummary({
+    reviewId: 'MRR-SEC-212',
+    reviewStatus: 'blocked',
+    commitSha: 'abc2120',
+    reviewedLogSources: [{
+      name: 'Repo validation',
+      url: 'https://github.example/checks/212',
+      rawLog: 'ghp_exampleSecretTokenValue1234567890',
+    }],
+    findings: [{ id: 'MRR-BLOCK', severity: 'blocker', summary: 'Evidence is inaccessible.' }],
+    metadata: { token: 'ghp_exampleSecretTokenValue1234567890' },
+  });
+
+  assert.match(summary, /Structured MergeReadinessReview/);
+  assert.doesNotMatch(summary, /ghp_exampleSecretTokenValue/);
+  assert.doesNotMatch(summary, /rawLog/);
+  assert.doesNotMatch(summary, /token/);
+});

--- a/tests/unit/task-platform-merge-readiness-gate.test.js
+++ b/tests/unit/task-platform-merge-readiness-gate.test.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { createFileTaskPlatformService } = require('../../lib/task-platform/service');
+const { createTaskPlatformService } = require('../../lib/task-platform');
+const {
+  shouldEnforceMergeReadiness,
+} = require('../../lib/task-platform/merge-readiness-enforcement');
 const {
   evaluateMergeReadinessBranchProtection,
 } = require('../../lib/task-platform/merge-readiness-branch-protection');
@@ -163,6 +167,70 @@ test('blocking-finding deferral requires risk acceptance, follow-up, permission,
     'technical_owner_risk_acceptance',
     'principal_or_sre_high_risk_approval',
   ]);
+});
+
+test('persisted reviews remain blocked when blocking-finding deferral lacks policy approvals', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-readiness-deferral-policy-'));
+  const calls = [];
+  const service = createTaskPlatformService({
+    baseDir,
+    mergeReadinessCheckRunClient: {
+      async createCheckRun(call) {
+        calls.push(call);
+        return { id: 21201 };
+      },
+    },
+  });
+  const task = service.createTask({ tenantId: 'engineering-team', actorId: 'pm-1', title: 'Deferral policy', status: 'READY_FOR_REVIEW' });
+
+  const review = await service.createMergeReadinessReview({
+    tenantId: 'engineering-team',
+    taskId: task.taskId,
+    repository: 'wiinc1/engineering-team',
+    pullRequestNumber: 212,
+    commitSha: 'abc2120',
+    reviewStatus: 'passed',
+    findings: [validDeferredFinding({ deferralAllowed: false, followUpLinks: [], approvals: [] })],
+  });
+
+  assert.equal(review.reviewStatus, 'blocked');
+  assert.equal(review.classification.finding_deferral_policy.status, 'blocked');
+  assert.deepEqual(review.classification.finding_deferral_policy.invalid_deferrals[0].missing_requirements, [
+    'policy_permission',
+    'follow_up_link',
+    'pm_risk_acceptance',
+    'technical_owner_risk_acceptance',
+    'principal_or_sre_high_risk_approval',
+  ]);
+  assert.equal(calls[0].payload.conclusion, 'failure');
+});
+
+test('ff_merge_readiness_enforcement targets autonomous workflow PRs for branch-protection gating', () => {
+  assert.equal(shouldEnforceMergeReadiness({ autonomousWorkflowPr: true }, { mergeReadinessEnforcementEnabled: true }), true);
+  assert.equal(shouldEnforceMergeReadiness({ autonomousWorkflowPr: true }, { mergeReadinessEnforcementEnabled: false }), false);
+  assert.equal(shouldEnforceMergeReadiness({ labels: ['documentation'] }, { mergeReadinessEnforcementEnabled: true }), false);
+});
+
+test('autonomous enforcement reports policy_blocked until branch protection requires Merge readiness', () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'merge-readiness-enforcement-'));
+  const service = createTaskPlatformService({ baseDir, mergeReadinessEnforcementEnabled: true });
+  const task = service.createTask({ tenantId: 'engineering-team', actorId: 'pm-1', title: 'Autonomous enforcement', status: 'READY_FOR_REVIEW' });
+
+  const review = service.createMergeReadinessReview({
+    tenantId: 'engineering-team',
+    taskId: task.taskId,
+    repository: 'wiinc1/engineering-team',
+    pullRequestNumber: 212,
+    commitSha: 'abc2121',
+    reviewStatus: 'passed',
+    autonomousWorkflowPr: true,
+    branchProtection: { required_status_checks: { contexts: ['Repo validation'] } },
+  });
+
+  assert.equal(review.reviewStatus, 'blocked');
+  assert.equal(review.classification.branch_protection_policy.status, 'policy_blocked');
+  assert.equal(review.metadata.merge_readiness_enforcement.flag, 'ff_merge_readiness_enforcement');
+  assert.equal(review.metadata.merge_readiness_enforcement.scope, 'autonomous_workflow_pr');
 });
 
 test('GitHub Merge readiness check-run emission covers pass, fail, and incomplete states', () => {


### PR DESCRIPTION
Closes #212.

Summary:
- Add feature-flagged autonomous merge-readiness enforcement targeting branch-protection verification.
- Enforce blocking-finding deferral policy in persisted reviews.
- Add docs, runbook, workflow diagram, standards checklist, and regression coverage.

Verification:
- npm test
- npm run standards:check
- npm run change:check
- pre-push verification including lint, typecheck, Python tests, unit/UI/browser tests, build, and standards:check

- Task: GitHub issue #212
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/reports/ISSUE-212_STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; observability and monitoring; authentication and secret handling; team and process
- Standards gaps or exceptions: Live branch-protection verifier could not run without a GitHub token; documented in the checklist.
- Standards check result: pass - npm run standards:check
- Lint result: pass - pre-push lint and typecheck passed
- Tests: pass - npm test and pre-push verification passed
- Test evidence paths: tests/unit/task-platform-merge-readiness-gate.test.js, tests/e2e/merge-readiness-enforcement.e2e.test.js, tests/security/merge-readiness-enforcement.security.test.js, tests/contract/projects-openapi.contract.test.js
- Docs updated: yes
- Doc evidence paths: docs/reports/ISSUE-212_STANDARDS_COMPLIANCE_CHECKLIST.md, docs/runbooks/merge-readiness-enforcement.md, docs/runbooks/task-platform-rollout.md, docs/diagrams/workflow-autonomous-merge-readiness-enforcement.mmd, docs/api/task-platform-openapi.yml, docs/feature-flags.md, .github/BRANCH_PROTECTION.md
- Risk level: high
- Rollback path: disable FF_MERGE_READINESS_ENFORCEMENT or revert PR #221