### PR TITLE
sync: mirror GitLab main (4901abe3)

### DIFF
--- a/docs/runbooks/dual-remote-gitlab-primary.md
+++ b/docs/runbooks/dual-remote-gitlab-primary.md
@@ -239,6 +239,17 @@ cat observability/dual-remote/last-sync.json
 npm run remotes:sync-status   # divergence.synced true
 ```
 
+**Proven (2026-07-12):** Full CLI `node scripts/dual-remote-mirror-github.js --merge-when-ready` with primary tip ahead of GitHub backup:
+
+1. Preflight maintainability + ownership green (ops split under baseline)  
+2. Waited for required Actions checks  
+3. Posted **Merge readiness** on head (does not require rollup visibility)  
+4. Merged GitHub PR **#306** without a human  
+5. `last-sync` → `action: mirror_merged_synced`, `exitCode: 0`, tip **trees equal**  
+6. Next poll → `noop_synced`  
+
+Ship order stays **GitLab primary first**. If GitHub is ever ahead (emergency path or drill), equalize into GitLab (`sync/gitlab-primary-main` MR) before treating backup as canonical. Never force-push protected `github/main`.
+
 ### Single-flight + locks
 
 - Lock file: `observability/dual-remote/mirror.lock`  


### PR DESCRIPTION
## Summary
Mirror GitLab primary `main` to GitHub backup (dual-remote MVP agent).

## Linked Task
GitLab dual-remote policy #270; automated GitLab→GitHub mirror agent

## Test plan
- [x] `npm run remotes:sync-status` (pre-mirror: backup behind or trees differ)
- [x] Mirror agent pushed `sync/github-mirror-gitlab` from `origin/main`
- [x] After merge: `npm run remotes:sync-status` → `divergence.synced: true`

## Governance checklist
- Task: Dual-remote mirror of GitLab primary main to GitHub backup
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/dual-remote-gitlab-primary.md
- Relevant standards areas: team and process; deployment and release
- Standards gaps or exceptions: none remaining for dual-remote tip content sync under #270 AC1
- Standards check result: passed for dual-remote unit suite and mirror agent dry logic
- Lint result: ownership map includes dual-remote mirror scripts
- Tests: dual-remote-sync-status and dual-remote-mirror-core unit suites
- Test evidence paths: docs/runbooks/dual-remote-gitlab-primary.md
- Docs updated: yes
- Doc evidence paths: docs/runbooks/dual-remote-gitlab-primary.md
- Risk level: low
- Rollback path: revert the GitHub merge commit on main if backup mirror is unwanted

## Dual-remote
Policy: `docs/runbooks/dual-remote-gitlab-primary.md`
GitLab tip: `4901abe39762` 4901abe Merge branch 'sync/equalize-after-309' into 'main'
GitHub tip before mirror: `e49fa5213d09`
Verify after merge: `npm run remotes:sync-status` → `divergence.synced: true`
Merge SHAs may differ across forges; tip **trees** should match.
