### PR TITLE
Map PM specialist for OpenClaw delegation

### DIFF
--- a/docs/runbooks/specialist-delegation.md
+++ b/docs/runbooks/specialist-delegation.md
@@ -16,6 +16,7 @@
 2. Configure `SPECIALIST_DELEGATION_RUNNER` to invoke the real OpenClaw/runtime handoff path, then start the command router.
 3. Repo-local OpenClaw bridge command: `SPECIALIST_DELEGATION_RUNNER='node scripts/openclaw-specialist-runner.js'`.
 4. Default repo-local alias map:
+- `pm -> pm`
 - `architect -> architect`
 - `engineer -> sr-engineer`
 - `qa -> qa-engineer`

--- a/scripts/openclaw-specialist-runner.js
+++ b/scripts/openclaw-specialist-runner.js
@@ -3,6 +3,7 @@
 const { spawn } = require('child_process');
 
 const DEFAULT_SPECIALIST_MAP = Object.freeze({
+  pm: 'pm',
   architect: 'architect',
   engineer: 'sr-engineer',
   qa: 'qa-engineer',

--- a/tests/contract/specialist-delegation.contract.test.js
+++ b/tests/contract/specialist-delegation.contract.test.js
@@ -59,6 +59,32 @@ test('OpenClaw gateway responses satisfy the bridge evidence contract', () => {
   assert.equal(bridge.ownership.specialistId, 'engineer');
 });
 
+test('OpenClaw PM refinement responses satisfy the bridge evidence contract', () => {
+  const bridge = buildBridgeResponse({
+    payload: {
+      specialist: 'pm',
+      delegationId: 'contract-pm-refinement',
+    },
+    runtimeAgent: 'pm',
+    response: {
+      result: {
+        message: 'PM refinement complete',
+        meta: {
+          agentMeta: {
+            sessionId: 'specialist-delegation-contract-pm-refinement',
+          },
+        },
+      },
+    },
+  });
+
+  assert.equal(bridge.agentId, 'pm');
+  assert.equal(bridge.sessionId, 'specialist-delegation-contract-pm-refinement');
+  assert.equal(bridge.output, 'PM refinement complete');
+  assert.equal(bridge.ownership.specialistId, 'pm');
+  assert.equal(bridge.ownership.runtimeAgentId, 'pm');
+});
+
 test('delegation artifacts may be stored outside the runtime working directory', async () => {
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'delegation-contract-cwd-'));
   const artifactBaseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'delegation-contract-artifacts-'));

--- a/tests/security/specialist-delegation.security.test.js
+++ b/tests/security/specialist-delegation.security.test.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { createSpecialistCoordinator, resolveDelegationArtifactBaseDir } = require('../../lib/software-factory/delegation');
+const { DEFAULT_SPECIALIST_MAP } = require('../../scripts/openclaw-specialist-runner');
 const { DEFAULT_SMOKE_REQUEST } = require('../../scripts/validate-specialist-runtime');
 
 test('delegation fallback messages stay sanitized when runtime execution fails', async () => {
@@ -61,4 +62,11 @@ test('serverless artifact base selection avoids read-only Vercel bundle paths', 
     ),
     '/tmp/delegation-artifacts',
   );
+});
+
+test('default OpenClaw specialist map covers all assignable pilot roles', () => {
+  for (const role of ['pm', 'architect', 'engineer', 'qa', 'sre']) {
+    assert.equal(typeof DEFAULT_SPECIALIST_MAP[role], 'string');
+    assert.notEqual(DEFAULT_SPECIALIST_MAP[role].trim(), '');
+  }
 });

--- a/tests/unit/openclaw-specialist-runner.test.js
+++ b/tests/unit/openclaw-specialist-runner.test.js
@@ -18,11 +18,13 @@ test('resolveSpecialistMap merges defaults with overrides', () => {
   });
 
   assert.equal(map.engineer, 'jr-engineer');
+  assert.equal(map.pm, 'pm');
   assert.equal(map.architect, 'architect');
   assert.equal(map.qa, 'qa-engineer');
 });
 
 test('resolveRuntimeAgent uses the configured alias map', () => {
+  assert.equal(resolveRuntimeAgent('pm'), 'pm');
   assert.equal(resolveRuntimeAgent('engineer'), 'sr-engineer');
   assert.equal(resolveRuntimeAgent('qa'), 'qa-engineer');
   assert.equal(resolveRuntimeAgent('engineer', {

--- a/tests/unit/specialist-delegation.test.js
+++ b/tests/unit/specialist-delegation.test.js
@@ -166,6 +166,33 @@ test('accepts runtime agent aliases when ownership carries the original speciali
   assert.equal(result.metadata.ownership.runtimeAgentId, 'sr-engineer');
 });
 
+test('delegates explicit PM refinement ownership through runtime evidence', async () => {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'specialist-pm-'));
+  const coordinator = createSpecialistCoordinator({
+    baseDir,
+    delegateWork: async ({ specialist }) => ({
+      agentId: 'pm',
+      sessionId: 'runtime-session-pm',
+      output: 'handled by product manager',
+      ownership: {
+        specialistId: specialist,
+        runtimeAgentId: 'pm',
+      },
+    }),
+  });
+
+  const result = await coordinator.handleRequest('Refine this intake task', {
+    coordinatorAgent: 'main',
+    targetSpecialist: 'pm',
+  });
+
+  assert.equal(result.mode, 'delegated');
+  assert.equal(result.agentId, 'pm');
+  assert.equal(result.specialist, 'pm');
+  assert.equal(result.metadata.sessionId, 'runtime-session-pm');
+  assert.equal(result.metadata.ownership.specialistId, 'pm');
+});
+
 test('classifyDelegationFailure maps runtime errors to stable fallback reasons', () => {
   assert.equal(classifyDelegationFailure({ code: 'SPECIALIST_RUNTIME_NOT_CONFIGURED' }), FALLBACK_REASONS.NOT_CONFIGURED);
   assert.equal(classifyDelegationFailure({ code: 'SPECIALIST_RUNTIME_EXEC_FAILED' }), FALLBACK_REASONS.RUNTIME_EXEC_FAILED);


### PR DESCRIPTION
## Summary
- Add the missing default OpenClaw PM specialist mapping used by PM refinement retry dispatch.
- Cover PM refinement delegation evidence in unit, contract, and security tests.
- Document the PM alias in the specialist delegation runbook.

## Validation
- node --test tests/unit/openclaw-specialist-runner.test.js tests/unit/specialist-delegation.test.js tests/contract/specialist-delegation.contract.test.js tests/security/specialist-delegation.security.test.js
- npm run change:check
- npm run lint
- npm run standards:check
- npm run build

## Production diagnosis
Vercel runtime logs showed `No OpenClaw agent mapping configured for specialist pm` after the retry endpoint route and writable artifact fixes were deployed. This PR makes PM refinement dispatch resolvable by the OpenClaw bridge.

- Task: Fix PM refinement retry runtime failure after PR #265
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/specialist-delegation.md
- Relevant standards areas: specialist delegation runtime evidence, PM refinement ownership, production fallback handling
- Standards gaps or exceptions: No standards gaps or exceptions identified.
- Standards check result: npm run standards:check passed
- Lint result: npm run lint passed
- Tests: node --test tests/unit/openclaw-specialist-runner.test.js tests/unit/specialist-delegation.test.js tests/contract/specialist-delegation.contract.test.js tests/security/specialist-delegation.security.test.js passed
- Test evidence paths: tests/unit/openclaw-specialist-runner.test.js, tests/unit/specialist-delegation.test.js, tests/contract/specialist-delegation.contract.test.js, tests/security/specialist-delegation.security.test.js
- Docs updated: yes
- Doc evidence paths: docs/runbooks/specialist-delegation.md
- Risk level: low
- Rollback path: revert the PR to remove the default PM alias and associated test/doc updates