### PR TITLE
fix(security): refresh runtime dependencies and PR metadata fallback

### DIFF
--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -24,7 +24,7 @@ Require this job if governance drift is treated as blocking in your environment:
 - Restrict direct pushes to the protected branch.
 
 ## Mapping To Workflow Files
-- `Pull request metadata` in `.github/workflows/validation.yml` runs `npm run pr:check`, `npm run change:check`, and `npm run ownership:lint`.
+- `Pull request metadata` in `.github/workflows/validation.yml` runs `npm run pr:check`, `npm run change:check`, and `npm run ownership:lint`. The job has read-only pull-request permission and exports its ephemeral `GITHUB_TOKEN` so `verify-pr-body.js` can live-fetch the current body when the event payload is stale or empty.
 - `Repo validation` in `.github/workflows/validation.yml` runs `npm run coverage`, `npm run standards:check`, `npm run ownership:lint`, `npm run test:unit`, and the non-browser Node suites.
 - `Browser validation` in `.github/workflows/validation.yml` runs `npm run test:browser`.
 - `verify` in `.github/workflows/verify.yml` runs `make verify`, which aggregates DESIGN.md gates, standards policy validators, `npm run lint`, `npm run typecheck`, `npm run test:unit`, `npm run test:browser`, `npm run build`, `npm run standards:check`, and artifact validators.

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   pull-request-metadata:
     name: Pull request metadata
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -141,6 +141,11 @@ make verify
 | `make verify` | `verify` in `.github/workflows/verify.yml` |
 | `npm run governance:drift:check` | `Governance drift report` in `.github/workflows/governance-drift.yml` |
 
+The pull-request metadata job has read-only pull-request permission and exports
+the ephemeral GitHub Actions token to `scripts/verify-pr-body.js`. This lets the
+validator fetch the current pull-request body when a rerun receives a stale or
+empty event payload, without granting write access.
+
 Read `DESIGN.md` before UI changes, change reusable visual semantics there
 first, and avoid hard-coded visual values in migrated CSS. A rare one-off must
 use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4528,9 +4528,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5447,9 +5447,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Refreshes two vulnerable production transitive dependencies discovered by the GitLab protected-branch pipeline and makes GitHub’s PR metadata check reliably live-fetch the current PR body.

- `fast-uri`: 3.1.4 → 3.1.5
- `js-yaml`: 4.3.0 → 4.3.1
- Grants the validation workflow read-only PR access and exports its ephemeral `GITHUB_TOKEN` to the metadata job.
- Documents the least-privilege live-body fallback in the branch-protection guide and canonical operator runbook.

No direct dependency ranges or application runtime code change.

## Root Cause

GitLab MR !323 correctly blocked on `npm audit --omit=dev` because the existing lockfile resolved versions affected by high-severity advisories. Separately, GitHub’s metadata script supports fetching the current PR body, but the workflow did not expose its token, so reruns could fall back to an empty or stale event body.

## Linked Task
- Task: Synchronize GitHub PR #312 to protected GitLab `main`, resolve the production dependency audit gate, and make PR metadata validation deterministic.

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: `.github/PULL_REQUEST_TEMPLATE.md`
- Relevant standards areas: security and compliance, dependency integrity, testing and quality assurance, delivery governance
- Standards gaps or exceptions: No exception. The local GitLab graph renderer was unavailable because `glci` is not installed; hosted GitLab parsed the pipeline successfully.

## Required Evidence
- Standards check result: `make standards-policy-gates` passed for the final four-file diff against GitHub `main`.
- Lint result: `npm run lint` passed.
- Tests: `npm audit --omit=dev`, `npm run security:sbom`, `npm run lint`, `npm run typecheck`, `npm run build`, and `node --test tests/unit/governance/verify-pr-body.test.js` passed.
- Test evidence paths: `package-lock.json`, `.github/workflows/validation.yml`
- Docs updated: yes
- Doc evidence paths: `.github/BRANCH_PROTECTION.md`, `docs/runbook.md`

## Risk and Rollback
- Risk level: high
- Rollback path: Revert the security/CI follow-up commits; reverting the lockfile update intentionally restores the production audit failure, while reverting the workflow update restores event-payload-only metadata behavior.

## Notes

The GitLab failure was a runtime security-gate failure in the build job, not a CI configuration error. The production audit now reports zero vulnerabilities. The GitHub workflow permission remains read-only.