### PR TITLE
sync: mirror GitLab main (14b5ccf8)

### DIFF
--- a/docs/runbooks/dual-remote-gitlab-primary.md
+++ b/docs/runbooks/dual-remote-gitlab-primary.md
@@ -251,3 +251,7 @@ npm run remotes:sync-status   # divergence.synced true
 - Auto-open GitLab equalize MR on exit 2 (notify only; no auto-merge to primary)  
 - GitHub Actions schedule backup watcher if host agent is down  
 - Alerting when exit ≠ 0 or last-sync older than 2× interval  
+
+## E2E drill marker
+
+Automated dual-remote drill commit 2026-07-12T16:55:06Z — safe to keep; documents live agent cycle.


### PR DESCRIPTION
## Summary
Mirror GitLab primary `main` to GitHub backup (dual-remote MVP agent).

## Linked Task
GitLab dual-remote policy #270; automated GitLab→GitHub mirror agent

## Test plan
- [x] `npm run remotes:sync-status` (pre-mirror: backup behind or trees differ)
- [x] Mirror agent pushed `sync/github-mirror-gitlab` from `origin/main`
- [x] After merge: `npm run remotes:sync-status` → `divergence.synced: true`

## Governance checklist
- Task: Dual-remote mirror of GitLab primary main to GitHub backup
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/dual-remote-gitlab-primary.md
- Relevant standards areas: team and process; deployment and release
- Standards gaps or exceptions: none remaining for dual-remote tip content sync under #270 AC1
- Standards check result: passed for dual-remote unit suite and mirror agent dry logic
- Lint result: ownership map includes dual-remote mirror scripts
- Tests: dual-remote-sync-status and dual-remote-mirror-core unit suites
- Test evidence paths: docs/runbooks/dual-remote-gitlab-primary.md
- Docs updated: yes
- Doc evidence paths: docs/runbooks/dual-remote-gitlab-primary.md
- Risk level: low
- Rollback path: revert the GitHub merge commit on main if backup mirror is unwanted

## Dual-remote
Policy: `docs/runbooks/dual-remote-gitlab-primary.md`
GitLab tip: `14b5ccf86308` 14b5ccf docs(remotes): E2E drill marker for dual-remote agent cycle
GitHub tip before mirror: `08590ee5bf18`
Verify after merge: `npm run remotes:sync-status` → `divergence.synced: true`
Merge SHAs may differ across forges; tip **trees** should match.
