### PR TITLE
fix: make Projects production smoke self-contained

### DIFF
--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -498,12 +498,13 @@
             "^tests/unit/task-platform-projects\\.test\\.js$",
             "^tests/unit/task-platform-backfill\\.test\\.js$",
             "^tests/unit/task-platform-source-policy\\.test\\.js$",
-            "^tests/unit/task-platform-github-check\\.test\\.js$",
-            "^tests/unit/task-platform-branch-protection\\.test\\.js$",
-            "^tests/unit/task-platform-pr-summary\\.test\\.js$",
-            "^tests/unit/task-platform-merge-readiness-gate\\.test\\.js$"
-          ]
-        },
+        "^tests/unit/task-platform-github-check\\.test\\.js$",
+        "^tests/unit/task-platform-branch-protection\\.test\\.js$",
+        "^tests/unit/task-platform-pr-summary\\.test\\.js$",
+        "^tests/unit/task-platform-merge-readiness-gate\\.test\\.js$",
+        "^tests/unit/projects-production-smoke\\.test\\.js$"
+      ]
+    },
         {
           "name": "integration",
           "patterns": [

--- a/docs/api/task-platform-openapi.yml
+++ b/docs/api/task-platform-openapi.yml
@@ -549,6 +549,33 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/Project'
+    ProjectsProductionSmokeEvidence:
+      type: object
+      description: Redacted operator evidence emitted by `npm run projects:production-smoke`.
+      required: [summary, api]
+      properties:
+        summary:
+          type: object
+          required: [taskFixtureCreated, taskAttached, taskDetached, evidenceRedacted]
+          properties:
+            taskFixtureCreated:
+              type: boolean
+              description: True only when the smoke creates its own safe task fixture.
+            taskAttached:
+              type: boolean
+            taskDetached:
+              type: boolean
+            evidenceRedacted:
+              type: boolean
+        api:
+          type: object
+          required: [createTaskStatus, taskFixtureCreated]
+          properties:
+            createTaskStatus:
+              type: integer
+              nullable: true
+            taskFixtureCreated:
+              type: boolean
     Task:
       type: object
       required: [taskId, title, status, version, owner, createdAt, updatedAt]

--- a/docs/runbooks/task-platform-rollout.md
+++ b/docs/runbooks/task-platform-rollout.md
@@ -79,6 +79,21 @@ npm run task-platform:verify
 
 `npm run task-platform:rollout` is the preferred operator entrypoint. Use the individual commands only when a step must be rerun in isolation.
 
+### Run Projects production smoke
+```bash
+DATABASE_URL=postgres://... \
+AUTH_PUBLIC_APP_URL=https://<host> \
+AUTH_JWT_SECRET=<jwt-secret> \
+AUTH_PROD_ROLLBACK_TARGET=<rollback-url> \
+npm run projects:production-smoke
+```
+
+The Projects production smoke creates a temporary task fixture through
+`POST /api/v1/tasks` before it attaches and detaches Project membership. Do
+not rely on an existing unassigned production task. The redacted evidence must
+show `summary.taskFixtureCreated=true`, `summary.taskAttached=true`, and
+`summary.taskDetached=true`.
+
 ## Database Verification
 `npm run task-platform:verify` automates the core checks below. Use the SQL directly when an operator needs to inspect raw rows.
 

--- a/lib/task-platform/projects-production-smoke.js
+++ b/lib/task-platform/projects-production-smoke.js
@@ -139,6 +139,16 @@ function createProject(ctx) {
   });
 }
 
+function createSmokeTask(ctx) {
+  return apiSend(ctx, '/api/v1/tasks', 'POST', ['admin'], {
+    title: `${ctx.projectName} task fixture`,
+    description: 'Issue 232 Projects production smoke task fixture. Safe to leave unassigned after smoke.',
+    status: 'BACKLOG',
+    priority: 'P3',
+    metadata: { issue: 232, smoke: true },
+  });
+}
+
 function updateProject(ctx, projectId, project) {
   return apiSend(ctx, projectRoute(projectId), 'PATCH', ['admin'], {
     name: `${ctx.projectName} updated`,
@@ -169,13 +179,17 @@ async function runProjectCrud(ctx) {
 }
 
 async function runTaskMembership(ctx, projectId) {
-  const api = { listTasks: await apiGet(ctx, '/api/v1/tasks') };
-  const task = listData(api.listTasks).find(item => !item.projectId && !item.project_id) || null;
+  const api = {
+    listTasks: await apiGet(ctx, '/api/v1/tasks'),
+    createTask: await createSmokeTask(ctx),
+  };
+  const createdTask = data(api.createTask);
+  const task = createdTask || listData(api.listTasks).find(item => !item.projectId && !item.project_id) || null;
   const taskId = task?.taskId || null;
   api.attachTask = taskId && projectId ? await updateTaskProject(ctx, taskId, projectId, task.version) : null;
   const attachedTask = data(api.attachTask);
   api.detachTask = taskId && attachedTask ? await updateTaskProject(ctx, taskId, null, attachedTask.version) : null;
-  return { api, taskId, attachedTask };
+  return { api, taskId, attachedTask, createdTask };
 }
 
 async function runArchiveAndIsolation(ctx, projectId, updatedProject) {
@@ -193,6 +207,7 @@ function summarizeApi(api, project, projectId) {
     projectCreated: responseOk(api.createProject, 201) && !!projectId,
     projectRead: responseOk(api.readProject, 200),
     projectUpdated: responseOk(api.updateProject, 200) && data(api.updateProject)?.version > project?.version,
+    taskFixtureCreated: responseOk(api.createTask, 201) && !!data(api.createTask)?.taskId,
     taskAttached: responseOk(api.attachTask, 200) && data(api.attachTask)?.project?.projectId === projectId,
     taskDetached: responseOk(api.detachTask, 200) && (data(api.detachTask)?.projectId ?? data(api.detachTask)?.project_id ?? null) === null,
     archiveDeleteEquivalent: responseOk(api.archiveProject, 200) && data(api.archiveProject)?.status === 'ARCHIVED',
@@ -200,7 +215,7 @@ function summarizeApi(api, project, projectId) {
   };
 }
 
-function formatApiEvidence(api, project, projectId, taskId, attachedTask) {
+function formatApiEvidence(api, project, projectId, taskId, attachedTask, createdTask) {
   return {
     listBeforeStatus: api.listBefore.status,
     projectId,
@@ -208,6 +223,7 @@ function formatApiEvidence(api, project, projectId, taskId, attachedTask) {
     createStatus: api.createProject.status,
     readStatus: api.readProject?.status || null,
     updateStatus: api.updateProject?.status || null,
+    createTaskStatus: api.createTask?.status || null,
     attachStatus: api.attachTask?.status || null,
     detachStatus: api.detachTask?.status || null,
     archiveStatus: api.archiveProject?.status || null,
@@ -218,6 +234,7 @@ function formatApiEvidence(api, project, projectId, taskId, attachedTask) {
     attachedTaskVersion: attachedTask?.version || null,
     detachedTaskProjectId: data(api.detachTask)?.projectId ?? data(api.detachTask)?.project_id ?? null,
     isolationListContainsProject: listData(api.isolationList).some(item => item.projectId === projectId),
+    taskFixtureCreated: !!createdTask,
     summary: summarizeApi(api, project, projectId),
   };
 }
@@ -233,6 +250,7 @@ async function runProjectsApiSmoke(options) {
     crud.projectId,
     membership.taskId,
     membership.attachedTask,
+    membership.createdTask,
   );
 }
 
@@ -284,6 +302,7 @@ function buildSummary(evidence) {
     projectCreated: evidence.api.summary.projectCreated,
     projectRead: evidence.api.summary.projectRead,
     projectUpdated: evidence.api.summary.projectUpdated,
+    taskFixtureCreated: evidence.api.summary.taskFixtureCreated,
     taskAttached: evidence.api.summary.taskAttached,
     taskDetached: evidence.api.summary.taskDetached,
     archiveDeleteEquivalent: evidence.api.summary.archiveDeleteEquivalent,

--- a/tests/contract/projects-openapi.contract.test.js
+++ b/tests/contract/projects-openapi.contract.test.js
@@ -19,6 +19,9 @@ test('task platform OpenAPI documents Projects planning containers', () => {
     'ProjectStatus',
     'UpdateTaskProjectRequest',
     'ProjectSummary',
+    'ProjectsProductionSmokeEvidence',
+    'taskFixtureCreated',
+    'createTaskStatus',
   ]) {
     assert.match(openapi, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }

--- a/tests/unit/projects-production-smoke.test.js
+++ b/tests/unit/projects-production-smoke.test.js
@@ -42,51 +42,89 @@ function createPool() {
   };
 }
 
-function createFetch() {
-  const state = {
+function createSmokeState() {
+  return {
     project: null,
-    task: { taskId: 'TSK-SMOKE', version: 1, projectId: null, project: null },
+    task: null,
   };
+}
+
+function handleProjectRoutes(state, parsed, options, isPrimaryTenant) {
+  if (parsed.pathname === '/api/v1/projects' && options.method === 'POST') {
+    const body = JSON.parse(options.body);
+    state.project = {
+      projectId: 'PRJ-SMOKE123',
+      name: body.name,
+      summary: body.summary,
+      status: body.status,
+      version: 1,
+    };
+    return jsonResponse(201, { data: state.project });
+  }
+  if (parsed.pathname === '/api/v1/projects' && !options.method) {
+    return jsonResponse(200, { data: isPrimaryTenant && state.project?.status !== 'ARCHIVED' ? [state.project] : [] });
+  }
+  return null;
+}
+
+function handleProjectDetailRoutes(state, parsed, options, isPrimaryTenant) {
+  if (parsed.pathname === '/api/v1/projects/PRJ-SMOKE123' && !options.method) {
+    return isPrimaryTenant
+      ? jsonResponse(200, { data: { ...state.project, tasks: state.task?.projectId ? [state.task] : [] } })
+      : jsonResponse(404, { error: { code: 'project_not_found' } });
+  }
+  if (parsed.pathname === '/api/v1/projects/PRJ-SMOKE123' && options.method === 'PATCH') {
+    const body = JSON.parse(options.body);
+    state.project = { ...state.project, ...body, version: state.project.version + 1 };
+    return jsonResponse(200, { data: state.project });
+  }
+  return null;
+}
+
+function handleTaskRoutes(state, parsed, options) {
+  if (parsed.pathname === '/api/v1/tasks' && options.method === 'POST') {
+    const body = JSON.parse(options.body);
+    state.task = {
+      taskId: 'TSK-SMOKE',
+      title: body.title,
+      description: body.description,
+      status: body.status,
+      priority: body.priority,
+      version: 1,
+      projectId: null,
+      project: null,
+    };
+    return jsonResponse(201, { data: state.task });
+  }
+  if (parsed.pathname === '/api/v1/tasks' && !options.method) {
+    return jsonResponse(200, { data: state.task ? [state.task] : [] });
+  }
+  return null;
+}
+
+function handleTaskProjectRoutes(state, parsed, options) {
+  if (parsed.pathname !== '/api/v1/tasks/TSK-SMOKE/project' || options.method !== 'PATCH') return null;
+  const body = JSON.parse(options.body);
+  state.task = {
+    ...state.task,
+    version: state.task.version + 1,
+    projectId: body.projectId,
+    project: body.projectId ? { projectId: body.projectId, name: state.project.name, status: state.project.status } : null,
+  };
+  return jsonResponse(200, { data: state.task });
+}
+
+function createFetch() {
+  const state = createSmokeState();
   return async function fetchImpl(url, options = {}) {
     const parsed = new URL(url);
     const claims = claimsFromAuth(options.headers);
     const isPrimaryTenant = claims.tenant_id === 'tenant-int';
-    if (parsed.pathname === '/api/v1/projects' && options.method === 'POST') {
-      const body = JSON.parse(options.body);
-      state.project = {
-        projectId: 'PRJ-SMOKE123',
-        name: body.name,
-        summary: body.summary,
-        status: body.status,
-        version: 1,
-      };
-      return jsonResponse(201, { data: state.project });
-    }
-    if (parsed.pathname === '/api/v1/projects' && !options.method) {
-      return jsonResponse(200, { data: isPrimaryTenant && state.project?.status !== 'ARCHIVED' ? [state.project] : [] });
-    }
-    if (parsed.pathname === '/api/v1/tasks' && !options.method) {
-      return jsonResponse(200, { data: [state.task] });
-    }
-    if (parsed.pathname === '/api/v1/projects/PRJ-SMOKE123' && !options.method) {
-      return isPrimaryTenant ? jsonResponse(200, { data: { ...state.project, tasks: state.task.projectId ? [state.task] : [] } }) : jsonResponse(404, { error: { code: 'project_not_found' } });
-    }
-    if (parsed.pathname === '/api/v1/projects/PRJ-SMOKE123' && options.method === 'PATCH') {
-      const body = JSON.parse(options.body);
-      state.project = { ...state.project, ...body, version: state.project.version + 1 };
-      return jsonResponse(200, { data: state.project });
-    }
-    if (parsed.pathname === '/api/v1/tasks/TSK-SMOKE/project' && options.method === 'PATCH') {
-      const body = JSON.parse(options.body);
-      state.task = {
-        ...state.task,
-        version: state.task.version + 1,
-        projectId: body.projectId,
-        project: body.projectId ? { projectId: body.projectId, name: state.project.name, status: state.project.status } : null,
-      };
-      return jsonResponse(200, { data: state.task });
-    }
-    return jsonResponse(404, { error: { code: 'not_found' } });
+    return handleProjectRoutes(state, parsed, options, isPrimaryTenant)
+      || handleProjectDetailRoutes(state, parsed, options, isPrimaryTenant)
+      || handleTaskRoutes(state, parsed, options)
+      || handleTaskProjectRoutes(state, parsed, options)
+      || jsonResponse(404, { error: { code: 'not_found' } });
   };
 }
 
@@ -107,11 +145,13 @@ test('Projects production smoke records redacted migration, CRUD, membership, ar
   assert.equal(evidence.summary.passed, true);
   assert.equal(evidence.summary.migration012Applied, true);
   assert.equal(evidence.summary.projectCreated, true);
+  assert.equal(evidence.summary.taskFixtureCreated, true);
   assert.equal(evidence.summary.taskAttached, true);
   assert.equal(evidence.summary.taskDetached, true);
   assert.equal(evidence.summary.archiveDeleteEquivalent, true);
   assert.equal(evidence.summary.tenantIsolationPassed, true);
   assert.equal(evidence.api.projectId, 'PRJ-SMOKE123');
+  assert.equal(evidence.api.taskFixtureCreated, true);
   assert.equal(JSON.parse(fs.readFileSync(outputPath, 'utf8')).summary.evidenceRedacted, true);
   assert.doesNotMatch(fs.readFileSync(outputPath, 'utf8'), /Bearer|test-secret|authorization/i);
 });


### PR DESCRIPTION
## Summary
- Make Projects production smoke create its own safe task fixture before attach/detach validation.
- Record `taskFixtureCreated` and create-task status in redacted smoke evidence.
- Add API/runbook evidence and register the production-smoke unit test under task-platform ownership checks.

## Linked Task
- Task: #232

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/task-platform-rollout.md
- Relevant standards areas: testing and quality assurance, deployment and release, observability and monitoring, security and compliance
- Standards gaps or exceptions: no new gap; remote OpenClaw evidence remains a separate #232 environment blocker
- [ ] UI changes use generated DESIGN.md tokens.
- [ ] `npm run design:tokens:check` passed.
- [ ] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: `npm run standards:check`
- Lint result: `git diff --check`
- Tests: `node --test tests/unit/projects-production-smoke.test.js tests/contract/projects-openapi.contract.test.js`; `npm run coverage`; `npm run standards:check`; `npm run ownership:lint`; `GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=/tmp/pr-233-event.json npm run change:check`; `GITHUB_TOKEN="$(gh auth token)" npm run task-platform:verify-branch-protection -- wiinc1/engineering-team main`
- Test evidence paths: tests/unit/projects-production-smoke.test.js, tests/contract/projects-openapi.contract.test.js
- Docs updated: task-platform API evidence schema and rollout runbook smoke guidance
- Doc evidence paths: docs/api/task-platform-openapi.yml, docs/runbooks/task-platform-rollout.md

## Risk and Rollback
- Risk level: low; validation-only smoke path creates a safe task fixture and keeps evidence redacted
- Rollback path: revert this PR branch or commits `5526ed8` and `79ec61e`

## Notes
Refs wiinc1/engineering-team#232. This PR addresses the Projects production smoke attach/detach blocker. It does not resolve the separate remote OpenClaw gateway/profile evidence blocker.
