### PR TITLE
test: cover release health method semantics

### DIFF
--- a/docs/api/audit-foundation-openapi.yml
+++ b/docs/api/audit-foundation-openapi.yml
@@ -1136,12 +1136,20 @@ paths:
                   source: { type: [string, 'null'] }
         '405':
           description: Method not allowed for release health reads
+          headers:
+            cache-control:
+              schema: { type: string }
+              description: Always `no-store`.
     head:
       summary: Return audit API release health headers without a body
       security: []
       responses:
         '200':
           description: Release health headers
+          headers:
+            cache-control:
+              schema: { type: string }
+              description: Always `no-store`.
   /health:
     get:
       summary: Alias for audit API release health and deployed commit metadata

--- a/docs/runbooks/audit-foundation.md
+++ b/docs/runbooks/audit-foundation.md
@@ -62,6 +62,8 @@ Local forgeadapter Phase 2 smoke: see `docs/runbooks/forge-local-smoke.md` for s
 
 The coordinated audit API exposes unauthenticated, read-only release health at `/version`, `/api/version`, `/backend/version`, and `/health`. These routes return `engineering-team-release-health.v1`, `service=engineering-team-audit-api`, `status`, and both `commitSha` and `commit_sha` for the deployed audit API revision.
 
+Release-health reads support `GET` and bodyless `HEAD`; unsupported methods return `405 method_not_allowed`. Responses set `cache-control: no-store` so strict delivery checks always read the current coordinated-stack revision.
+
 Commit source order is explicit `releaseCommitSha`/`commitSha` options, coordinated-stack env vars (`ENGINEERING_TEAM_RELEASE_COMMIT_SHA`, `ENGINEERING_TEAM_COMMIT_SHA`, `RELEASE_COMMIT_SHA`, `COMMIT_SHA`, `GITHUB_SHA`), then `git rev-parse HEAD`. Strict hosted proof should require the health response to include the expected deployed commit and should use the coordinated stack endpoint, not Vercel or hosted Supabase.
 
 Autonomous delivery metrics are exposed behind `ff_autonomous_delivery_metrics_mvp`.

--- a/tests/unit/audit-release-health-http.test.js
+++ b/tests/unit/audit-release-health-http.test.js
@@ -35,7 +35,7 @@ function requestPath(pathname, options = {}) {
     ...options,
   });
   const response = createResponseRecorder();
-  server.emit('request', { method: 'GET', url: pathname, headers: {} }, response);
+  server.emit('request', { method: options.method || 'GET', url: pathname, headers: {} }, response);
   return response;
 }
 
@@ -50,6 +50,22 @@ test('release health exposes commit-bearing /version without auth', async () => 
   assert.equal(body.service, 'engineering-team-audit-api');
   assert.equal(body.commitSha, COMMIT_SHA);
   assert.equal(body.commit_sha, COMMIT_SHA);
+});
+
+test('release health supports HEAD /version without a body', async () => {
+  const response = requestPath('/version', { method: 'HEAD' });
+  assert.equal(response.statusCode, 200);
+  assert.equal(response.headers['cache-control'], 'no-store');
+  assert.equal(response.body, '');
+});
+
+test('release health rejects unsupported methods with method_not_allowed', async () => {
+  const response = requestPath('/version', { method: 'POST' });
+  assert.equal(response.statusCode, 405);
+  assert.equal(response.headers['cache-control'], 'no-store');
+
+  const body = JSON.parse(response.body);
+  assert.equal(body.error.code, 'method_not_allowed');
 });
 
 test('release health route works through API and backend proxy prefixes', async () => {


### PR DESCRIPTION
## Linked Task
- Task: Strict hosted real-delivery proof follow-up for coordinated audit API release-health evidence.

## Summary
- adds release-health unit coverage for `HEAD /version` empty-body behavior
- adds `method_not_allowed` coverage for unsupported `/version` methods
- documents release-health method semantics for coordinated-stack proof

## OpenClaw implementer evidence
- OpenClaw agent: `sr-engineer`
- Patch-author session: `real-delivery-proof-20260707-patch-author-2`
- Persistence probe session: `real-delivery-proof-20260707-write-probe`
- Integration note: OpenClaw authored the patch intent; Codex applied the equivalent context-correct patch after OpenClaw direct `apply_patch` attempts timed out without a persisted diff.

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: testing, release evidence, coordinated-stack operator runbooks
- Standards gaps or exceptions: Gap observed: this PR strengthens local release-health proof only; hosted deployment health still requires a real non-local coordinated-stack endpoint. Documented rationale: Vercel and hosted Supabase are outside this factory delivery path.

## Required Evidence
- Standards check result: pending GitHub Repo validation
- Lint result: pending GitHub Repo validation
- Tests: `node --test tests/unit/audit-release-health-http.test.js`
- Test evidence paths: tests/unit/audit-release-health-http.test.js
- Docs updated: docs/runbooks/audit-foundation.md; docs/api/audit-foundation-openapi.yml
- Doc evidence paths: docs/runbooks/audit-foundation.md, docs/api/audit-foundation-openapi.yml

## Risk and Rollback
- Risk level: low
- Rollback path: revert PR #295 or revert commits `e62caf189879dfb5fc81f351700576396015f48c` and `186e920`
