### PR TITLE
feat(factory): version trusted cohort evidence prospectively

### DIFF
--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -574,6 +574,7 @@
             "^tests/unit/audit-release-health-http\\.test\\.js$",
             "^tests/unit/governance/(check-secrets|source-integrity)\\.test\\.js$",
             "^tests/unit/trusted-simple-close-evidence\\.test\\.js$",
+            "^tests/unit/simple-trusted-cohort\\.test\\.js$",
             "^tests/unit/forge-claim-policy\\.test\\.js$"
           ]
         },
@@ -581,6 +582,7 @@
           "name": "integration",
           "patterns": [
             "^tests/contract/factory-stack-root-binding\\.contract\\.test\\.js$",
+            "^tests/contract/simple-trusted-cohort-v2\\.contract\\.test\\.js$",
             "^tests/contract/forge-execution-readiness\\.contract\\.test\\.js$",
             "^tests/integration/forge-local-smoke-seed\\.integration\\.test\\.js$",
             "^tests/unit/projection-catch-up\\.test\\.js$",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -192,3 +192,6 @@ Use `docs/runbook.md` for exact operator commands. At the architecture level:
 - Governance runtime workflow: `docs/diagrams/workflow-governance-runtime-gates.mmd`
 - Governance runtime architecture: `docs/diagrams/architecture-governance-runtime-gates.mmd`
 - Existing domain diagrams: `docs/diagrams/`
+### Prospective trusted Simple cohort policy
+
+`simple-trusted-cohort.v2` applies to closeouts generated on or after 2026-08-19. Earlier evidence keeps its v1 evaluation. A v2 closeout is trusted only when it points to a repository-contained `trusted-simple-close-evidence.v1` package by relative path and SHA-256; the package must validate as a real merged PR and carry the same task id. This makes the cohort reproducible without rewriting historical decisions.

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -1144,3 +1144,6 @@ Operator checklist: `docs/runbooks/milestone-a-hosted-factory.md`.
 - `../forgeadapter/docs/runbooks/phase2-local-smoke.md` — forge local stack
 - `docs/architecture/openclaw-forge-delivery-architecture.md` — target architecture
 - `prd/software-factory.md` — full factory vision
+### Record a prospective v2 trusted close
+
+For closeouts generated on or after 2026-08-19, write the validated trusted-close package beneath `observability/trusted-simple-close/`, calculate its SHA-256, and record both as `trustedSimpleCloseEvidence.path` and `trustedSimpleCloseEvidence.sha256` in the task closeout. The path must stay inside the repository and the evidence package `taskId` must match the closeout. Missing, changed, invalid, or cross-task evidence is reported as untrusted; do not edit the effective date or grandfather a new task.

--- a/lib/task-platform/simple-trusted-cohort.js
+++ b/lib/task-platform/simple-trusted-cohort.js
@@ -7,9 +7,13 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const crypto = require('node:crypto');
 const { aggregateAutonomousDeliveryMetrics } = require('../audit/autonomous-delivery-metrics-aggregate');
+const { assertTrustedSimpleCloseEvidence } = require('./trusted-simple-close-evidence');
 
-const COHORT_POLICY_VERSION = 'simple-trusted-cohort.v1';
+const LEGACY_COHORT_POLICY_VERSION = 'simple-trusted-cohort.v1';
+const COHORT_POLICY_VERSION = 'simple-trusted-cohort.v2';
+const COHORT_V2_EFFECTIVE_AT = '2026-08-19T00:00:00.000Z';
 const DEFAULT_BAR = Object.freeze({
   minTrustedCloses: 10,
   minAutonomousRate: 0.8,
@@ -61,20 +65,68 @@ function listJsonFiles(dir) {
   return out;
 }
 
-function loadCloseouts(closeoutDir) {
+function evidenceReference(doc) {
+  return doc.trustedSimpleCloseEvidence || doc.trustedCloseEvidence || null;
+}
+
+function loadTrustedEvidenceReference(doc, { root, taskId }) {
+  const reference = evidenceReference(doc);
+  if (!reference) return { provided: false, valid: false, reasons: ['missing_trusted_close_evidence_reference'] };
+  const relativePath = reference.path || reference.filePath;
+  const expectedSha256 = String(reference.sha256 || reference.digest || '').toLowerCase();
+  const reasons = [];
+  if (!relativePath) reasons.push('missing_trusted_close_evidence_path');
+  if (!/^[a-f0-9]{64}$/.test(expectedSha256)) reasons.push('invalid_trusted_close_evidence_sha256');
+  if (reasons.length) return { provided: true, valid: false, path: relativePath || null, reasons };
+
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, relativePath);
+  if (resolvedPath !== resolvedRoot && !resolvedPath.startsWith(`${resolvedRoot}${path.sep}`)) {
+    return { provided: true, valid: false, path: relativePath, reasons: ['trusted_close_evidence_outside_repository'] };
+  }
+  if (!fs.existsSync(resolvedPath)) {
+    return { provided: true, valid: false, path: relativePath, reasons: ['trusted_close_evidence_missing'] };
+  }
+
+  const body = fs.readFileSync(resolvedPath);
+  const actualSha256 = crypto.createHash('sha256').update(body).digest('hex');
+  if (actualSha256 !== expectedSha256) reasons.push('trusted_close_evidence_digest_mismatch');
+  let evidence = null;
+  try {
+    evidence = JSON.parse(body.toString('utf8'));
+    assertTrustedSimpleCloseEvidence(evidence);
+  } catch {
+    reasons.push('trusted_close_evidence_invalid');
+  }
+  if (evidence && evidence.taskId !== taskId) reasons.push('trusted_close_evidence_task_mismatch');
+  return {
+    provided: true,
+    valid: reasons.length === 0,
+    path: relativePath,
+    sha256: actualSha256,
+    prUrl: evidence?.prUrl || evidence?.github?.prUrl || null,
+    mergeCommitSha: evidence?.mergeCommitSha || evidence?.github?.mergeCommitSha || null,
+    reasons: [...new Set(reasons)],
+  };
+}
+
+function loadCloseouts(closeoutDir, { root = process.cwd() } = {}) {
   return listJsonFiles(closeoutDir)
     .filter((p) => /TSK-\d+\.json$/i.test(path.basename(p)))
     .map((filePath) => {
       const doc = readJson(filePath);
+      const taskId = doc.taskId || doc.task_id || path.basename(filePath, '.json');
       return {
         filePath,
-        taskId: doc.taskId || doc.task_id || path.basename(filePath, '.json'),
+        taskId,
         deliveryStatus: doc.deliveryStatus || doc.status || null,
         generatedAt: doc.generatedAt || null,
         manualInterventions: Array.isArray(doc.manualInterventions) ? doc.manualInterventions : [],
         stepClassification: doc.stepClassification || null,
         stepsCompleted: Number(doc.stepsCompleted) || (Array.isArray(doc.steps) ? doc.steps.length : 0),
         liveSessions: extractLiveSessions(doc),
+        cohortPolicyVersion: doc.cohortPolicyVersion || doc.cohort_policy_version || null,
+        trustedEvidence: loadTrustedEvidenceReference(doc, { root, taskId }),
       };
     });
 }
@@ -122,14 +174,26 @@ function selectEvidence(evidenceRows) {
   return { liveEvidence, phase6Evidence };
 }
 
+function policyVersionFor(closeout) {
+  const generatedAt = Date.parse(closeout.generatedAt || '');
+  const effectiveAt = Date.parse(COHORT_V2_EFFECTIVE_AT);
+  if (closeout.cohortPolicyVersion === COHORT_POLICY_VERSION
+    || (Number.isFinite(generatedAt) && generatedAt >= effectiveAt)) return COHORT_POLICY_VERSION;
+  return LEGACY_COHORT_POLICY_VERSION;
+}
+
 function buildCloseoutRow(closeout, evidenceRows, bar) {
   const { liveEvidence, phase6Evidence } = selectEvidence(evidenceRows);
   const closed = isPhase6Complete(closeout.deliveryStatus);
   const interventionCount = closeout.manualInterventions.length;
   const liveSessions = phase6Evidence?.liveSessions || liveEvidence?.liveSessions || closeout.liveSessions || [];
   const liveSessionCount = liveSessions.length;
+  const policyVersion = policyVersionFor(closeout);
+  const prEvidenceRequired = policyVersion === COHORT_POLICY_VERSION;
+  const prEvidenceValid = closeout.trustedEvidence?.valid === true;
   const trusted = closed && interventionCount === 0 && liveSessionCount > 0
-    && (phase6Evidence != null || (liveEvidence != null && isPhase6Complete(closeout.deliveryStatus)));
+    && (phase6Evidence != null || (liveEvidence != null && isPhase6Complete(closeout.deliveryStatus)))
+    && (!prEvidenceRequired || prEvidenceValid);
   return {
     taskId: closeout.taskId,
     task_class: bar.taskClass,
@@ -140,12 +204,22 @@ function buildCloseoutRow(closeout, evidenceRows, bar) {
     liveSessionCount,
     liveSessions: liveSessions.slice(0, 8),
     trusted,
+    policyVersion,
+    prEvidenceRequired,
+    prEvidenceValid,
+    trustedEvidencePath: closeout.trustedEvidence?.path || null,
+    trustedEvidenceSha256: closeout.trustedEvidence?.sha256 || null,
+    prUrl: closeout.trustedEvidence?.prUrl || null,
+    mergeCommitSha: closeout.trustedEvidence?.mergeCommitSha || null,
     trustedReason: trusted
       ? 'phase6 closeout + zero recorded post-closeout interventions + live OpenClaw session evidence'
       : [
         !closed ? 'not_phase6_complete' : null,
         interventionCount > 0 ? 'has_manual_interventions' : null,
         liveSessionCount === 0 ? 'missing_live_session_evidence' : null,
+        ...(prEvidenceRequired && !prEvidenceValid
+          ? (closeout.trustedEvidence?.reasons || ['missing_trusted_close_evidence_reference'])
+          : []),
       ].filter(Boolean),
     closeoutPath: closeout.filePath,
     factoryEvidencePath: (phase6Evidence || liveEvidence)?.filePath || null,
@@ -159,11 +233,16 @@ function appendEvidenceOnlyRows(rows, evidenceByTask, bar) {
     if (closeoutTaskIds.has(taskId)) continue;
     const evidence = evidenceRows.find((row) => isPhase6Complete(row.status) && row.liveSessionCount > 0);
     if (!evidence) continue;
+    const policyVersion = policyVersionFor({ generatedAt: evidence.completedAt });
+    const prospective = policyVersion === COHORT_POLICY_VERSION;
     rows.push({
       taskId, task_class: bar.taskClass, template_tier: 'Simple', closed: true,
       deliveryStatus: evidence.status, interventionCount: 0, liveSessionCount: evidence.liveSessionCount,
-      liveSessions: evidence.liveSessions.slice(0, 8), trusted: true,
-      trustedReason: 'phase6 factory evidence with live sessions (no separate closeout file)',
+      liveSessions: evidence.liveSessions.slice(0, 8), trusted: !prospective,
+      policyVersion, prEvidenceRequired: prospective, prEvidenceValid: false,
+      trustedReason: prospective
+        ? ['missing_closeout', 'missing_trusted_close_evidence_reference']
+        : 'phase6 factory evidence with live sessions (legacy policy; no separate closeout file)',
       closeoutPath: null, factoryEvidencePath: evidence.filePath, generatedAt: evidence.completedAt,
     });
   }
@@ -226,16 +305,19 @@ function buildSimpleTrustedCohort({
 function buildSimpleTrustedCohortFromRepo(root = process.cwd(), options = {}) {
   const closeoutDir = options.closeoutDir || path.join(root, 'observability', 'factory-closeout');
   const observabilityDir = options.observabilityDir || path.join(root, 'observability');
-  const closeouts = loadCloseouts(closeoutDir);
+  const closeouts = loadCloseouts(closeoutDir, { root });
   const factoryEvidence = loadFactoryEvidence(observabilityDir);
   return buildSimpleTrustedCohort({ closeouts, factoryEvidence, bar: options.bar || DEFAULT_BAR });
 }
 
 module.exports = {
   COHORT_POLICY_VERSION,
+  LEGACY_COHORT_POLICY_VERSION,
+  COHORT_V2_EFFECTIVE_AT,
   DEFAULT_BAR,
   extractLiveSessions,
   loadCloseouts,
+  loadTrustedEvidenceReference,
   loadFactoryEvidence,
   buildSimpleTrustedCohort,
   buildSimpleTrustedCohortFromRepo,

--- a/tests/contract/simple-trusted-cohort-v2.contract.test.js
+++ b/tests/contract/simple-trusted-cohort-v2.contract.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { buildSimpleTrustedCohortFromRepo } = require('../../lib/task-platform/simple-trusted-cohort');
+const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/trusted-simple-close-evidence');
+
+function writeProspectiveCohort(root, expectedDigest) {
+  const closeoutDir = path.join(root, 'observability', 'factory-closeout');
+  fs.mkdirSync(closeoutDir, { recursive: true });
+  fs.writeFileSync(path.join(closeoutDir, 'TSK-319.json'), JSON.stringify({
+    taskId: 'TSK-319', deliveryStatus: 'phase6_complete',
+    generatedAt: '2026-08-19T18:00:00.000Z', manualInterventions: [],
+    trustedSimpleCloseEvidence: {
+      path: 'observability/trusted-simple-close/TSK-319.json', sha256: expectedDigest,
+    },
+  }));
+  fs.writeFileSync(path.join(root, 'observability', 'factory-milestone-c-319.json'), JSON.stringify({
+    taskId: 'TSK-319', status: 'phase6_complete',
+    session: 'specialist-delegation-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee19',
+  }));
+  return closeoutDir;
+}
+
+it('joins immutable task-bound PR evidence and rejects a changed package', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cohort-v2-contract-'));
+  const evidenceDir = path.join(root, 'observability', 'trusted-simple-close');
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  const evidencePath = path.join(evidenceDir, 'TSK-319.json');
+  const evidence = {
+    ...buildTrustedSimpleCloseEvidence({
+    taskId: 'TSK-319', repository: 'wiinc1/engineering-team',
+    branchName: 'agent/simple-cohort-v2-pr-evidence',
+    commitSha: 'e9c769fe45eef8e1498ff018c1c939109e8047bd',
+    prUrl: 'https://github.com/wiinc1/engineering-team/pull/301',
+    mergeCommitSha: '6f8ebd8ad9d48b27480dcc06845e8fc9a24f31f1',
+    mergedAt: '2026-08-19T17:00:00.000Z', changedFiles: ['README.md'],
+      includeGithubCheckProof: true, requiredChecks: ['unit tests', 'Merge readiness'],
+    }),
+    taskId: 'TSK-319',
+  };
+  const body = `${JSON.stringify(evidence, null, 2)}\n`;
+  fs.writeFileSync(evidencePath, body);
+  const digest = crypto.createHash('sha256').update(body).digest('hex');
+  const closeoutDir = writeProspectiveCohort(root, digest);
+
+  let cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
+  assert.equal(cohort.rows[0].trusted, true);
+  fs.appendFileSync(evidencePath, ' ');
+  cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
+  assert.equal(cohort.rows[0].trusted, false);
+  assert.ok(cohort.rows[0].trustedReason.includes('trusted_close_evidence_digest_mismatch'));
+});

--- a/tests/unit/simple-trusted-cohort.test.js
+++ b/tests/unit/simple-trusted-cohort.test.js
@@ -5,12 +5,15 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const crypto = require('node:crypto');
 const {
   extractLiveSessions,
   buildSimpleTrustedCohort,
   buildSimpleTrustedCohortFromRepo,
   DEFAULT_BAR,
+  COHORT_POLICY_VERSION,
 } = require('../../lib/task-platform/simple-trusted-cohort');
+const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/trusted-simple-close-evidence');
 
   it('extracts live specialist-delegation session ids', () => {
     const sessions = extractLiveSessions({
@@ -92,4 +95,62 @@ const {
     assert.equal(cohort.summary.trustedCloses, 10);
     assert.equal(cohort.summary.barMet, true);
     assert.ok(cohort.summary.autonomous_delivery_rate >= 0.8);
+  });
+
+  it('requires immutable real PR evidence only for prospective v2 closeouts', () => {
+    const cohort = buildSimpleTrustedCohort({
+      closeouts: [{
+        filePath: '/repo/observability/factory-closeout/TSK-321.json',
+        taskId: 'TSK-321', deliveryStatus: 'phase6_complete',
+        generatedAt: '2026-08-19T18:00:00.000Z', manualInterventions: [], liveSessions: [],
+        trustedEvidence: { provided: false, valid: false, reasons: ['missing_trusted_close_evidence_reference'] },
+      }],
+      factoryEvidence: [{
+        filePath: '/repo/observability/factory-milestone-c-321.json', taskId: 'TSK-321',
+        status: 'phase6_complete',
+        liveSessions: ['specialist-delegation-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee21'], liveSessionCount: 1,
+      }],
+    });
+    assert.equal(cohort.rows[0].policyVersion, COHORT_POLICY_VERSION);
+    assert.equal(cohort.rows[0].trusted, false);
+    assert.ok(cohort.rows[0].trustedReason.includes('missing_trusted_close_evidence_reference'));
+  });
+
+  it('loads a task-bound evidence package by repository path and SHA-256', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cohort-v2-'));
+    const closeoutDir = path.join(root, 'observability', 'factory-closeout');
+    const evidenceDir = path.join(root, 'observability', 'trusted-simple-close');
+    fs.mkdirSync(closeoutDir, { recursive: true });
+    fs.mkdirSync(evidenceDir, { recursive: true });
+    const evidencePath = path.join(evidenceDir, 'TSK-321.json');
+    const evidence = {
+      ...buildTrustedSimpleCloseEvidence({
+      taskId: 'TSK-321', templateTier: 'Simple', repository: 'wiinc1/engineering-team',
+      branchName: 'agent/simple-cohort-v2-pr-evidence',
+      commitSha: 'e9c769fe45eef8e1498ff018c1c939109e8047bd',
+      prUrl: 'https://github.com/wiinc1/engineering-team/pull/301', prNumber: 301,
+      mergeCommitSha: '6f8ebd8ad9d48b27480dcc06845e8fc9a24f31f1',
+      mergedAt: '2026-08-19T17:00:00.000Z', changedFiles: ['README.md'],
+        includeGithubCheckProof: true, requiredChecks: ['unit tests', 'Merge readiness'],
+      }),
+      taskId: 'TSK-321',
+    };
+    const evidenceBody = `${JSON.stringify(evidence, null, 2)}\n`;
+    fs.writeFileSync(evidencePath, evidenceBody);
+    const digest = crypto.createHash('sha256').update(evidenceBody).digest('hex');
+    fs.writeFileSync(path.join(closeoutDir, 'TSK-321.json'), `${JSON.stringify({
+      taskId: 'TSK-321', deliveryStatus: 'phase6_complete', generatedAt: '2026-08-19T18:00:00.000Z',
+      manualInterventions: [], trustedSimpleCloseEvidence: {
+        path: 'observability/trusted-simple-close/TSK-321.json', sha256: digest,
+      },
+    })}\n`);
+    fs.writeFileSync(path.join(root, 'observability', 'factory-milestone-c-321.json'), JSON.stringify({
+      taskId: 'TSK-321', status: 'phase6_complete',
+      session: 'specialist-delegation-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee21',
+    }));
+
+    const cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
+    assert.equal(cohort.rows[0].trusted, true);
+    assert.equal(cohort.rows[0].trustedEvidenceSha256, digest);
+    assert.equal(cohort.rows[0].prUrl, 'https://github.com/wiinc1/engineering-team/pull/301');
   });


### PR DESCRIPTION
## Summary

Introduce prospective simple-trusted-cohort.v2 and require immutable task-bound real PR evidence for new closeouts while preserving historical v1 decisions.

## Linked Task
- Task: GitHub #319, Simple

## Standards Compliance
- Standards baseline reviewed: yes, docs/standards/software-development-standards.md
- Checklist completed or updated: yes, scoped Simple-task review
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: auditability, evidence integrity, testing, rollback safety
- Standards gaps or exceptions: no known exceptions

## Required Evidence
- Standards check result: npm run standards:check passed locally
- Lint result: npm run lint passed locally
- Tests: 15 focused unit and contract tests passed
- Test evidence paths: tests/unit/simple-trusted-cohort.test.js, tests/contract/simple-trusted-cohort-v2.contract.test.js
- Docs updated: prospective policy architecture and closeout procedure
- Doc evidence paths: docs/architecture.md, docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: low; prospective report eligibility only
- Rollback path: revert this PR; pre-effective v1 results remain unchanged either way

## Notes

New closeouts fail closed unless a repository-relative trusted evidence package matches its SHA-256, validates as a real merged PR, and carries the same task identity.

Closes #319