### PR TITLE
fix: exclude observability worktrees from vitest (GP-023)

### DIFF
--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -489,6 +489,8 @@ curl -s -X POST -H "Authorization: Bearer local-forgeadapter-token" \
 
 **Local (default):**
 
+`vitest.config.ts` excludes `observability/**` so forgeadapter worktrees under `observability/golden-path-local-dev/` do not pollute GP-023 `test:unit` during phase 6 closeout.
+
 ```bash
 # With dev stack up — validation only; UI already at http://127.0.0.1:15173
 npm run lint && npm run test:unit && npm run standards:check

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,11 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      'observability/**',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'json-summary'],


### PR DESCRIPTION
## Summary

Exclude `observability/**` from vitest discovery so forgeadapter worktree copies do not break GP-023 `test:unit` during golden-path phase 6 closeout.

## Linked Task
- Task: Golden-path epic #269 — GP-023 local deploy validation without `--skip-validation`

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: testing and quality assurance, golden-path phase 6 closeout
- Standards gaps or exceptions: none; vitest config-only change
- [ ] UI changes use generated DESIGN.md tokens.
- [ ] `npm run design:tokens:check` passed.
- [ ] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: `npm run standards:check` pass locally; CI verify expected green
- Lint result: `npm run lint` pass locally
- Tests: `npm run test:ui:vitest` (28 files, was 140 with worktree dupes); `npm run test:unit` pass
- Test evidence paths: vitest.config.ts
- Docs updated: yes
- Doc evidence paths: docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: low — narrows vitest scan scope to exclude local observability artifacts
- Rollback path: revert PR; GP-023 may require `--skip-validation` again when worktrees exist under observability