### PR TITLE
Fix task detail null read model crash

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,6 +8,7 @@ runtimeContracts:
     versionSourceEndpoint: "/v1/tasks/:taskId"
     notes: "Task detail assignment controls use canonical task-platform JSON endpoints so Vercel SPA fallbacks cannot return HTML to owner-save requests."
     draftPmRefinementFeedback: "When the owner save returns workflow.nextRequiredAction, the assignment status reports that PM refinement started instead of only confirming owner persistence."
+    nullReadModelDefaults: "Task detail form defaults tolerate null optional read-model sections so incomplete draft tasks render owner, next action, and activity instead of white-screening."
 colors:
   palette-page-bg: "#EEF2F7"
   palette-surface: "#FFFFFF"

--- a/src/app/AppDetailReadModel.test.tsx
+++ b/src/app/AppDetailReadModel.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { Fn, Vn, Wn, Xn, Zn, es, jn } from './app-model.jsx';
+
+describe('task detail read-model defaults', () => {
+  it('keeps form state stable when optional sections are null', () => {
+    expect(Fn(null)).toMatchObject({
+      readyForEngineering: false,
+      engineerTier: 'Sr',
+      technicalSpec: { summary: '', scope: '', design: '', rolloutPlan: '' },
+    });
+    expect(Wn(null)).toEqual({ commitSha: '', prUrl: '' });
+    expect(jn(null)).toEqual({ reason: '' });
+    expect(Vn(null)).toEqual({ summary: '', evidence: '' });
+    expect(Xn(null)).toMatchObject({ outcome: 'fail', summary: '' });
+    expect(Zn(null)).toMatchObject({ deploymentEnvironment: 'production', deploymentUrl: '' });
+    expect(es(null)).toEqual({ reason: '', evidence: '' });
+  });
+});

--- a/src/app/AppRouteModel.test.tsx
+++ b/src/app/AppRouteModel.test.tsx
@@ -5,12 +5,19 @@ import path from 'node:path';
 import {
   De,
   Fa,
+  Fn,
   Hn,
   Ie,
   Pe,
+  Vn,
+  Wn,
+  Xn,
+  Zn,
   qe,
   authModeFromSearch,
   authSearchWithMode,
+  es,
+  jn,
   va,
   we,
   za,
@@ -63,5 +70,21 @@ describe('browser app route model helpers', () => {
     const design = fs.readFileSync(path.join(process.cwd(), 'DESIGN.md'), 'utf8');
     expect(design).toContain('draftPmRefinementFeedback');
     expect(design).toContain('workflow.nextRequiredAction');
+  });
+});
+
+describe('task detail read-model defaults', () => {
+  it('keeps form state stable when optional sections are null', () => {
+    expect(Fn(null)).toMatchObject({
+      readyForEngineering: false,
+      engineerTier: 'Sr',
+      technicalSpec: { summary: '', scope: '', design: '', rolloutPlan: '' },
+    });
+    expect(Wn(null)).toEqual({ commitSha: '', prUrl: '' });
+    expect(jn(null)).toEqual({ reason: '' });
+    expect(Vn(null)).toEqual({ summary: '', evidence: '' });
+    expect(Xn(null)).toMatchObject({ outcome: 'fail', summary: '' });
+    expect(Zn(null)).toMatchObject({ deploymentEnvironment: 'production', deploymentUrl: '' });
+    expect(es(null)).toEqual({ reason: '', evidence: '' });
   });
 });

--- a/src/app/app-model.jsx
+++ b/src/app/app-model.jsx
@@ -274,11 +274,11 @@ function po(i) {
   }
 }
 function Fn(i = {}) {
-  return { readyForEngineering: !!i.readyForEngineering, engineerTier: i.engineerTier || "Sr", tierRationale: i.tierRationale || "", technicalSpec: { summary: i.
-  technicalSpec?.summary || "", scope: i.technicalSpec?.scope || "", design: i.technicalSpec?.design || "", rolloutPlan: i.technicalSpec?.rolloutPlan || "" }, monitoringSpec: {
-  service: i.monitoringSpec?.service || "", dashboardUrls: Array.isArray(i.monitoringSpec?.dashboardUrls) ? i.monitoringSpec.dashboardUrls.join(`
-`) : "", alertPolicies: Array.isArray(i.monitoringSpec?.alertPolicies) ? i.monitoringSpec.alertPolicies.join(`
-`) : "", runbook: i.monitoringSpec?.runbook || "", successMetrics: Array.isArray(i.monitoringSpec?.successMetrics) ? i.monitoringSpec.successMetrics.join(`
+  return { readyForEngineering: !!i?.readyForEngineering, engineerTier: i?.engineerTier || "Sr", tierRationale: i?.tierRationale || "", technicalSpec: { summary: i?.
+  technicalSpec?.summary || "", scope: i?.technicalSpec?.scope || "", design: i?.technicalSpec?.design || "", rolloutPlan: i?.technicalSpec?.rolloutPlan || "" }, monitoringSpec: {
+  service: i?.monitoringSpec?.service || "", dashboardUrls: Array.isArray(i?.monitoringSpec?.dashboardUrls) ? i.monitoringSpec.dashboardUrls.join(`
+`) : "", alertPolicies: Array.isArray(i?.monitoringSpec?.alertPolicies) ? i.monitoringSpec.alertPolicies.join(`
+`) : "", runbook: i?.monitoringSpec?.runbook || "", successMetrics: Array.isArray(i?.monitoringSpec?.successMetrics) ? i.monitoringSpec.successMetrics.join(`
 `) : "" } };
 }
 function zn(i) {
@@ -292,47 +292,47 @@ function zn(i) {
   }
 }
 function Wn(i = {}) {
-  return { commitSha: i.commitSha || "", prUrl: i.prUrl || "" };
+  return { commitSha: i?.commitSha || "", prUrl: i?.prUrl || "" };
 }
 function jn(i = {}) {
-  return { reason: i.reason || "" };
+  return { reason: i?.reason || "" };
 }
 function Vn(i = {}) {
-  return { summary: i.lastActivity?.summary || "", evidence: Array.isArray(i.lastActivity?.evidence) ? i.lastActivity.evidence.join(`
+  return { summary: i?.lastActivity?.summary || "", evidence: Array.isArray(i?.lastActivity?.evidence) ? i.lastActivity.evidence.join(`
 `) : "" };
 }
 function Kn(i = {}) {
-  return { engineerTier: i.retiering?.engineerTier || i.architectHandoff?.engineerTier || "Sr", tierRationale: i.retiering?.tierRationale || "", reason: i.retiering?.
+  return { engineerTier: i?.retiering?.engineerTier || i?.architectHandoff?.engineerTier || "Sr", tierRationale: i?.retiering?.tierRationale || "", reason: i?.retiering?.
   reason || "" };
 }
 function Jn(i = {}) {
-  return { mode: i.reassignment?.mode || "inactivity", reason: i.reassignment?.reason || "", assignee: i.reassignment?.assignee || "", engineerTier: i.reassignment?.
-  engineerTier || i.retiering?.engineerTier || i.architectHandoff?.engineerTier || "" };
+  return { mode: i?.reassignment?.mode || "inactivity", reason: i?.reassignment?.reason || "", assignee: i?.reassignment?.assignee || "", engineerTier: i?.reassignment?.
+  engineerTier || i?.retiering?.engineerTier || i?.architectHandoff?.engineerTier || "" };
 }
 function go(i = {}) {
-  const o = String(i.commitSha || "").trim(), l = String(i.prUrl || "").trim(), u = [];
+  const o = String(i?.commitSha || "").trim(), l = String(i?.prUrl || "").trim(), u = [];
   return o && !Wi.test(o) && u.push("commitSha"), l && !ji.test(l) && u.push("prUrl"), { commitSha: o, prUrl: l, missingAll: !o && !l, invalidFields: u, isValid: u.
   length === 0 && (!!o || !!l), primaryReference: l || o || null };
 }
 function Yn(i = {}) {
-  return { commentType: i.commentType || "question", title: i.title || "", body: i.body || "", blocking: !!i.blocking, linkedEventId: i.linkedEventId || "" };
+  return { commentType: i?.commentType || "question", title: i?.title || "", body: i?.body || "", blocking: !!i?.blocking, linkedEventId: i?.linkedEventId || "" };
 }
 function Xn(i = {}) {
-  return { outcome: i.outcome || "fail", summary: i.summary || "", scenarios: Array.isArray(i.scenarios) ? i.scenarios.join(`
-`) : "", findings: Array.isArray(i.findings) ? i.findings.join(`
-`) : "", reproductionSteps: Array.isArray(i.reproductionSteps) ? i.reproductionSteps.join(`
-`) : "", stackTraces: Array.isArray(i.stackTraces) ? i.stackTraces.join(`
-`) : "", envLogs: Array.isArray(i.envLogs) ? i.envLogs.join(`
-`) : "", retestScope: Array.isArray(i.reTestScope) ? i.reTestScope.join(`
+  return { outcome: i?.outcome || "fail", summary: i?.summary || "", scenarios: Array.isArray(i?.scenarios) ? i.scenarios.join(`
+`) : "", findings: Array.isArray(i?.findings) ? i.findings.join(`
+`) : "", reproductionSteps: Array.isArray(i?.reproductionSteps) ? i.reproductionSteps.join(`
+`) : "", stackTraces: Array.isArray(i?.stackTraces) ? i.stackTraces.join(`
+`) : "", envLogs: Array.isArray(i?.envLogs) ? i.envLogs.join(`
+`) : "", retestScope: Array.isArray(i?.reTestScope) ? i.reTestScope.join(`
 `) : "" };
 }
 function Zn(i = {}) {
-  return { deploymentEnvironment: i.deployment?.environment || "production", deploymentUrl: i.deployment?.url || "", deploymentVersion: i.deployment?.version ||
-  "", evidence: Array.isArray(i.deployment?.evidence) ? i.deployment.evidence.join(`
+  return { deploymentEnvironment: i?.deployment?.environment || "production", deploymentUrl: i?.deployment?.url || "", deploymentVersion: i?.deployment?.version ||
+  "", evidence: Array.isArray(i?.deployment?.evidence) ? i.deployment.evidence.join(`
 `) : "" };
 }
 function es(i = {}) {
-  return { reason: i.approval?.reason || "", evidence: Array.isArray(i.approval?.evidence) ? i.approval.evidence.join(`
+  return { reason: i?.approval?.reason || "", evidence: Array.isArray(i?.approval?.evidence) ? i.approval.evidence.join(`
 `) : "" };
 }
 function ts(i = {}) {


### PR DESCRIPTION
## Summary
Fixes the task detail white-screen that occurs when production draft tasks include null optional read-model sections.

- Task: TSK-7455C9C1
- Standards baseline reviewed: Yes, standards:check passed locally.
- Checklist completed or updated: Yes, docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md reviewed.
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: Browser shell task detail, runtime contracts, unit UI coverage.
- Standards gaps or exceptions: No exceptions requested.
- Standards check result: npm run standards:check passed.
- Lint result: npm run lint passed.
- Tests: npx vitest run src/app/AppRouteModel.test.tsx src/app/AppDetailReadModel.test.tsx passed.
- Test evidence paths: src/app/AppRouteModel.test.tsx, src/app/AppDetailReadModel.test.tsx
- Docs updated: DESIGN.md documents null read-model defaults for task detail assignment surfaces.
- Doc evidence paths: DESIGN.md
- Risk level: Low; frontend defaulting only for nullable optional task detail sections.
- Rollback path: Revert this PR to restore the previous task detail read-model default behavior.