### PR TITLE
feat(factory): solve cohort count and rate residuals

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -198,3 +198,6 @@ Use `docs/runbook.md` for exact operator commands. At the architecture level:
 ### Trusted-close authority timeline
 
 Prospective cohort rows retain the authoritative `task.pm_architect_human_review_recorded` and `task.execution_contract_approved` event identities, actor provenance, roles, and timestamps from task history. The closeout classifies intervention events against the approval timestamp. Missing human role provenance, missing approval identity, ambiguous intervention time, or any post-approval intervention makes a v2 row untrusted.
+### Cohort residual arithmetic
+
+The trusted Simple residual solves both thresholds under an explicit all-future-closes-are-trusted assumption. It reports the larger of the count shortfall and `ceil((targetRate × closed - trusted) / (1 - targetRate))`, plus projected totals and rate. A 100% target is reported as unreachable by adding closes when any existing close is untrusted.

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -1150,3 +1150,6 @@ For closeouts generated on or after 2026-08-19, write the validated trusted-clos
 ### Audit human authority and intervention timing
 
 Before counting a prospective trusted close, confirm its closeout contains PM and Architect records sourced from `task.pm_architect_human_review_recorded`, plus the event id and timestamp for `task.execution_contract_approved`. Every intervention must have a parseable `recordedAt`. The cohort fails closed for missing provenance or timestamps and rejects any intervention at or after approval; repair the source audit trail instead of editing the report.
+### Interpret the cohort residual
+
+Use `summary.residual.additionalTrustedClosesRequired`, not only the distance to ten. The residual satisfies both the minimum count and delivery-rate bar and assumes every added Simple close will be trusted. Review the projected trusted/closed totals and projected rate before scheduling the cohort; `null` with `achievableWithAdditionalTrustedCloses=false` means additions alone cannot satisfy the configured target.

--- a/lib/task-platform/simple-trusted-cohort-residual.js
+++ b/lib/task-platform/simple-trusted-cohort-residual.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function requiredForRate(trustedCloses, closedTasks, targetRate) {
+  if (targetRate <= 0) return 0;
+  if (targetRate >= 1) return trustedCloses === closedTasks ? 0 : null;
+  const raw = ((targetRate * closedTasks) - trustedCloses) / (1 - targetRate);
+  return Math.max(0, Math.ceil(raw - 1e-12));
+}
+
+function projectedRate(trustedCloses, closedTasks, additions) {
+  if (additions == null) return null;
+  const projectedClosed = closedTasks + additions;
+  if (projectedClosed === 0) return 0;
+  return Number(((trustedCloses + additions) / projectedClosed).toFixed(4));
+}
+
+function calculateCohortResidual({ trustedCloses, closedTasks, bar }) {
+  const targetCount = Number(bar.minTrustedCloses) || 0;
+  const targetRate = Number(bar.minAutonomousRate) || 0;
+  const countRequired = Math.max(0, targetCount - trustedCloses);
+  const rateRequired = requiredForRate(trustedCloses, closedTasks, targetRate);
+  const additions = rateRequired == null ? null : Math.max(countRequired, rateRequired);
+  const currentRate = closedTasks > 0 ? trustedCloses / closedTasks : 0;
+  return {
+    trustedCloseShortfall: countRequired,
+    rateShortfall: Number(Math.max(0, targetRate - currentRate).toFixed(4)),
+    additionalTrustedClosesForRate: rateRequired,
+    additionalTrustedClosesRequired: additions,
+    achievableWithAdditionalTrustedCloses: additions != null,
+    projectedTrustedCloses: additions == null ? null : trustedCloses + additions,
+    projectedClosedTasks: additions == null ? null : closedTasks + additions,
+    projectedAutonomousDeliveryRate: projectedRate(trustedCloses, closedTasks, additions),
+    assumption: 'every additional closed Simple task is trusted',
+  };
+}
+
+module.exports = { calculateCohortResidual, requiredForRate };

--- a/lib/task-platform/simple-trusted-cohort.js
+++ b/lib/task-platform/simple-trusted-cohort.js
@@ -10,6 +10,7 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 const { aggregateAutonomousDeliveryMetrics } = require('../audit/autonomous-delivery-metrics-aggregate');
 const { assertTrustedSimpleCloseEvidence } = require('./trusted-simple-close-evidence');
+const { calculateCohortResidual } = require('./simple-trusted-cohort-residual');
 
 const LEGACY_COHORT_POLICY_VERSION = 'simple-trusted-cohort.v1';
 const COHORT_POLICY_VERSION = 'simple-trusted-cohort.v2';
@@ -322,6 +323,7 @@ function summarizeCohort(rows, closeouts, factoryEvidence, bar) {
   const trusted = rows.filter((row) => row.trusted);
   const closed = rows.filter((row) => row.closed);
   const rate = closed.length > 0 ? Number((trusted.length / closed.length).toFixed(4)) : 0;
+  const residual = calculateCohortResidual({ trustedCloses: trusted.length, closedTasks: closed.length, bar });
   return {
     trusted,
     summary: {
@@ -333,6 +335,7 @@ function summarizeCohort(rows, closeouts, factoryEvidence, bar) {
       barMet: trusted.length >= bar.minTrustedCloses && rate >= bar.minAutonomousRate,
       minTrustedCloses: bar.minTrustedCloses,
       minAutonomousRate: bar.minAutonomousRate,
+      residual,
     },
   };
 }
@@ -378,6 +381,7 @@ module.exports = {
   loadCloseouts,
   loadTrustedEvidenceReference,
   evaluateProspectiveProvenance,
+  calculateCohortResidual,
   loadFactoryEvidence,
   buildSimpleTrustedCohort,
   buildSimpleTrustedCohortFromRepo,

--- a/tests/contract/simple-trusted-cohort-v2.contract.test.js
+++ b/tests/contract/simple-trusted-cohort-v2.contract.test.js
@@ -61,8 +61,10 @@ it('joins immutable task-bound PR evidence and rejects a changed package', () =>
 
   let cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
   assert.equal(cohort.rows[0].trusted, true);
+  assert.equal(cohort.summary.residual.additionalTrustedClosesRequired, 9);
   fs.appendFileSync(evidencePath, ' ');
   cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
   assert.equal(cohort.rows[0].trusted, false);
+  assert.equal(cohort.summary.residual.additionalTrustedClosesRequired, 10);
   assert.ok(cohort.rows[0].trustedReason.includes('trusted_close_evidence_digest_mismatch'));
 });

--- a/tests/unit/simple-trusted-cohort.test.js
+++ b/tests/unit/simple-trusted-cohort.test.js
@@ -12,6 +12,7 @@ const {
   buildSimpleTrustedCohortFromRepo,
   DEFAULT_BAR,
   COHORT_POLICY_VERSION,
+  calculateCohortResidual,
 } = require('../../lib/task-platform/simple-trusted-cohort');
 const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/trusted-simple-close-evidence');
 
@@ -111,6 +112,27 @@ function prospectiveProvenance() {
     assert.equal(cohort.summary.trustedCloses, 10);
     assert.equal(cohort.summary.barMet, true);
     assert.ok(cohort.summary.autonomous_delivery_rate >= 0.8);
+  });
+
+  it('calculates additions needed for both the count and rate bars', () => {
+    const residual = calculateCohortResidual({
+      trustedCloses: 6, closedTasks: 9, bar: DEFAULT_BAR,
+    });
+    assert.equal(residual.trustedCloseShortfall, 4);
+    assert.equal(residual.additionalTrustedClosesForRate, 6);
+    assert.equal(residual.additionalTrustedClosesRequired, 6);
+    assert.equal(residual.projectedTrustedCloses, 12);
+    assert.equal(residual.projectedClosedTasks, 15);
+    assert.equal(residual.projectedAutonomousDeliveryRate, 0.8);
+  });
+
+  it('reports an imperfect cohort cannot reach a 100 percent target by addition', () => {
+    const residual = calculateCohortResidual({
+      trustedCloses: 9, closedTasks: 10,
+      bar: { minTrustedCloses: 10, minAutonomousRate: 1 },
+    });
+    assert.equal(residual.achievableWithAdditionalTrustedCloses, false);
+    assert.equal(residual.additionalTrustedClosesRequired, null);
   });
 
   it('requires immutable real PR evidence only for prospective v2 closeouts', () => {


### PR DESCRIPTION
## Summary

Calculate the exact all-trusted closeout residual required to satisfy both cohort count and trust-rate thresholds, including an explicit impossible result for a 100% target with existing untrusted rows.

## Linked Task
- Task: GitHub #322, Simple

## Standards Compliance
- Standards baseline reviewed: yes, docs/standards/software-development-standards.md
- Checklist completed or updated: yes, scoped Simple-task review
- Compliance checklist path: docs/templates/STANDARDS_COMPLIANCE_CHECKLIST.md
- Relevant standards areas: deterministic reporting, boundary arithmetic, test coverage, rollback safety
- Standards gaps or exceptions: no known exceptions

## Required Evidence
- Standards check result: npm run standards:check passed locally
- Lint result: npm run lint passed locally
- Tests: focused unit and contract cohort tests passed
- Test evidence paths: tests/unit/simple-trusted-cohort.test.js, tests/contract/simple-trusted-cohort-v2.contract.test.js
- Docs updated: cohort arithmetic architecture and operator guidance
- Doc evidence paths: docs/architecture.md, docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: low; deterministic reporting arithmetic only
- Rollback path: revert this PR to restore the previous count-only residual

## Notes

The current 6/9 baseline requires six all-trusted additions and projects 12/15 = 80%.

Closes #322
