### PR TITLE
Prioritize PM refinement retry over monitoring

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -612,6 +612,7 @@ Task detail UX is governed by the task-detail read model, not by ad hoc client-s
 - Stale, degraded, restricted, empty, and error task-detail states must be visually distinct and must include direct recovery or next-step language when recovery exists.
 - Deterministic status precedence must be preserved: blocked, waiting, degraded/stale, review, done, and closed states should not compete through color alone.
 - Role-specific next-action panels may derive from the canonical read model plus session roles, but must not introduce a second task-detail source of truth or hide blocked, waiting, stale, or read-only states behind action-only copy.
+- Pending PM refinement is a blocking intake state; its retry action takes precedence over monitoring context until a refinement artifact or Execution Contract exists.
 - Linked child tasks, PR metadata, orchestration counts, and telemetry summaries must avoid N+1-style page behavior. Summaries should be pre-projected or loaded through explicit adjacent panels.
 - Truncated payloads, hidden orchestration, redacted owner data, and unavailable telemetry must identify the limitation and its source.
 - Manual refresh is the default recovery model for stale task-detail data unless a route defines a stronger live-update contract.

--- a/docs/reports/ISSUE-203_STANDARDS_COMPLIANCE_CHECKLIST.md
+++ b/docs/reports/ISSUE-203_STANDARDS_COMPLIANCE_CHECKLIST.md
@@ -77,3 +77,16 @@
 - Tests added or updated: `tests/unit/task-detail-next-action.test.js`; `tests/contract/task-detail-next-action.contract.test.js`; `tests/browser/task-detail-next-action.browser.spec.ts`; `tests/visual/task-assignment.visual.spec.ts`; `tests/visual/__snapshots__/task-assignment.visual.spec.ts.snap`.
 - Validation evidence: `node --test tests/unit/task-detail-next-action.test.js tests/contract/task-detail-next-action.contract.test.js`; `npx playwright test tests/browser/task-detail-next-action.browser.spec.ts`; `npx vitest run tests/visual/task-assignment.visual.spec.ts`; `npm run lint`; `npm run standards:check`; `npm run build`.
 - Rollout and rollback: Deploy with PR #262. Rollback by reverting the PR or disabling the task detail next-action redesign with `VITE_FF_TASK_DETAIL_NEXT_ACTION_REDESIGN=false`.
+
+## PR #263 Addendum - PM Refinement Retry Precedence
+
+- Change or task ID: PR #263, keep pending PM refinement ahead of monitoring next actions.
+- Owner: Codex implementation agent.
+- Date: 2026-06-01.
+- Scope summary: Fixed the task-detail next-action resolver so a DRAFT intake task with pending PM refinement still renders `Retry PM refinement` even when stale or pending monitoring context is present.
+- Standards baseline reviewed: `docs/standards/software-development-standards.md` and `DESIGN.md`.
+- Applicable standards areas: task detail UX, PM refinement workflow recovery, role-specific next-action precedence, and browser coverage.
+- Standards gaps or exceptions: No new exception. The change preserves SRE monitoring precedence once PM refinement is no longer requested/pending.
+- Tests added or updated: `tests/unit/task-detail-next-action.test.js`; `tests/browser/task-detail-next-action.browser.spec.ts`.
+- Validation evidence: `node --test tests/unit/task-detail-next-action.test.js tests/contract/task-detail-next-action.contract.test.js`; `npx playwright test tests/browser/task-detail-next-action.browser.spec.ts`; `npm run lint`; `npm run standards:check`; `npm run build`.
+- Rollout and rollback: Deploy with PR #263. Rollback by reverting the PR to restore the previous SRE-before-PM next-action precedence.

--- a/src/features/task-detail/next-action.mjs
+++ b/src/features/task-detail/next-action.mjs
@@ -145,12 +145,17 @@ function roleMatch(roles, role) {
 
 function pickRole(roles, signals) {
   if (signals.closeGovernance?.humanDecision?.required && roleMatch(roles, 'human')) return 'human';
+  if (isPendingPmRefinement(signals) && roleMatch(roles, 'pm')) return 'pm';
   if (isSreAction(signals) && roleMatch(roles, 'sre')) return 'sre';
   if (isQaAction(signals) && roleMatch(roles, 'qa')) return 'qa';
   if (isPmAction(signals) && roleMatch(roles, 'pm')) return 'pm';
   if (isArchitectAction(signals) && roleMatch(roles, 'architect')) return 'architect';
   if (isEngineerAction(signals) && roleMatch(roles, 'engineer')) return 'engineer';
   return ROLE_PRIORITY.find((role) => roles.includes(role)) || roles[0] || 'reader';
+}
+
+function isPendingPmRefinement(signals) {
+  return signals.pmRefinementStatus?.value === 'Requested/pending';
 }
 
 function isPmAction(signals) {

--- a/tests/browser/task-detail-next-action.browser.spec.ts
+++ b/tests/browser/task-detail-next-action.browser.spec.ts
@@ -346,7 +346,8 @@ test.describe('task detail PM refinement retry', () => {
       status: 'waiting',
       intakeDraft: true,
       nextAction: 'PM refinement required',
-    }), ['pm', 'reader']);
+      monitoring: { state: 'pending_start', canApprove: false },
+    }), ['admin', 'pm', 'sre', 'reader']);
 
     await page.route(`**/api/v1/tasks/${TASK_ID}/refinement/start`, async (route) => {
       retryRequests.push(route.request().postDataJSON());

--- a/tests/unit/task-detail-next-action.test.js
+++ b/tests/unit/task-detail-next-action.test.js
@@ -62,6 +62,26 @@ test('next-action resolver prioritizes PM refinement for intake drafts', async (
   assert.equal(result.statusFacts.find((fact) => fact.label === 'PM refinement').value, 'Requested/pending');
 });
 
+test('next-action resolver keeps pending PM refinement ahead of monitoring state', async () => {
+  const { resolveTaskDetailNextAction } = await modulePromise;
+  const result = resolveTaskDetailNextAction(
+    screen({
+      stage: 'DRAFT',
+      status: 'waiting',
+      ownerId: 'pm',
+      ownerLabel: 'pm',
+      intakeDraft: true,
+      nextAction: 'PM refinement required',
+      monitoring: { state: 'pending_start', canApprove: false },
+    }),
+    principal('admin', 'pm', 'sre', 'reader'),
+  );
+  assert.equal(result.action, 'pm_refinement');
+  assert.equal(result.role, 'pm');
+  assert.equal(result.primaryAction, 'retry_pm_refinement');
+  assert.equal(result.primaryLabel, 'Retry PM refinement');
+});
+
 test('next-action resolver distinguishes active and completed PM refinement', async () => {
   const { resolveTaskDetailNextAction } = await modulePromise;
   const inProgress = resolveTaskDetailNextAction(


### PR DESCRIPTION
## Summary
- Fix task-detail next-action precedence so pending PM refinement renders the `Retry PM refinement` button even when monitoring context is also present.
- Add unit and browser regressions matching the production shape for TSK-7455C9C1: DRAFT intake, PM owner, pending refinement, and pending monitoring state.
- Document the precedence rule in design and compliance evidence.

## Required Metadata
- Task: Fix hidden PM refinement retry button for pending intake tasks
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/reports/ISSUE-203_STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: task detail UX, PM refinement workflow, next-action role precedence
- Standards gaps or exceptions: No standards gaps identified
- Standards check result: `npm run standards:check` passed
- Lint result: `npm run lint` passed
- Tests: focused unit/contract/browser resolver tests passed; production build passed
- Test evidence paths: tests/unit/task-detail-next-action.test.js, tests/browser/task-detail-next-action.browser.spec.ts
- Docs updated: yes
- Doc evidence paths: DESIGN.md, docs/reports/ISSUE-203_STANDARDS_COMPLIANCE_CHECKLIST.md
- Risk level: low
- Rollback path: revert this PR to restore the previous SRE-before-PM next-action precedence

## Verification
- `node --test tests/unit/task-detail-next-action.test.js tests/contract/task-detail-next-action.contract.test.js`
- `npx playwright test tests/browser/task-detail-next-action.browser.spec.ts`
- `npm run change:check`
- `npm run lint`
- `npm run standards:check`
- `npm run build`