### PR TITLE
fix(factory): report stale launchd checkout paths

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,9 @@ The stack stores that binding outside repository worktrees, records it as
 conflicting checkouts. Moving the factory of record requires the explicit
 `factory:stack:* -- --rebind-root` operator action; staging uses separate labels
 and ports instead of replacing this binding.
+Stack health includes configuration integrity: installed launchd definitions
+must reference existing paths and agree with the canonical root even when an old
+process is still temporarily responding.
 
 ## Runtime Model
 

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -158,6 +158,9 @@ the canonical checkout in `~/Library/Application Support/engineering-team-factor
 Commands from `/tmp`, `/private/tmp`, managed `_checkouts`, or a different checkout
 fail before changing launchd. To deliberately move the factory of record, run
 `npm run factory:stack:restart -- --rebind-root` from the intended canonical checkout.
+`factory:stack:status` also inspects every installed plist and reports stale
+working directories, executable arguments, root metadata, and ForgeAdapter
+repository bindings with the canonical restart remediation.
 
 | Service | LaunchAgent label | Port / role |
 | --- | --- | --- |

--- a/lib/task-platform/factory-stack/launchd.js
+++ b/lib/task-platform/factory-stack/launchd.js
@@ -16,6 +16,7 @@ const {
   buildUiEnv,
   buildForgeadapterEnv,
 } = require('./defaults');
+const { inspectLaunchdPlist } = require('./plist-diagnostics');
 
 function escapeXml(value) {
   return String(value)
@@ -336,6 +337,7 @@ function launchdStatus() {
       pid: loaded.pid,
       plist: plistPath(label),
       plistExists: fs.existsSync(plistPath(label)),
+      configuration: inspectLaunchdPlist(plistPath(label)),
     };
   }
   return status;
@@ -353,5 +355,6 @@ module.exports = {
   writeServiceEnv,
   writeServicePlists,
   serviceLoaded,
+  inspectLaunchdPlist,
   allLabels,
 };

--- a/lib/task-platform/factory-stack/plist-diagnostics.js
+++ b/lib/task-platform/factory-stack/plist-diagnostics.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { ROOT } = require('./defaults');
+
+function decodeXml(value = '') {
+  return String(value)
+    .replace(/&apos;/g, "'").replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>').replace(/&lt;/g, '<').replace(/&amp;/g, '&');
+}
+
+function plistStringForKey(xml, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = xml.match(new RegExp(`<key>${escaped}<\\/key>\\s*<string>([\\s\\S]*?)<\\/string>`));
+  return match ? decodeXml(match[1]) : null;
+}
+
+function plistArrayForKey(xml, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = xml.match(new RegExp(`<key>${escaped}<\\/key>\\s*<array>([\\s\\S]*?)<\\/array>`));
+  if (!match) return [];
+  return [...match[1].matchAll(/<string>([\s\S]*?)<\/string>/g)].map((entry) => decodeXml(entry[1]));
+}
+
+function temporaryPath(candidate) {
+  const normalized = path.resolve(candidate);
+  return normalized === '/tmp' || normalized.startsWith('/tmp/')
+    || normalized === '/private/tmp' || normalized.startsWith('/private/tmp/')
+    || normalized.split(path.sep).includes('_checkouts');
+}
+
+function boundPaths(xml) {
+  const workingDirectory = plistStringForKey(xml, 'WorkingDirectory');
+  const configuredRoot = plistStringForKey(xml, 'FACTORY_STACK_REPO_ROOT');
+  const programArgs = plistArrayForKey(xml, 'ProgramArguments');
+  const paths = [workingDirectory, ...programArgs.filter((entry) => path.isAbsolute(entry))].filter(Boolean);
+  let repoBindingRoot = null;
+  try {
+    const bindings = JSON.parse(plistStringForKey(xml, 'FORGEADAPTER_REPO_BINDINGS') || '{}');
+    repoBindingRoot = bindings['wiinc1/engineering-team']?.repoPath || null;
+    if (repoBindingRoot) paths.push(repoBindingRoot);
+  } catch {
+    return { workingDirectory, configuredRoot, repoBindingRoot, paths, invalidRepoBindings: true };
+  }
+  return { workingDirectory, configuredRoot, repoBindingRoot, paths, invalidRepoBindings: false };
+}
+
+function inspectLaunchdPlist(plistFile, { expectedRoot = ROOT } = {}) {
+  const remediation = 'Run npm run factory:stack:restart from the canonical checkout.';
+  if (!fs.existsSync(plistFile)) {
+    return { ok: false, expectedRoot, stalePaths: [plistFile], reasons: ['plist_missing'], remediation };
+  }
+  const values = boundPaths(fs.readFileSync(plistFile, 'utf8'));
+  const stalePaths = [...new Set(values.paths.filter((entry) => temporaryPath(entry) || !fs.existsSync(entry)))];
+  const reasons = [];
+  if (values.workingDirectory && path.resolve(values.workingDirectory) !== path.resolve(expectedRoot)
+    && values.workingDirectory.includes('engineering-team')) reasons.push('working_directory_conflict');
+  if (values.configuredRoot && path.resolve(values.configuredRoot) !== path.resolve(expectedRoot)) reasons.push('bound_root_conflict');
+  if (values.repoBindingRoot && path.resolve(values.repoBindingRoot) !== path.resolve(expectedRoot)) reasons.push('forgeadapter_repo_binding_conflict');
+  if (values.invalidRepoBindings) reasons.push('forgeadapter_repo_bindings_invalid');
+  if (stalePaths.length) reasons.push('stale_or_temporary_path');
+  return {
+    ok: reasons.length === 0,
+    expectedRoot,
+    configuredRoot: values.configuredRoot,
+    workingDirectory: values.workingDirectory,
+    repoBindingRoot: values.repoBindingRoot,
+    stalePaths,
+    reasons: [...new Set(reasons)],
+    remediation: reasons.length ? remediation : null,
+  };
+}
+
+module.exports = { inspectLaunchdPlist, plistArrayForKey, plistStringForKey, temporaryPath };

--- a/scripts/factory-stack.js
+++ b/scripts/factory-stack.js
@@ -230,7 +230,8 @@ async function cmdStatus(options) {
     ok: health.ok === true
       && launchd.api.loaded === true
       && launchd.workers.loaded === true
-      && launchd.postgresEnsure.loaded === true,
+      && launchd.postgresEnsure.loaded === true
+      && Object.values(launchd).every((service) => service.plistExists !== true || service.configuration?.ok === true),
     action: 'status',
     ports: DEFAULT_PORTS,
     openclawUrl: defaultOpenclawUrl(),

--- a/tests/contract/factory-stack-root-binding.contract.test.js
+++ b/tests/contract/factory-stack-root-binding.contract.test.js
@@ -10,7 +10,11 @@ const {
   assertPersistentRepoRoot,
   buildServiceEnv,
 } = require('../../lib/task-platform/factory-stack/defaults');
-const { buildServiceSpecs } = require('../../lib/task-platform/factory-stack/launchd');
+const {
+  buildPlist,
+  buildServiceSpecs,
+  inspectLaunchdPlist,
+} = require('../../lib/task-platform/factory-stack/launchd');
 
 it('keeps every persistent service spec on the bound canonical checkout', () => {
   const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-stack-contract-'));
@@ -27,4 +31,18 @@ it('keeps every persistent service spec on the bound canonical checkout', () => 
       assert.ok(argument.startsWith(`${binding.repoRoot}${path.sep}`), `${spec.key} escapes canonical root`);
     }
   }
+});
+
+it('accepts a canonical generated plist as configuration evidence', () => {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-stack-plist-contract-'));
+  const plist = path.join(fixture, 'api.plist');
+  fs.writeFileSync(plist, buildPlist({
+    label: 'com.engineering-team.factory-audit-api',
+    programArgs: [process.execPath, path.join(ROOT, 'scripts', 'run-audit-api.js')],
+    env: buildServiceEnv(),
+    stdoutLog: path.join(fixture, 'out.log'),
+    stderrLog: path.join(fixture, 'err.log'),
+    workingDirectory: ROOT,
+  }));
+  assert.equal(inspectLaunchdPlist(plist).ok, true);
 });

--- a/tests/unit/factory-stack-service.test.js
+++ b/tests/unit/factory-stack-service.test.js
@@ -6,6 +6,7 @@ const os = require('node:os');
 const {
   buildPlist,
   buildServiceSpecs,
+  inspectLaunchdPlist,
 } = require('../../lib/task-platform/factory-stack/launchd');
 const {
   buildServiceEnv,
@@ -108,6 +109,24 @@ describe('factory-stack launchd plist', () => {
     assert.deepEqual(keys.filter((k) => k !== 'forgeadapter'), ['postgresEnsure', 'api', 'workers', 'ui']);
     assert.equal(skipped.forgeadapter, true);
     assert.ok(specs.find((s) => s.key === 'postgresEnsure').programArgs.some((a) => String(a).includes('factory-stack-postgres-watch')));
+  });
+
+  it('reports stale temporary checkout paths with remediation', () => {
+    const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-plist-status-'));
+    const plist = path.join(fixture, 'stale.plist');
+    fs.writeFileSync(plist, buildPlist({
+      label: LABELS.api,
+      programArgs: ['/usr/bin/node', '/private/tmp/engineering-team-staging/scripts/run-audit-api.js'],
+      env: { FACTORY_STACK_REPO_ROOT: '/private/tmp/engineering-team-staging' },
+      stdoutLog: path.join(fixture, 'out.log'),
+      stderrLog: path.join(fixture, 'err.log'),
+      workingDirectory: '/private/tmp/engineering-team-staging',
+    }));
+    const result = inspectLaunchdPlist(plist, { expectedRoot: ROOT });
+    assert.equal(result.ok, false);
+    assert.ok(result.reasons.includes('bound_root_conflict'));
+    assert.ok(result.reasons.includes('stale_or_temporary_path'));
+    assert.match(result.remediation, /factory:stack:restart/);
   });
 });
 


### PR DESCRIPTION
## Summary

Expose deleted, temporary, and conflicting checkout paths in factory stack status, with a canonical restart remediation.

## Linked Task
- Task: GitHub #317, Simple

## Standards Compliance
- Standards baseline reviewed: yes, docs/standards/software-development-standards.md
- Checklist completed or updated: yes, scoped Simple-task review
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: reliability, observability, testing, rollback safety
- Standards gaps or exceptions: no known exceptions

## Required Evidence
- Standards check result: npm run standards:check passed locally
- Lint result: npm run lint passed locally
- Tests: 15 focused unit and contract tests passed
- Test evidence paths: tests/unit/factory-stack-service.test.js, tests/contract/factory-stack-root-binding.contract.test.js
- Docs updated: launchd status contract and operator recovery guidance
- Doc evidence paths: docs/architecture.md, docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: low; read-only plist diagnostics added to status
- Rollback path: revert this PR; existing launchd generation and service lifecycle remain unchanged

## Notes

The status command now fails closed when installed plists are stale, and identifies the exact paths and reason codes that must be repaired.

Closes #317