### PR TITLE
Ignore local environment files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ data/
 docs/design/no-design-impact.txt
 __pycache__/
 *.pyc
+.env*


### PR DESCRIPTION
## Summary

Ignore local environment files generated by the Vercel CLI so pulled deployment secrets stay out of git.

## Linked Task
- Task: Vercel deployment setup

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: .github/PULL_REQUEST_TEMPLATE.md
- Relevant standards areas: repository hygiene, secret handling, deployment setup
- Standards gaps or exceptions: No gaps; metadata-only repository hygiene change.
- [ ] UI changes use generated DESIGN.md tokens.
- [ ] `npm run design:tokens:check` passed.
- [ ] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: Not run locally; PR validation will run standards checks.
- Lint result: Not run locally; PR validation will run lint checks.
- Tests: Not run locally; metadata-only ignore-file change.
- Test evidence paths: .gitignore
- Docs updated: Not needed; no product or developer workflow documentation changed.
- Doc evidence paths: .gitignore

## Risk and Rollback
- Risk level: Low
- Rollback path: Revert commit 5f2be87 to remove the `.env*` ignore pattern.

## Notes

Vercel preview deploy completed before this PR and generated `.env.local`; this PR keeps local env files untracked.
