### PR TITLE
[docs] Document Clawpatch usage for autonomous workflow

### DIFF
--- a/docs/diagrams/workflow-clawpatch-autonomous-operator-runbook.mmd
+++ b/docs/diagrams/workflow-clawpatch-autonomous-operator-runbook.mmd
@@ -1,0 +1,27 @@
+flowchart TD
+  Start[Task, issue, and Project context] --> Contract{Approved scope and validation commands?}
+  Contract -- No --> PMQuestion[Resolve PM blocking question before patching]
+  Contract -- Yes --> Decision{Clawpatch decision}
+  Decision -- Not used --> Fallback[Use Codex and OpenClaw fallback workflow]
+  Decision -- Out of scope --> Fallback
+  Decision -- Required or optional --> Branch[Use approved branch or isolated worktree]
+  Branch --> Clean{Worktree clean for task-owned files?}
+  Clean -- No --> StopDirty[Stop and isolate or get owner decision]
+  Clean -- Yes --> Setup[Install from upstream docs and run clawpatch doctor]
+  Setup --> SetupOk{Smoke check passes?}
+  SetupOk -- No --> EvidenceFail[Record redacted failure evidence]
+  EvidenceFail --> Fallback
+  SetupOk -- Yes --> Review[Run review or map commands in task scope]
+  Review --> Finding{Scoped finding selected?}
+  Finding -- No --> Fallback
+  Finding -- Yes --> Patch[Apply one Clawpatch fix]
+  Patch --> Diff[Manual diff review]
+  Diff --> Safe{Patch safe and in scope?}
+  Safe -- No --> Reject[Reject patch, preserve redacted evidence, recover safely]
+  Reject --> Fallback
+  Safe -- Yes --> Validate[Run standards, lint, tests, build, and Vercel as applicable]
+  Validate --> Checks{All required checks green?}
+  Checks -- No --> Repair[Repair normally or reject Clawpatch patch]
+  Repair --> Fallback
+  Checks -- Yes --> PR[Open PR with Clawpatch decision and evidence]
+  PR --> Closeout[Merge after green checks and record closeout note]

--- a/docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
+++ b/docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
@@ -1,0 +1,72 @@
+# Standards Compliance Checklist
+
+## Linked Standards
+
+- Standards document: `docs/standards/software-development-standards.md`
+- Required gap statement format: `Gap observed: X. Documented rationale: Y (source Z).`
+
+## Change Metadata
+
+- Change or task ID: GitHub issue #214
+- Owner: Codex implementation agent
+- Date: 2026-05-18
+- Scope summary: Document Clawpatch usage boundaries, setup validation, optional/fallback workflow, failure recovery, evidence requirements, and supervised pilot references for autonomous workflow operators.
+
+## Standards Alignment
+
+- Standards baseline reviewed: `docs/standards/software-development-standards.md`
+- Applicable standards areas: documentation; team and process; security and compliance; testing and quality assurance; deployment and release.
+- Evidence expected for this change: Clawpatch operator runbook, decision table, setup/smoke instructions, workflow diagram, failure-mode documentation, pilot runbook reference, external URL validation, and required validation commands.
+- Gap observed: issue #207 contains only the Clawpatch installation link and no repo-specific workflow guidance. Documented rationale: operators need repo-specific boundaries before using a patch tool in an autonomous implementation workflow (source https://github.com/wiinc1/engineering-team/issues/207).
+
+## Architecture and Design
+
+- Applicable: Yes
+- Evidence in this change: `docs/runbooks/clawpatch-autonomous-workflow.md`, `docs/runbooks/supervised-autonomous-pilot.md`, and `docs/diagrams/workflow-clawpatch-autonomous-operator-runbook.mmd`
+- Gap observed: Clawpatch is not a governed control-plane component in this repository. Documented rationale: Issue #214 scopes Clawpatch as optional operator tooling guidance, not runtime architecture or connector implementation (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Coding and Code Quality
+
+- Applicable: No
+- Evidence in this change: No runtime code changed.
+- Gap observed: No Clawpatch automation is added. Documented rationale: Issue #214 instructs not to install or run Clawpatch as part of implementation unless required for documentation validation (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Testing and Quality Assurance
+
+- Applicable: Yes
+- Evidence in this change: Documentation validation commands and external installation URL validation.
+- Gap observed: No executable smoke automation is added. Documented rationale: The issue marks tests as not applicable unless setup smoke automation is added; this PR documents a smoke path without adding runtime tooling (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Deployment and Release
+
+- Applicable: Yes
+- Evidence in this change: Runbook states Clawpatch does not bypass branch protection, PR checks, Vercel, QA, SRE, or closeout.
+- Gap observed: No runtime rollout or feature flag exists. Documented rationale: The change is documentation-only and can be rolled back by reverting the documentation PR (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Observability and Monitoring
+
+- Applicable: Yes
+- Evidence in this change: Runbook requires closeout notes and future task evidence to state whether Clawpatch was used.
+- Gap observed: No automated retrospective signal is added. Documented rationale: Issue #214 lists future optional signal recording but does not require runtime observability changes (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Authentication and Secret Handling
+
+- Applicable: Yes
+- AuthN/AuthZ surfaces changed: None.
+- Secret, token, cookie, password, or PII redaction evidence: Runbook forbids putting secrets, credentials, customer records, production env values, or restricted data into Clawpatch prompts, reports, configs, issues, PR bodies, or logs.
+- Abuse-control or rate-limit evidence: Not applicable to this documentation-only slice.
+- Rollback or removal impact: Revert the runbook, diagram, pilot-runbook reference, and checklist.
+- Gap observed: Clawpatch setup can create local tool state outside this repo's current tracked workflow. Documented rationale: The runbook treats Clawpatch-generated local state as generated tooling state unless a task explicitly requires committing it (source https://clawpatch.ai/#installation).
+
+## Team and Process
+
+- Applicable: Yes
+- Evidence in this change: Operator decision table, fallback path, failure recovery table, evidence checklist, and supervised pilot reference.
+- Gap observed: Operators previously had no repo-specific answer for whether Clawpatch is required, optional, or out of scope. Documented rationale: Issue #214 requires clear guidance before repeated autonomous workflow pilots (source https://github.com/wiinc1/engineering-team/issues/214).
+
+## Required Evidence
+
+- Commands run: `curl -I -L https://clawpatch.ai/#installation`; `npm run standards:check`; `npm run lint`; `npm run change:check`; `git diff --check`; `npm test`; `npm run build`.
+- Tests added or updated: None; documentation-only runbook and diagram.
+- Rollout or rollback notes: No runtime rollout; rollback is a normal git revert of the documentation changes.
+- Docs updated: `docs/runbooks/clawpatch-autonomous-workflow.md`; `docs/runbooks/supervised-autonomous-pilot.md`; `docs/diagrams/workflow-clawpatch-autonomous-operator-runbook.mmd`; this checklist.

--- a/docs/runbooks/clawpatch-autonomous-workflow.md
+++ b/docs/runbooks/clawpatch-autonomous-workflow.md
@@ -1,0 +1,145 @@
+# Clawpatch Autonomous Workflow Runbook
+
+Use this runbook when a Software Factory operator asks how Clawpatch fits into an autonomous implementation loop. Clawpatch is an optional patch-review and repair aid; it does not replace Codex, OpenClaw, GitHub PRs, task approvals, branch protection, tests, Vercel checks, QA, SRE, or operator closeout.
+
+Related operator question: GitHub issue #207. Installation source: https://clawpatch.ai/#installation.
+
+## Decision Summary
+
+For the first supervised autonomous pilot, Clawpatch is optional, not required. The default fallback remains the normal Codex/OpenClaw workflow: task and Project context, approved Execution Contract, branch, implementation, local validation, PR, required checks, Vercel status, merge, QA/SRE closeout, and retrospective evidence.
+
+| Situation | Decision | Operator action |
+| --- | --- | --- |
+| Issue, Execution Contract, or operator explicitly requires Clawpatch | Required for that task | Validate setup, run only in the task branch/worktree, record commands and evidence, and block merge if validation fails. |
+| Low-risk docs, tests, fixtures, or clear refactor where operator wants patch assistance | Optional | Use Clawpatch after branch setup and before final validation; keep Codex/OpenClaw as fallback. |
+| First supervised autonomous pilot with no explicit Clawpatch requirement | Optional, not required | Proceed without Clawpatch unless the operator chooses to trial it and records that decision. |
+| Auth, secrets, credentials, production data, schema migration, deployment, or compliance-sensitive change | Out of scope unless explicitly approved | Do not provide secrets to Clawpatch; use normal workflow and security review. |
+| Dirty worktree with unrelated user changes | Out of scope until isolated | Stop and move to a clean branch/worktree or get owner approval before applying any patch. |
+| Clawpatch unavailable, setup fails, or smoke validation fails | Not required | Preserve setup evidence and fall back to Codex/OpenClaw. |
+
+## Prerequisites
+
+- A task or issue ID, Project ID when applicable, and approved Execution Contract or documented operator scope.
+- A short-lived branch or isolated worktree named for the task.
+- A clean `git status -sb` for the files Clawpatch may touch.
+- GitHub permissions to push a branch and open a PR.
+- Local test commands identified before patching.
+- Operator acceptance that Clawpatch output is advisory until reviewed, tested, and merged through the normal PR workflow.
+
+## Installation And Setup
+
+Use the upstream installation page as the source of truth: https://clawpatch.ai/#installation. As of 2026-05-18, the checked page documents global npm and pnpm installation, source installation from `https://github.com/openclaw/clawpatch`, and `clawpatch doctor` as the setup check.
+
+Allowed setup patterns:
+
+```bash
+npm install -g clawpatch
+pnpm add -g clawpatch
+```
+
+Source installation is also documented upstream, but prefer package-manager installation unless the operator explicitly needs a local Clawpatch development build.
+
+Setup validation:
+
+```bash
+clawpatch doctor
+git status -sb
+```
+
+The smoke check is successful only when `clawpatch doctor` exits successfully and `git status -sb` shows no unexpected repo changes. If Clawpatch creates local state such as `.clawpatch/`, treat it as generated local tooling state unless the task explicitly requires committing a Clawpatch configuration or report.
+
+## Secret Handling
+
+- Do not paste tokens, API keys, cookies, passwords, private keys, customer records, production env values, or credentials into Clawpatch prompts, configuration, generated reports, issue comments, PR bodies, or logs.
+- Do not ask Clawpatch to inspect unredacted `.env` files, production credentials, private incident records, or restricted customer data.
+- If a patch or report contains a secret-like value, stop the workflow, preserve a redacted summary, notify the security/operator owner, and rotate the credential when required.
+- Clawpatch does not bypass repo authentication, GitHub permissions, branch protection, PR metadata checks, Vercel checks, task approvals, or closeout gates.
+
+## Operator Workflow
+
+1. Open the task, issue, and Project. Record the task ID, Project ID, branch name, and whether Clawpatch is `required`, `optional`, or `not used`.
+2. Confirm the approved scope and local validation commands. If scope is unclear, create or resolve the PM blocking question before using Clawpatch.
+3. Create or switch to the task branch/worktree. Confirm unrelated local changes are absent.
+4. Validate setup with `clawpatch doctor`.
+5. Start in review mode. Use Clawpatch to inspect only the task-relevant surface before applying a fix.
+6. Select one finding or repair target at a time. The selected target must map to the approved task scope.
+7. Apply the patch only after confirming the target, files, and expected validation command.
+8. Review the diff manually. Reject patches that touch unrelated files, generated artifacts, secrets, auth boundaries, deployment configuration, or unapproved runtime behavior.
+9. Run the task validation matrix. At minimum, run the commands required by the task and the repo standards checks.
+10. Open the PR with normal metadata. Include whether Clawpatch was used, the setup smoke result, commands run, and any fallback or recovery action.
+11. Merge only after required GitHub checks and Vercel are green.
+12. Record closeout evidence in the task history or report, including whether Clawpatch was used and whether any Clawpatch suggestion was rejected.
+
+## Suggested Command Sequence
+
+These commands are examples, not a required automation contract. Follow upstream Clawpatch documentation for exact CLI behavior.
+
+```bash
+git status -sb
+clawpatch doctor
+clawpatch init
+clawpatch map
+clawpatch review --limit 10
+clawpatch report
+clawpatch fix --finding <finding-id>
+clawpatch revalidate --finding <finding-id>
+git status -sb
+git diff --check
+npm run standards:check
+npm run lint
+```
+
+Only run `clawpatch fix` after selecting a scoped finding. If the task adds no executable schema or runtime code, tests may remain documentation validation only; otherwise run the relevant unit, integration, browser, security, or build commands before opening the PR.
+
+## Fallback Path Without Clawpatch
+
+Use the normal agent workflow when Clawpatch is unavailable, optional but skipped, or out of scope:
+
+1. Keep the task in the approved Project and branch.
+2. Implement with Codex and OpenClaw using the approved Execution Contract.
+3. Review `git diff` manually.
+4. Run the required local validation matrix.
+5. Open the PR with standards metadata and evidence.
+6. Wait for GitHub checks and Vercel.
+7. Merge only when checks are green.
+8. Record closeout evidence and note `Clawpatch not used`.
+
+Skipping Clawpatch is not a workflow failure unless the issue or Execution Contract explicitly required it.
+
+## Failure Recovery
+
+| Failure mode | Required recovery |
+| --- | --- |
+| Clawpatch unavailable or installation fails | Stop Clawpatch usage, record the command and redacted error summary, and fall back to Codex/OpenClaw. |
+| `clawpatch doctor` fails | Do not patch. Record the failure and use the fallback path. |
+| Patch conflicts with local changes | Stop. Preserve evidence with a redacted summary. Move to a clean worktree or ask the owner how to handle existing changes. |
+| Patch changes unrelated files | Reject the patch. Do not commit unrelated changes. Re-run from a narrower finding or fall back. |
+| Patch touches secrets, credentials, auth, compliance, production config, or customer data unexpectedly | Stop, notify the operator/security owner, redact evidence, and do not continue under Simple docs/test workflow. |
+| Tests or standards checks fail | Treat the patch as unverified. Fix through the normal workflow or revert the task-scoped patch only after confirming ownership of the changed files. |
+| Patch cannot be explained or mapped to the task | Reject the patch and open a PM blocking question if scope is ambiguous. |
+
+Avoid broad destructive cleanup commands. If a patch must be discarded, preserve the diff or a redacted summary first, confirm the affected files are owned by the current task, and then restore only those task-owned files.
+
+## Evidence Checklist
+
+- Task ID, Project ID, branch/worktree, and PR URL.
+- Decision: `required`, `optional`, `not used`, or `out of scope`.
+- Installation source and setup smoke result.
+- Clawpatch commands run, if any.
+- Findings or repair target IDs, if any.
+- Diff review summary and rejected-patch notes.
+- Test, lint, standards, build, browser, and Vercel evidence as applicable.
+- Failure recovery notes, if any.
+- Closeout note stating whether Clawpatch was used.
+
+## Standards Alignment
+
+- Applicable standards areas: documentation as code, team and process, testing and quality assurance, deployment and release, authentication and secret handling.
+- Evidence expected for changes that use Clawpatch: task/Project linkage, branch and PR evidence, explicit validation commands, redacted setup or failure output, and closeout notes.
+- Gap observed: issue #207 contains only the Clawpatch installation link and no repo-specific operator workflow guidance. Documented rationale: operators need repo-specific boundaries before using a patch tool in an autonomous implementation workflow (source https://github.com/wiinc1/engineering-team/issues/207).
+
+## Required Evidence
+
+- Required local checks for this runbook change: `npm run standards:check`, `npm run lint`, docs validation relevant to changed files, and external installation URL validation.
+- Required future evidence when Clawpatch is used on a task: setup smoke result, patch review summary, validation commands, PR checks, Vercel status when applicable, and closeout note.
+- Rollback: revert the documentation change if this guidance is rejected.

--- a/docs/runbooks/supervised-autonomous-pilot.md
+++ b/docs/runbooks/supervised-autonomous-pilot.md
@@ -9,6 +9,7 @@ Use this runbook for the Issue 209 style pilot: one supervised, low-risk task th
 - OpenClaw delegation runtime access is available, or a visible blocker can be recorded.
 - The task candidate is Simple, docs/test-only, reversible by git revert, and has no auth, schema, deployment, data, or production-risk flags.
 - The pilot Project must contain exactly one pilot task until the report is archived.
+- Clawpatch is optional for the first supervised pilot, not required. If the operator chooses to use it, follow `docs/runbooks/clawpatch-autonomous-workflow.md` and record the decision in closeout evidence.
 
 ## Workflow
 
@@ -19,12 +20,13 @@ Use this runbook for the Issue 209 style pilot: one supervised, low-risk task th
 5. Request policy auto-approval only if the contract is low risk; otherwise record explicit operator approval and the reason.
 6. Dispatch implementation ownership and record the assigned agent.
 7. Run `npm run test:delegation:live-smoke:openclaw` and capture the runtime-owned agent and session ID. If the command falls back or times out, stop the pilot and link a remediation issue.
-8. Implement through a normal branch and PR. Keep the change scoped to the pilot contract.
-9. Validate the PR with the affected test matrix, standards gate, GitHub PR checks, browser validation if UI changed, and Vercel preview/production status.
-10. Merge only after required checks pass.
-11. Record QA pass, SRE monitoring approval, PR sync evidence, and closeout in task history.
-12. Publish the pilot report and classify every manual action as `routine observation`, `required approval`, or `operator intervention`.
-13. Record the operator decision: repeat pilot, remediate, or stop.
+8. Decide whether Clawpatch is used for the implementation loop. If used, treat it as optional patch assistance and keep Codex/OpenClaw, PR checks, Vercel, QA, SRE, and operator closeout authoritative.
+9. Implement through a normal branch and PR. Keep the change scoped to the pilot contract.
+10. Validate the PR with the affected test matrix, standards gate, GitHub PR checks, browser validation if UI changed, and Vercel preview/production status.
+11. Merge only after required checks pass.
+12. Record QA pass, SRE monitoring approval, PR sync evidence, and closeout in task history.
+13. Publish the pilot report and classify every manual action as `routine observation`, `required approval`, or `operator intervention`.
+14. Record the operator decision: repeat pilot, remediate, or stop.
 
 ## Manual Action Classifications
 
@@ -39,6 +41,7 @@ Routine observation and required approval are not counted as autonomy failures. 
 - Project ID and task ID.
 - Contract version, approval mode, policy or explicit approval details.
 - Delegation selected specialist, runtime session ID, and command result.
+- Clawpatch decision: `required`, `optional`, `not used`, or `out of scope`; include setup smoke and patch evidence only if used.
 - Branch, commit SHA, PR URL, PR checks, and Vercel deployment status.
 - Test commands and local/CI/browser results.
 - QA pass, SRE approval, PR sync, and closeout events.


### PR DESCRIPTION
- Task: Closes #214; references #207
- Standards baseline reviewed: yes - docs/standards/software-development-standards.md
- Checklist completed or updated: yes - docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
- Compliance checklist path: docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: documentation; team and process; security and compliance; testing and quality assurance; deployment and release.
- Standards gaps or exceptions: Clawpatch remains optional operator tooling, not a governed runtime component; no Clawpatch automation or executable smoke command was added, and setup guidance uses the upstream installation page plus documented local validation.
- Standards check result: pass - npm run standards:check
- Lint result: pass - npm run lint
- Tests: pass - npm test; pass - npm run build; pass - npm run change:check; pass - git diff --check; pass - curl -I -L https://clawpatch.ai/#installation.
- Test evidence paths: docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
- Docs updated: yes
- Doc evidence paths: docs/runbooks/clawpatch-autonomous-workflow.md, docs/runbooks/supervised-autonomous-pilot.md, docs/diagrams/workflow-clawpatch-autonomous-operator-runbook.mmd, docs/reports/ISSUE-214_STANDARDS_COMPLIANCE_CHECKLIST.md
- Risk level: low - documentation-only runbook and diagram.
- Rollback path: revert this PR to remove the Clawpatch runbook, diagram, pilot-runbook reference, and checklist.
