### PR TITLE
Expose coordinated stack release health

### DIFF
--- a/docs/api/audit-foundation-openapi.yml
+++ b/docs/api/audit-foundation-openapi.yml
@@ -22,6 +22,7 @@ info:
     Autonomous delivery metrics MVP routes are mounted by the audit API wrapper and documented in `docs/api/autonomous-delivery-metrics-openapi.yml`: `/api/v1/metrics/autonomous-delivery`, `/api/v1/tasks/{taskId}/retrospective-signal`, and `/api/v1/metrics/autonomous-delivery/rebuild`.
     Forgeadapter Phase 2 canonical task reads use `GET /tasks/{taskId}/forge-execution-readiness`, which returns camelCase execution-ready task JSON when the task has an approved execution contract, dispatch readiness, and `forge_dispatch` metadata. Service-to-service callers authenticate with `FORGE_SERVICE_TOKEN` bearer; JWT callers require `forge:read`.
     Product delivery integrity (`product-delivery-integrity.v1`) is additive for UI-affecting execution contracts: `PUT /tasks/{id}/engineer-submission` records `task.engineer_submission_recorded` with `runnable_surface_verified` only when the submitted commit SHA is present on the configured runnable surface branch; orphan SHAs return `409 runnable_surface_not_merged`. `POST /tasks/{id}/product-delivery-reconcile` records `task.product_delivery_reconciled` when operators report platform/product divergence and returns a reconciliation report. Task state and detail projections expose dual `platform_delivery` and `product_delivery` layers; closeout for `affects_ui` tasks requires `product_delivery.status=verified` or returns `409 product_delivery_not_verified`, and QA pass after failed reconciliation returns `409 product_delivery_reconciliation_required`.
+    Release health reads are mounted by the coordinated audit API at `/version`, `/api/version`, `/backend/version`, and `/health`. These unauthenticated read-only endpoints return the deployed audit API commit SHA for strict release-health proof and set `cache-control: no-store`.
 components:
   securitySchemes:
     BearerAuth:
@@ -1110,6 +1111,44 @@ components:
 security:
   - BearerAuth: []
 paths:
+  /version:
+    get:
+      summary: Return audit API release health and deployed commit metadata
+      security: []
+      responses:
+        '200':
+          description: Release health payload
+          headers:
+            cache-control:
+              schema: { type: string }
+              description: Always `no-store`.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [schemaVersion, status, service, commitSha, commit_sha, source]
+                properties:
+                  schemaVersion: { type: string, enum: [engineering-team-release-health.v1] }
+                  status: { type: string, enum: [ok, degraded] }
+                  service: { type: string, enum: [engineering-team-audit-api] }
+                  commitSha: { type: [string, 'null'] }
+                  commit_sha: { type: [string, 'null'] }
+                  source: { type: [string, 'null'] }
+        '405':
+          description: Method not allowed for release health reads
+    head:
+      summary: Return audit API release health headers without a body
+      security: []
+      responses:
+        '200':
+          description: Release health headers
+  /health:
+    get:
+      summary: Alias for audit API release health and deployed commit metadata
+      security: []
+      responses:
+        '200':
+          description: Release health payload; schema matches `/version`.
   /deferred-considerations:
     get:
       summary: List the PM Deferred Considerations review queue

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -58,6 +58,12 @@ Unready tasks return `422 task_not_execution_ready` with structured details. Mis
 
 Local forgeadapter Phase 2 smoke: see `docs/runbooks/forge-local-smoke.md` for seeding `TSK-LOCAL001`, file-backend audit-api bootstrap, and `FORGE_SERVICE_TOKEN` pairing with forgeadapter `ENGINEERING_TEAM_SERVICE_TOKEN`.
 
+## Release Health
+
+The coordinated audit API exposes unauthenticated, read-only release health at `/version`, `/api/version`, `/backend/version`, and `/health`. These routes return `engineering-team-release-health.v1`, `service=engineering-team-audit-api`, `status`, and both `commitSha` and `commit_sha` for the deployed audit API revision.
+
+Commit source order is explicit `releaseCommitSha`/`commitSha` options, coordinated-stack env vars (`ENGINEERING_TEAM_RELEASE_COMMIT_SHA`, `ENGINEERING_TEAM_COMMIT_SHA`, `RELEASE_COMMIT_SHA`, `COMMIT_SHA`, `GITHUB_SHA`), then `git rev-parse HEAD`. Strict hosted proof should require the health response to include the expected deployed commit and should use the coordinated stack endpoint, not Vercel or hosted Supabase.
+
 Autonomous delivery metrics are exposed behind `ff_autonomous_delivery_metrics_mvp`.
 PM, product-owner, SRE, and admin roles with `metrics:read` can read tenant metrics and task retrospective signals.
 Only admin role holders with `projections:rebuild` can rebuild the projection.

--- a/docs/runbooks/milestone-a-hosted-factory.md
+++ b/docs/runbooks/milestone-a-hosted-factory.md
@@ -33,11 +33,12 @@ Confirm:
 
 ```bash
 npm run dev:golden-path:status
+curl -s http://127.0.0.1:13000/version
 curl -s http://127.0.0.1:13000/metrics | grep workflow_projection_lag_seconds
 curl -s http://127.0.0.1:14010/health
 ```
 
-Workers log to `observability/golden-path-local-dev/logs/audit-workers.log`. State: `observability/golden-path-local-dev/stack.json`.
+`/version` exposes the audit API commit SHA used by strict release-health proof when the coordinated stack is promoted through a non-local operator/API endpoint. Workers log to `observability/golden-path-local-dev/logs/audit-workers.log`. State: `observability/golden-path-local-dev/stack.json`.
 
 Optional: enable continuous factory ticks when bringing the stack up:
 

--- a/lib/audit/http-projects.js
+++ b/lib/audit/http-projects.js
@@ -7,27 +7,32 @@ const { createAutonomousDeliveryMetricsRouteWrapper } = require('./autonomous-de
 const { createForgeExecutionReadinessRouteWrapper } = require('./forge-execution-http');
 const { createLiveTaskUpdatesRouteWrapper } = require('./live-task-updates-http');
 const { createProjectRouteWrapper } = require('./projects-http');
+const { createReleaseHealthRouteWrapper } = require('./release-health-http');
 const { createGitHubWebhookRouteWrapper } = require('./github-webhook-http');
 const { createGitLabWebhookRouteWrapper } = require('./gitlab-webhook-http');
 
 function createAuditApiServer(options = {}) {
-  return createGitLabWebhookRouteWrapper(
-    createGitHubWebhookRouteWrapper(
-    createAutonomousDeliveryMetricsRouteWrapper(
-      createLiveTaskUpdatesRouteWrapper(
-        createForgeExecutionReadinessRouteWrapper(
-          createProjectRouteWrapper(createBaseAuditApiServer(options), options, { getRequestContext }),
+  return createReleaseHealthRouteWrapper(
+    createGitLabWebhookRouteWrapper(
+      createGitHubWebhookRouteWrapper(
+        createAutonomousDeliveryMetricsRouteWrapper(
+          createLiveTaskUpdatesRouteWrapper(
+            createForgeExecutionReadinessRouteWrapper(
+              createProjectRouteWrapper(createBaseAuditApiServer(options), options, { getRequestContext }),
+              options,
+              { getRequestContext },
+            ),
+            options,
+            { getRequestContext },
+          ),
           options,
           { getRequestContext },
         ),
         options,
-        { getRequestContext },
+        { getRequestContext, createIntakeDraftFromWebhook },
       ),
       options,
-      { getRequestContext },
-    ),
-    options,
-    { getRequestContext, createIntakeDraftFromWebhook },
+      { getRequestContext, createIntakeDraftFromWebhook },
     ),
     options,
     { getRequestContext, createIntakeDraftFromWebhook },

--- a/lib/audit/release-health-http.js
+++ b/lib/audit/release-health-http.js
@@ -1,0 +1,127 @@
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+
+const RELEASE_HEALTH_SCHEMA_VERSION = 'engineering-team-release-health.v1';
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+
+function normalizeRoutePath(pathname) {
+  let path = pathname || '/';
+  for (const prefix of ['/api', '/backend']) {
+    if (path === prefix) return '/';
+    if (path.startsWith(`${prefix}/`)) path = path.slice(prefix.length) || '/';
+  }
+  return path || '/';
+}
+
+function isReleaseHealthRoute(path) {
+  return path === '/version' || path === '/health';
+}
+
+function normalizeCommitSha(value) {
+  const text = String(value || '').trim();
+  return COMMIT_SHA_PATTERN.test(text) ? text : '';
+}
+
+function commitShaFromEnv(env = process.env) {
+  const keys = [
+    'ENGINEERING_TEAM_RELEASE_COMMIT_SHA',
+    'ENGINEERING_TEAM_COMMIT_SHA',
+    'RELEASE_COMMIT_SHA',
+    'COMMIT_SHA',
+    'GITHUB_SHA',
+  ];
+  for (const key of keys) {
+    const commitSha = normalizeCommitSha(env[key]);
+    if (commitSha) return { commitSha, source: `env:${key}` };
+  }
+  return { commitSha: '', source: null };
+}
+
+function commitShaFromGit(cwd = process.cwd()) {
+  const result = spawnSync('git', ['rev-parse', 'HEAD'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 3000,
+  });
+  const commitSha = normalizeCommitSha(result.stdout);
+  return commitSha ? { commitSha, source: 'git:rev-parse HEAD' } : { commitSha: '', source: null };
+}
+
+function resolveReleaseCommitSha(options = {}, env = process.env) {
+  const explicit = normalizeCommitSha(options.releaseCommitSha || options.commitSha);
+  if (explicit) return { commitSha: explicit, source: 'options' };
+  const fromEnv = commitShaFromEnv(env);
+  if (fromEnv.commitSha) return fromEnv;
+  return commitShaFromGit(options.repoRoot || options.baseDir || process.cwd());
+}
+
+function buildReleaseHealthPayload(options = {}, env = process.env) {
+  const resolved = resolveReleaseCommitSha(options, env);
+  return {
+    schemaVersion: RELEASE_HEALTH_SCHEMA_VERSION,
+    status: resolved.commitSha ? 'ok' : 'degraded',
+    service: 'engineering-team-audit-api',
+    commitSha: resolved.commitSha || null,
+    commit_sha: resolved.commitSha || null,
+    source: resolved.source,
+  };
+}
+
+function sendJson(res, statusCode, payload, requestId, method = 'GET') {
+  if (res.writableEnded) return;
+  res.statusCode = statusCode;
+  res.setHeader('content-type', 'application/json; charset=utf-8');
+  res.setHeader('cache-control', 'no-store');
+  res.setHeader('x-request-id', requestId);
+  if (method === 'HEAD') return res.end();
+  return res.end(JSON.stringify(payload, null, 2));
+}
+
+function dispatchOriginal(server, listeners, req, res) {
+  for (const listener of listeners) {
+    const result = listener.call(server, req, res);
+    if (result && typeof result.catch === 'function') {
+      result.catch(error => {
+        if (!res.writableEnded) {
+          res.statusCode = 500;
+          res.end(JSON.stringify({ error: { code: 'internal_error', message: error.message } }));
+        }
+      });
+    }
+  }
+}
+
+function createReleaseHealthRouteWrapper(bundle, options = {}) {
+  const server = bundle.server;
+  const listeners = server.listeners('request');
+  const releaseHealthPayload = buildReleaseHealthPayload(options);
+  server.removeAllListeners('request');
+  server.on('request', (req, res) => {
+    const requestId = req.headers['x-request-id'] || crypto.randomUUID();
+    const url = new URL(req.url || '/', 'http://localhost');
+    if (!isReleaseHealthRoute(normalizeRoutePath(url.pathname))) {
+      return dispatchOriginal(server, listeners, req, res);
+    }
+    if (req.method === 'OPTIONS') return sendJson(res, 204, {}, requestId);
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      return sendJson(res, 405, {
+        error: {
+          code: 'method_not_allowed',
+          message: 'Method not allowed',
+          request_id: requestId,
+          requestId,
+        },
+      }, requestId, req.method);
+    }
+    return sendJson(res, 200, releaseHealthPayload, requestId, req.method);
+  });
+  return bundle;
+}
+
+module.exports = {
+  RELEASE_HEALTH_SCHEMA_VERSION,
+  buildReleaseHealthPayload,
+  createReleaseHealthRouteWrapper,
+  normalizeRoutePath,
+  resolveReleaseCommitSha,
+};

--- a/tests/contract/forge-execution-readiness.contract.test.js
+++ b/tests/contract/forge-execution-readiness.contract.test.js
@@ -5,7 +5,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { createAuditApiServer } = require('../../lib/audit/http-projects');
 
 test('audit foundation OpenAPI documents forge execution-readiness route and canonical task shape', () => {
   const root = path.join(__dirname, '../..');
@@ -33,5 +35,40 @@ test('audit foundation OpenAPI documents forge execution-readiness route and can
     'golden-path-phases.js',
   ]) {
     assert.match(platform, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: '',
+    writableEnded: false,
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+    },
+    end(chunk = '') {
+      this.body += String(chunk);
+      this.writableEnded = true;
+    },
+  };
+}
+
+test('audit foundation release health contract returns commit metadata without auth', () => {
+  const commitSha = 'abcdef1234567890abcdef1234567890abcdef12';
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-health-contract-'));
+  const { server } = createAuditApiServer({ baseDir, releaseCommitSha: commitSha });
+
+  for (const url of ['/version', '/api/version', '/backend/version', '/health']) {
+    const response = createResponseRecorder();
+    server.emit('request', { method: 'GET', url, headers: {} }, response);
+    assert.equal(response.statusCode, 200, url);
+    assert.equal(response.headers['cache-control'], 'no-store', url);
+    const body = JSON.parse(response.body);
+    assert.equal(body.schemaVersion, 'engineering-team-release-health.v1', url);
+    assert.equal(body.service, 'engineering-team-audit-api', url);
+    assert.equal(body.status, 'ok', url);
+    assert.equal(body.commitSha, commitSha, url);
+    assert.equal(body.commit_sha, commitSha, url);
   }
 });

--- a/tests/performance/audit-foundation.performance.test.js
+++ b/tests/performance/audit-foundation.performance.test.js
@@ -34,3 +34,18 @@ test('pollForgeExecutionReadiness stays within bounded retry budget', async () =
     global.fetch = originalFetch;
   }
 });
+
+const { buildReleaseHealthPayload } = require('../../lib/audit/release-health-http');
+
+test('release health payload construction stays within bounded read budget', () => {
+  const started = performance.now();
+  for (let index = 0; index < 500; index += 1) {
+    const payload = buildReleaseHealthPayload({
+      releaseCommitSha: 'abcdef1234567890abcdef1234567890abcdef12',
+    }, {});
+    assert.equal(payload.status, 'ok');
+    assert.equal(payload.service, 'engineering-team-audit-api');
+  }
+  const elapsed = performance.now() - started;
+  assert.ok(elapsed < 100, `release health payload budget exceeded: ${elapsed}ms`);
+});

--- a/tests/unit/audit-release-health-http.test.js
+++ b/tests/unit/audit-release-health-http.test.js
@@ -1,0 +1,80 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { createAuditApiServer } = require('../../lib/audit/http-projects');
+const {
+  RELEASE_HEALTH_SCHEMA_VERSION,
+  buildReleaseHealthPayload,
+} = require('../../lib/audit/release-health-http');
+
+const COMMIT_SHA = '3f4a7c9e12b84d6f90a1c2e3b4d5f6789012abcd';
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    headers: {},
+    body: '',
+    writableEnded: false,
+    setHeader(name, value) {
+      this.headers[String(name).toLowerCase()] = value;
+    },
+    end(chunk = '') {
+      this.body += String(chunk);
+      this.writableEnded = true;
+    },
+  };
+}
+
+function requestPath(pathname, options = {}) {
+  const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audit-release-health-'));
+  const { server } = createAuditApiServer({
+    baseDir,
+    releaseCommitSha: COMMIT_SHA,
+    ...options,
+  });
+  const response = createResponseRecorder();
+  server.emit('request', { method: 'GET', url: pathname, headers: {} }, response);
+  return response;
+}
+
+test('release health exposes commit-bearing /version without auth', async () => {
+  const response = requestPath('/version');
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers['cache-control'], 'no-store');
+
+  const body = JSON.parse(response.body);
+  assert.equal(body.schemaVersion, RELEASE_HEALTH_SCHEMA_VERSION);
+  assert.equal(body.status, 'ok');
+  assert.equal(body.service, 'engineering-team-audit-api');
+  assert.equal(body.commitSha, COMMIT_SHA);
+  assert.equal(body.commit_sha, COMMIT_SHA);
+});
+
+test('release health route works through API and backend proxy prefixes', async () => {
+  for (const pathname of ['/api/version', '/backend/version', '/health']) {
+    const response = requestPath(pathname);
+    assert.equal(response.statusCode, 200, pathname);
+    assert.equal(JSON.parse(response.body).commitSha, COMMIT_SHA, pathname);
+  }
+});
+
+test('release health payload prefers explicit commit and falls back to env', () => {
+  assert.deepEqual(
+    buildReleaseHealthPayload({ releaseCommitSha: COMMIT_SHA }, {}),
+    {
+      schemaVersion: RELEASE_HEALTH_SCHEMA_VERSION,
+      status: 'ok',
+      service: 'engineering-team-audit-api',
+      commitSha: COMMIT_SHA,
+      commit_sha: COMMIT_SHA,
+      source: 'options',
+    },
+  );
+
+  const envPayload = buildReleaseHealthPayload({}, { ENGINEERING_TEAM_COMMIT_SHA: COMMIT_SHA });
+  assert.equal(envPayload.status, 'ok');
+  assert.equal(envPayload.commitSha, COMMIT_SHA);
+  assert.equal(envPayload.source, 'env:ENGINEERING_TEAM_COMMIT_SHA');
+});


### PR DESCRIPTION
## Summary
- Add unauthenticated audit API release-health endpoints for `/version`, `/api/version`, `/backend/version`, and `/health`.
- Expose commit SHA from explicit options, coordinated-stack env vars, or `git rev-parse` for strict release-health proof.
- Document the coordinated-stack `/version` check in Milestone A without adding Vercel or hosted Supabase dependencies.

## Governance
- Task: Strict hosted real-delivery proof requires the coordinated audit API to expose deployed commit health.
- Standards baseline reviewed: Yes, release evidence, testing, observability, and change governance standards reviewed.
- Checklist completed or updated: Yes, PR governance fields are completed and the Milestone A runbook is updated.
- Compliance checklist path: docs/runbooks/milestone-a-hosted-factory.md
- Relevant standards areas: deployment and release, observability and monitoring, testing and quality assurance, change governance
- Standards gaps or exceptions: No standards exception requested; this keeps the release-health proof on the coordinated stack path.
- Standards check result: Not separately run in the proof worktree; full unit gate and `git diff --check` passed, and CI Repo validation is running standards checks.
- Lint result: `git diff --check` passed.
- Tests: `node --test tests/unit/audit-release-health-http.test.js tests/contract/forge-execution-readiness.contract.test.js tests/performance/audit-foundation.performance.test.js`; `npm run test:unit` passed in the clean proof worktree with sandbox escalation for existing localhost-binding tests.
- Test evidence paths: tests/unit/audit-release-health-http.test.js, tests/contract/forge-execution-readiness.contract.test.js, tests/performance/audit-foundation.performance.test.js
- Docs updated: Yes, Milestone A and audit-foundation docs describe the coordinated-stack release-health surface.
- Doc evidence paths: docs/runbooks/milestone-a-hosted-factory.md, docs/runbooks/audit-foundation.md, docs/api/audit-foundation-openapi.yml
- Risk level: Low, additive unauthenticated health/readiness endpoint returning commit metadata only.
- Rollback path: Revert this PR's merge commit to remove the release-health wrapper and runbook/test additions.

## Verification
- `NODE_PATH=/Users/wiinc2/.openclaw/workspace/engineering-team/node_modules NODE_ENV=test node --test tests/unit/audit-release-health-http.test.js`
- `NODE_PATH=/Users/wiinc2/.openclaw/workspace/engineering-team/node_modules NODE_ENV=test node --test tests/unit/audit-release-health-http.test.js tests/contract/forge-execution-readiness.contract.test.js tests/performance/audit-foundation.performance.test.js`
- `PATH=/Users/wiinc2/.openclaw/workspace/engineering-team/node_modules/.bin:$PATH NODE_PATH=/Users/wiinc2/.openclaw/workspace/engineering-team/node_modules NODE_ENV=test npm run test:unit`

Note: the full unit gate needed sandbox escalation because existing tests bind `127.0.0.1` and the sandbox returned `listen EPERM`.
