### PR TITLE
feat(factory): audit post-approval intervention provenance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -195,3 +195,6 @@ Use `docs/runbook.md` for exact operator commands. At the architecture level:
 ### Prospective trusted Simple cohort policy
 
 `simple-trusted-cohort.v2` applies to closeouts generated on or after 2026-08-19. Earlier evidence keeps its v1 evaluation. A v2 closeout is trusted only when it points to a repository-contained `trusted-simple-close-evidence.v1` package by relative path and SHA-256; the package must validate as a real merged PR and carry the same task id. This makes the cohort reproducible without rewriting historical decisions.
+### Trusted-close authority timeline
+
+Prospective cohort rows retain the authoritative `task.pm_architect_human_review_recorded` and `task.execution_contract_approved` event identities, actor provenance, roles, and timestamps from task history. The closeout classifies intervention events against the approval timestamp. Missing human role provenance, missing approval identity, ambiguous intervention time, or any post-approval intervention makes a v2 row untrusted.

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -1147,3 +1147,6 @@ Operator checklist: `docs/runbooks/milestone-a-hosted-factory.md`.
 ### Record a prospective v2 trusted close
 
 For closeouts generated on or after 2026-08-19, write the validated trusted-close package beneath `observability/trusted-simple-close/`, calculate its SHA-256, and record both as `trustedSimpleCloseEvidence.path` and `trustedSimpleCloseEvidence.sha256` in the task closeout. The path must stay inside the repository and the evidence package `taskId` must match the closeout. Missing, changed, invalid, or cross-task evidence is reported as untrusted; do not edit the effective date or grandfather a new task.
+### Audit human authority and intervention timing
+
+Before counting a prospective trusted close, confirm its closeout contains PM and Architect records sourced from `task.pm_architect_human_review_recorded`, plus the event id and timestamp for `task.execution_contract_approved`. Every intervention must have a parseable `recordedAt`. The cohort fails closed for missing provenance or timestamps and rejects any intervention at or after approval; repair the source audit trail instead of editing the report.

--- a/lib/task-platform/factory-closeout.js
+++ b/lib/task-platform/factory-closeout.js
@@ -36,6 +36,34 @@ function extractManualInterventions(evidence = {}) {
   }));
 }
 
+function buildInterventionAudit(interventions, approvedAt) {
+  const approvalMs = Date.parse(approvedAt || '');
+  const ambiguous = [];
+  const postApproval = [];
+  for (const intervention of interventions) {
+    const occurredMs = Date.parse(intervention.recordedAt || '');
+    if (!Number.isFinite(approvalMs) || !Number.isFinite(occurredMs)) ambiguous.push(intervention);
+    else if (occurredMs >= approvalMs) postApproval.push(intervention);
+  }
+  return {
+    approvalTimestampValid: Number.isFinite(approvalMs),
+    classificationComplete: ambiguous.length === 0,
+    totalCount: interventions.length,
+    postApprovalCount: postApproval.length,
+    postApproval,
+    ambiguous,
+  };
+}
+
+function closeoutGovernance(evidence, interventions) {
+  const audit = evidence.phase1?.contract?.autoApprovalPolicy?.auditProvenance || {};
+  return {
+    humanReviewProvenance: audit.humanReview || null,
+    approvalProvenance: audit.approval || null,
+    interventionAudit: buildInterventionAudit(interventions, audit.approval?.approvedAt),
+  };
+}
+
 function buildFactoryCloseoutReport(evidence = {}, options = {}) {
   const inventory = loadManualStepsInventory(options.inventoryPath);
   const steps = (inventory.steps || []).map((step) => ({
@@ -52,6 +80,7 @@ function buildFactoryCloseoutReport(evidence = {}, options = {}) {
   const completedManual = steps.filter((step) => step.status === 'completed_manual').length;
   const stillManual = steps.filter((step) => step.status === 'manual').length;
   const manualInterventions = extractManualInterventions(evidence);
+  const governance = closeoutGovernance(evidence, manualInterventions);
 
   return {
     schemaVersion: '1.0',
@@ -71,6 +100,7 @@ function buildFactoryCloseoutReport(evidence = {}, options = {}) {
     },
     steps,
     manualInterventions,
+    ...governance,
     phase6: {
       validationOk: evidence.phase6?.api?.validation?.ok === true,
       taskClosedOk: evidence.phase6?.api?.taskClosed?.ok === true,
@@ -105,4 +135,5 @@ module.exports = {
   buildFactoryCloseoutReport,
   writeFactoryCloseoutReport,
   classifyStepStatus,
+  buildInterventionAudit,
 };

--- a/lib/task-platform/golden-path-human-review.js
+++ b/lib/task-platform/golden-path-human-review.js
@@ -1,5 +1,66 @@
 'use strict';
 
+const REVIEW_EVENT = 'task.pm_architect_human_review_recorded';
+const APPROVAL_EVENT = 'task.execution_contract_approved';
+
+function historyItems(body = {}) {
+  const value = body?.data?.items || body?.items || body?.data || body;
+  return Array.isArray(value) ? value : [];
+}
+
+function eventValue(event, snake, camel) {
+  return event?.[snake] || event?.[camel] || null;
+}
+
+function roleProvenance(review, event) {
+  return {
+    actorId: review?.actorId || review?.actor_id || eventValue(event, 'actor_id', 'actorId'),
+    actorType: review?.actorType || review?.actor_type || eventValue(event, 'actor_type', 'actorType'),
+    reviewedAt: review?.reviewedAt || review?.reviewed_at || eventValue(event, 'occurred_at', 'occurredAt'),
+    eventId: eventValue(event, 'event_id', 'eventId'),
+  };
+}
+
+function extractFactoryApprovalProvenance(historyBody = {}) {
+  const entries = historyItems(historyBody);
+  const reviewEvent = entries.find((entry) => eventValue(entry, 'event_type', 'eventType') === REVIEW_EVENT);
+  const approvalEvent = entries.find((entry) => eventValue(entry, 'event_type', 'eventType') === APPROVAL_EVENT);
+  const reviews = reviewEvent?.payload?.reviews || reviewEvent?.payload?.human_reviews || {};
+  return {
+    policyVersion: 'factory-closeout-approval-provenance.v1',
+    humanReview: reviewEvent ? {
+      eventId: eventValue(reviewEvent, 'event_id', 'eventId'),
+      eventType: REVIEW_EVENT,
+      recordedAt: eventValue(reviewEvent, 'occurred_at', 'occurredAt'),
+      roles: {
+        pm: roleProvenance(reviews.pm, reviewEvent),
+        architect: roleProvenance(reviews.architect, reviewEvent),
+      },
+    } : null,
+    approval: approvalEvent ? {
+      eventId: eventValue(approvalEvent, 'event_id', 'eventId'),
+      eventType: APPROVAL_EVENT,
+      approvedAt: eventValue(approvalEvent, 'occurred_at', 'occurredAt'),
+      actorId: eventValue(approvalEvent, 'actor_id', 'actorId'),
+      actorType: eventValue(approvalEvent, 'actor_type', 'actorType'),
+      approvalMode: approvalEvent.payload?.approval_mode || approvalEvent.payload?.approvalMode || null,
+    } : null,
+  };
+}
+
+async function attachFactoryApprovalProvenance(response, { ctx, taskId, apiSend }) {
+  const history = await apiSend(
+    ctx, `/tasks/${encodeURIComponent(taskId)}/history?limit=500`, 'GET', ['reader', 'pm'],
+  );
+  const provenance = extractFactoryApprovalProvenance(history.ok ? history.body : {});
+  const data = response?.body?.data;
+  if (!data || typeof data !== 'object') return response;
+  const policy = data.autoApprovalPolicy && typeof data.autoApprovalPolicy === 'object'
+    ? data.autoApprovalPolicy : {};
+  data.autoApprovalPolicy = { ...policy, auditProvenance: provenance };
+  return response;
+}
+
 function requiresHumanReview(ctx, options, contractBody) {
   return ctx.agentDrivenPhase1
     || options.agentDrivenPhases === true
@@ -32,4 +93,9 @@ async function recordGoldenPathHumanReview({
   api.projectionPostHumanReview = await runProjectionCatchUp(ctx, 'pm-architect-human-review-recorded');
 }
 
-module.exports = { recordGoldenPathHumanReview, requiresHumanReview };
+module.exports = {
+  recordGoldenPathHumanReview,
+  requiresHumanReview,
+  extractFactoryApprovalProvenance,
+  attachFactoryApprovalProvenance,
+};

--- a/lib/task-platform/golden-path-phase1-contract.js
+++ b/lib/task-platform/golden-path-phase1-contract.js
@@ -1,4 +1,5 @@
 const { recordGoldenPathHumanReview } = require('./golden-path-human-review');
+const { attachFactoryApprovalProvenance } = require('./golden-path-human-review');
 
 async function approveExecutionContractWithRetry(ctx, helpers, taskId) {
   const { apiSend, runProjectionCatchUp } = helpers;
@@ -15,7 +16,9 @@ async function approveExecutionContractWithRetry(ctx, helpers, taskId) {
       ['pm', 'reader'],
       approvalBody,
     );
-    if (lastResponse.ok) return lastResponse;
+    if (lastResponse.ok) {
+      return attachFactoryApprovalProvenance(lastResponse, { ctx, taskId, apiSend });
+    }
     const missingContract = lastResponse.status === 404
       && lastResponse.body?.error?.code === 'execution_contract_not_found';
     if (!missingContract || attempt === 5) return lastResponse;

--- a/lib/task-platform/simple-trusted-cohort.js
+++ b/lib/task-platform/simple-trusted-cohort.js
@@ -127,6 +127,9 @@ function loadCloseouts(closeoutDir, { root = process.cwd() } = {}) {
         liveSessions: extractLiveSessions(doc),
         cohortPolicyVersion: doc.cohortPolicyVersion || doc.cohort_policy_version || null,
         trustedEvidence: loadTrustedEvidenceReference(doc, { root, taskId }),
+        humanReviewProvenance: doc.humanReviewProvenance || null,
+        approvalProvenance: doc.approvalProvenance || null,
+        interventionAudit: doc.interventionAudit || null,
       };
     });
 }
@@ -182,18 +185,73 @@ function policyVersionFor(closeout) {
   return LEGACY_COHORT_POLICY_VERSION;
 }
 
+function validTimestamp(value) {
+  return Number.isFinite(Date.parse(value || ''));
+}
+
+function evaluateProspectiveProvenance(closeout) {
+  const reasons = [];
+  const review = closeout.humanReviewProvenance;
+  const approval = closeout.approvalProvenance;
+  if (!review?.eventId || review?.eventType !== 'task.pm_architect_human_review_recorded') {
+    reasons.push('missing_human_review_event_provenance');
+  }
+  const approvalValid = Boolean(
+    approval?.eventId
+    && approval?.eventType === 'task.execution_contract_approved'
+    && validTimestamp(approval.approvedAt),
+  );
+  if (!approvalValid) reasons.push('missing_contract_approval_event_provenance');
+  for (const role of ['pm', 'architect']) {
+    const record = review?.roles?.[role];
+    const actorType = String(record?.actorType || '').toLowerCase();
+    if (!record?.actorId || !['human', 'user', 'operator', 'person'].includes(actorType)
+      || !record?.eventId || !validTimestamp(record.reviewedAt)) {
+      reasons.push(`missing_human_${role}_review_provenance`);
+    } else if (approvalValid && Date.parse(record.reviewedAt) > Date.parse(approval.approvedAt)) {
+      reasons.push(`human_${role}_review_after_approval`);
+    }
+  }
+  const interventions = closeout.manualInterventions || [];
+  const ambiguous = interventions.filter((entry) => !validTimestamp(entry.recordedAt));
+  const postApproval = approvalValid
+    ? interventions.filter((entry) => validTimestamp(entry.recordedAt)
+      && Date.parse(entry.recordedAt) >= Date.parse(approval.approvedAt))
+    : [];
+  if (ambiguous.length) reasons.push('ambiguous_intervention_timestamp');
+  if (postApproval.length) reasons.push('has_post_approval_interventions');
+  return {
+    valid: reasons.length === 0,
+    reasons: [...new Set(reasons)],
+    postApprovalInterventionCount: postApproval.length,
+    interventionClassificationComplete: ambiguous.length === 0 && approvalValid,
+  };
+}
+
+function trustedEvidenceFields(closeout) {
+  return {
+    trustedEvidencePath: closeout.trustedEvidence?.path || null,
+    trustedEvidenceSha256: closeout.trustedEvidence?.sha256 || null,
+    prUrl: closeout.trustedEvidence?.prUrl || null,
+    mergeCommitSha: closeout.trustedEvidence?.mergeCommitSha || null,
+  };
+}
+
 function buildCloseoutRow(closeout, evidenceRows, bar) {
   const { liveEvidence, phase6Evidence } = selectEvidence(evidenceRows);
   const closed = isPhase6Complete(closeout.deliveryStatus);
-  const interventionCount = closeout.manualInterventions.length;
+  const totalInterventionCount = closeout.manualInterventions.length;
   const liveSessions = phase6Evidence?.liveSessions || liveEvidence?.liveSessions || closeout.liveSessions || [];
   const liveSessionCount = liveSessions.length;
   const policyVersion = policyVersionFor(closeout);
   const prEvidenceRequired = policyVersion === COHORT_POLICY_VERSION;
   const prEvidenceValid = closeout.trustedEvidence?.valid === true;
+  const provenance = evaluateProspectiveProvenance(closeout);
+  const interventionCount = prEvidenceRequired
+    ? provenance.postApprovalInterventionCount : totalInterventionCount;
   const trusted = closed && interventionCount === 0 && liveSessionCount > 0
     && (phase6Evidence != null || (liveEvidence != null && isPhase6Complete(closeout.deliveryStatus)))
-    && (!prEvidenceRequired || prEvidenceValid);
+    && (!prEvidenceRequired || (prEvidenceValid && provenance.valid));
   return {
     taskId: closeout.taskId,
     task_class: bar.taskClass,
@@ -201,16 +259,16 @@ function buildCloseoutRow(closeout, evidenceRows, bar) {
     closed,
     deliveryStatus: closeout.deliveryStatus,
     interventionCount,
+    totalInterventionCount,
+    humanReviewProvenanceValid: provenance.valid,
+    interventionClassificationComplete: provenance.interventionClassificationComplete,
     liveSessionCount,
     liveSessions: liveSessions.slice(0, 8),
     trusted,
     policyVersion,
     prEvidenceRequired,
     prEvidenceValid,
-    trustedEvidencePath: closeout.trustedEvidence?.path || null,
-    trustedEvidenceSha256: closeout.trustedEvidence?.sha256 || null,
-    prUrl: closeout.trustedEvidence?.prUrl || null,
-    mergeCommitSha: closeout.trustedEvidence?.mergeCommitSha || null,
+    ...trustedEvidenceFields(closeout),
     trustedReason: trusted
       ? 'phase6 closeout + zero recorded post-closeout interventions + live OpenClaw session evidence'
       : [
@@ -220,6 +278,7 @@ function buildCloseoutRow(closeout, evidenceRows, bar) {
         ...(prEvidenceRequired && !prEvidenceValid
           ? (closeout.trustedEvidence?.reasons || ['missing_trusted_close_evidence_reference'])
           : []),
+        ...(prEvidenceRequired && !provenance.valid ? provenance.reasons : []),
       ].filter(Boolean),
     closeoutPath: closeout.filePath,
     factoryEvidencePath: (phase6Evidence || liveEvidence)?.filePath || null,
@@ -318,6 +377,7 @@ module.exports = {
   extractLiveSessions,
   loadCloseouts,
   loadTrustedEvidenceReference,
+  evaluateProspectiveProvenance,
   loadFactoryEvidence,
   buildSimpleTrustedCohort,
   buildSimpleTrustedCohortFromRepo,

--- a/tests/contract/simple-trusted-cohort-v2.contract.test.js
+++ b/tests/contract/simple-trusted-cohort-v2.contract.test.js
@@ -18,6 +18,17 @@ function writeProspectiveCohort(root, expectedDigest) {
     trustedSimpleCloseEvidence: {
       path: 'observability/trusted-simple-close/TSK-319.json', sha256: expectedDigest,
     },
+    humanReviewProvenance: {
+      eventId: 'review-319', eventType: 'task.pm_architect_human_review_recorded',
+      roles: {
+        pm: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:58:00.000Z', eventId: 'review-319' },
+        architect: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:58:00.000Z', eventId: 'review-319' },
+      },
+    },
+    approvalProvenance: {
+      eventId: 'approval-319', eventType: 'task.execution_contract_approved',
+      approvedAt: '2026-08-19T17:59:00.000Z', approvalMode: 'policy',
+    },
   }));
   fs.writeFileSync(path.join(root, 'observability', 'factory-milestone-c-319.json'), JSON.stringify({
     taskId: 'TSK-319', status: 'phase6_complete',

--- a/tests/unit/factory-closeout.test.js
+++ b/tests/unit/factory-closeout.test.js
@@ -7,6 +7,7 @@ const {
   buildFactoryCloseoutReport,
   writeFactoryCloseoutReport,
   classifyStepStatus,
+  buildInterventionAudit,
 } = require('../../lib/task-platform/factory-closeout');
 
 test('classifyStepStatus marks completed automated steps', () => {
@@ -46,4 +47,13 @@ test('writeFactoryCloseoutReport writes JSON artifact', () => {
   }, { outputDir: dir });
   assert.equal(fs.existsSync(outputPath), true);
   assert.equal(report.kind, 'factory-closeout-report');
+});
+
+test('closeout preserves approval provenance and classifies later interventions', () => {
+  const audit = buildInterventionAudit([
+    { recordedAt: '2026-08-19T17:59:00.000Z' },
+    { recordedAt: '2026-08-19T18:01:00.000Z' },
+  ], '2026-08-19T18:00:00.000Z');
+  assert.equal(audit.classificationComplete, true);
+  assert.equal(audit.postApprovalCount, 1);
 });

--- a/tests/unit/golden-path-human-review.test.js
+++ b/tests/unit/golden-path-human-review.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  extractFactoryApprovalProvenance,
+  attachFactoryApprovalProvenance,
+} = require('../../lib/task-platform/golden-path-human-review');
+
+function provenanceHistory() {
+  return { items: [
+    {
+      event_id: 'approval-1', event_type: 'task.execution_contract_approved',
+      occurred_at: '2026-08-19T18:00:00.000Z', actor_id: 'policy', actor_type: 'system',
+      payload: { approval_mode: 'policy' },
+    },
+    {
+      event_id: 'review-1', event_type: 'task.pm_architect_human_review_recorded',
+      occurred_at: '2026-08-19T17:59:00.000Z', actor_id: 'operator-1', actor_type: 'user',
+      payload: { reviews: {
+        pm: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:59:00.000Z' },
+        architect: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:59:00.000Z' },
+      } },
+    },
+  ] };
+}
+
+it('extracts human PM/Architect and approval event identities from task history', () => {
+  const provenance = extractFactoryApprovalProvenance(provenanceHistory());
+  assert.equal(provenance.humanReview.roles.pm.eventId, 'review-1');
+  assert.equal(provenance.humanReview.roles.architect.actorType, 'human');
+  assert.equal(provenance.approval.eventId, 'approval-1');
+});
+
+it('attaches task-history provenance to the policy object returned by approval', async () => {
+  const response = { body: { data: { autoApprovalPolicy: { status: 'ready' } } } };
+  const attached = await attachFactoryApprovalProvenance(response, {
+    ctx: {}, taskId: 'TSK-320',
+    apiSend: async () => ({ ok: true, body: provenanceHistory() }),
+  });
+  const audit = attached.body.data.autoApprovalPolicy.auditProvenance;
+  assert.equal(audit.humanReview.eventId, 'review-1');
+  assert.equal(audit.approval.eventId, 'approval-1');
+});

--- a/tests/unit/simple-trusted-cohort.test.js
+++ b/tests/unit/simple-trusted-cohort.test.js
@@ -15,6 +15,22 @@ const {
 } = require('../../lib/task-platform/simple-trusted-cohort');
 const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/trusted-simple-close-evidence');
 
+function prospectiveProvenance() {
+  return {
+    humanReviewProvenance: {
+      eventId: 'review-1', eventType: 'task.pm_architect_human_review_recorded',
+      recordedAt: '2026-08-19T17:59:00.000Z', roles: {
+        pm: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:59:00.000Z', eventId: 'review-1' },
+        architect: { actorId: 'operator-1', actorType: 'human', reviewedAt: '2026-08-19T17:59:00.000Z', eventId: 'review-1' },
+      },
+    },
+    approvalProvenance: {
+      eventId: 'approval-1', eventType: 'task.execution_contract_approved',
+      approvedAt: '2026-08-19T18:00:00.000Z', approvalMode: 'policy',
+    },
+  };
+}
+
   it('extracts live specialist-delegation session ids', () => {
     const sessions = extractLiveSessions({
       a: 'specialist-delegation-6eeeca15-04e1-46ff-bbb2-2e0137035f58',
@@ -104,6 +120,7 @@ const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/tru
         taskId: 'TSK-321', deliveryStatus: 'phase6_complete',
         generatedAt: '2026-08-19T18:00:00.000Z', manualInterventions: [], liveSessions: [],
         trustedEvidence: { provided: false, valid: false, reasons: ['missing_trusted_close_evidence_reference'] },
+        ...prospectiveProvenance(),
       }],
       factoryEvidence: [{
         filePath: '/repo/observability/factory-milestone-c-321.json', taskId: 'TSK-321',
@@ -143,6 +160,7 @@ const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/tru
       manualInterventions: [], trustedSimpleCloseEvidence: {
         path: 'observability/trusted-simple-close/TSK-321.json', sha256: digest,
       },
+      ...prospectiveProvenance(),
     })}\n`);
     fs.writeFileSync(path.join(root, 'observability', 'factory-milestone-c-321.json'), JSON.stringify({
       taskId: 'TSK-321', status: 'phase6_complete',
@@ -153,4 +171,19 @@ const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/tru
     assert.equal(cohort.rows[0].trusted, true);
     assert.equal(cohort.rows[0].trustedEvidenceSha256, digest);
     assert.equal(cohort.rows[0].prUrl, 'https://github.com/wiinc1/engineering-team/pull/301');
+  });
+
+  it('rejects a prospective close with an intervention after contract approval', () => {
+    const result = buildSimpleTrustedCohort({ closeouts: [{
+      taskId: 'TSK-322', deliveryStatus: 'phase6_complete',
+      generatedAt: '2026-08-19T19:00:00.000Z',
+      manualInterventions: [{ recordedAt: '2026-08-19T18:01:00.000Z' }],
+      trustedEvidence: { valid: true }, ...prospectiveProvenance(),
+    }], factoryEvidence: [{
+      taskId: 'TSK-322', status: 'phase6_complete', filePath: '/repo/evidence.json',
+      liveSessions: ['specialist-delegation-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee22'], liveSessionCount: 1,
+    }] });
+    assert.equal(result.rows[0].trusted, false);
+    assert.equal(result.rows[0].interventionCount, 1);
+    assert.ok(result.rows[0].trustedReason.includes('has_post_approval_interventions'));
   });


### PR DESCRIPTION
## Summary

Preserve authoritative human PM/Architect and contract-approval event provenance in factory closeouts, then fail closed on ambiguous or post-approval interventions.

## Linked Task
- Task: GitHub #320, Simple

## Standards Compliance
- Standards baseline reviewed: yes, docs/standards/software-development-standards.md
- Checklist completed or updated: yes, scoped Simple-task review
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: auditability, authorization provenance, testing, rollback safety
- Standards gaps or exceptions: no known exceptions

## Required Evidence
- Standards check result: npm run standards:check passed locally
- Lint result: npm run lint passed locally
- Tests: 15 focused extraction, closeout, cohort, and contract tests passed
- Test evidence paths: tests/unit/golden-path-human-review.test.js, tests/unit/factory-closeout.test.js, tests/unit/simple-trusted-cohort.test.js, tests/contract/simple-trusted-cohort-v2.contract.test.js
- Docs updated: authority timeline and intervention audit procedure
- Doc evidence paths: docs/architecture.md, docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: low; additional closeout evidence and prospective eligibility checks
- Rollback path: revert this PR; historical v1 rows remain unchanged

## Notes

New v2 rows require PM and Architect human actor records, source event IDs, approval event identity, ordered timestamps, and zero interventions at or after approval.

Closes #320