### PR TITLE
fix(docs): remove ADR trailing whitespace

### DIFF
--- a/docs/adr/ADD-2026-03-30-team-setup.md
+++ b/docs/adr/ADD-2026-03-30-team-setup.md
@@ -1,7 +1,7 @@
 # Architecture Decision Record: Team Engineering Setup
 
-**Date:** 2026-03-30  
-**Status:** Accepted  
+**Date:** 2026-03-30
+**Status:** Accepted
 **Deciders:** Human (wiinc1), Architect (Bran)
 
 ## Context
@@ -46,11 +46,11 @@ All significant decisions are documented in Architecture Decision Records (ADRs)
 ## Alternatives Considered
 
 ### Alternative 1: Flat team, all PRs reviewed by all
-**Decision:** Rejected  
+**Decision:** Rejected
 **Trade-offs:** Too chaotic, no clear ownership, decision fatigue
 
 ### Alternative 2: Only human review required
-**Decision:** Rejected  
+**Decision:** Rejected
 **Trade-offs:** Bottlenecks on human time, agents can't self-govern
 
 ## Related Decisions


### PR DESCRIPTION
## Summary

Removes four legacy trailing-space sequences from the team setup ADR.

This is a documentation-only correction required by GitLab’s final `git diff --check` reconciliation gate. All runtime, security, load, browser, coverage, and standards assertions completed successfully before that gate identified the whitespace.

## Linked Task
- Task: Complete the GitHub-to-GitLab protected-main synchronization after PR #313.

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: `.github/PULL_REQUEST_TEMPLATE.md`
- Relevant standards areas: documentation quality and delivery governance
- Standards gaps or exceptions: No gaps or exceptions; rationale: this changes only legacy Markdown whitespace identified by the existing merge gate.

## Required Evidence
- Standards check result: Prior GitHub PR #313 and post-merge standards checks passed; this branch changes Markdown whitespace only.
- Lint result: Not applicable to Markdown-only whitespace cleanup.
- Tests: `git diff --check` passed for the local change and for the complete GitLab-main-to-branch diff.
- Test evidence paths: `docs/adr/ADD-2026-03-30-team-setup.md`
- Docs updated: yes
- Doc evidence paths: `docs/adr/ADD-2026-03-30-team-setup.md`

## Risk and Rollback
- Risk level: low
- Rollback path: Revert commit `fbff2da`; doing so would restore the GitLab reconciliation failure.

## Notes

No prose, application code, dependency, workflow, or policy semantics change.