### PR TITLE
feat(factory): publish stable trusted-cohort report provenance

### DIFF
--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -575,6 +575,7 @@
             "^tests/unit/governance/(check-secrets|source-integrity)\\.test\\.js$",
             "^tests/unit/trusted-simple-close-evidence\\.test\\.js$",
             "^tests/unit/simple-trusted-cohort\\.test\\.js$",
+            "^tests/unit/simple-trusted-cohort-report\\.test\\.js$",
             "^tests/unit/forge-claim-policy\\.test\\.js$"
           ]
         },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,3 +201,6 @@ Prospective cohort rows retain the authoritative `task.pm_architect_human_review
 ### Cohort residual arithmetic
 
 The trusted Simple residual solves both thresholds under an explicit all-future-closes-are-trusted assumption. It reports the larger of the count shortfall and `ceil((targetRate × closed - trusted) / (1 - targetRate))`, plus projected totals and rate. A 100% target is reported as unreachable by adding closes when any existing close is untrusted.
+### Stable cohort report provenance
+
+The canonical cohort report lives at `docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.md`. Its JSON and Markdown carry the exact Git revision, policy and generator identity, a sorted source inventory with per-file SHA-256 and byte size, and an aggregate source-set digest. A caller-supplied generation timestamp supports deterministic rebuilds; dated legacy reports remain immutable historical snapshots.

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -110,7 +110,7 @@ Near-term bar (Q1): ≥10 Simple operator-trusted closes with live session evide
 ```bash
 npm run cohort:simple-trusted
 # writes observability/trusted-simple-close/cohort-report.json
-# and docs/reports/SIMPLE_TRUSTED_COHORT_REPORT_2026-07-13.md
+# and docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.md
 ```
 
 Trusted close definition (evaluator): `phase6_complete` closeout/evidence, zero recorded manual interventions, ≥1 live `specialist-delegation-*` session id.

--- a/docs/runbooks/simple-trusted-cohort.md
+++ b/docs/runbooks/simple-trusted-cohort.md
@@ -39,4 +39,6 @@ Implemented in `lib/task-platform/simple-trusted-cohort.js`:
 ## Artifacts
 
 - `observability/trusted-simple-close/cohort-report.json`
-- `docs/reports/SIMPLE_TRUSTED_COHORT_REPORT_2026-07-13.md`
+- `docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.md`
+
+The canonical report records the exact Git revision, generation time, generator, every source input with its SHA-256 and size, and an aggregate source-set digest. Set `COHORT_REPORT_GENERATED_AT` when byte-for-byte deterministic regeneration is required. The dated 2026-07-13 report remains a historical snapshot and is not overwritten.

--- a/lib/task-platform/simple-trusted-cohort-report.js
+++ b/lib/task-platform/simple-trusted-cohort-report.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+const path = require('node:path');
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
+function candidatePaths(cohort) {
+  return cohort.rows.flatMap((row) => [
+    row.closeoutPath,
+    row.factoryEvidencePath,
+    row.trustedEvidencePath,
+  ]).filter(Boolean);
+}
+
+function sourceFileRecords(cohort, root) {
+  const resolvedRoot = path.resolve(root);
+  const relativePaths = [...new Set(candidatePaths(cohort).map((candidate) => {
+    const absolute = path.isAbsolute(candidate) ? candidate : path.resolve(resolvedRoot, candidate);
+    return path.relative(resolvedRoot, absolute);
+  }))].sort();
+  return relativePaths.map((relativePath) => {
+    const absolute = path.resolve(resolvedRoot, relativePath);
+    const body = fs.readFileSync(absolute);
+    return { path: relativePath, sha256: sha256(body), bytes: body.length };
+  });
+}
+
+function buildReportProvenance(cohort, options = {}) {
+  const inputs = sourceFileRecords(cohort, options.root || process.cwd());
+  const sourceSetSha256 = sha256(JSON.stringify(inputs));
+  return {
+    schemaVersion: 'simple-trusted-cohort-report-provenance.v1',
+    generator: 'scripts/build-simple-trusted-cohort-report.js',
+    policyVersion: cohort.policy_version,
+    revision: options.revision,
+    generatedAt: options.generatedAt,
+    sourceSetSha256,
+    inputCount: inputs.length,
+    inputs,
+  };
+}
+
+module.exports = { buildReportProvenance, sourceFileRecords, sha256 };

--- a/scripts/build-simple-trusted-cohort-report.js
+++ b/scripts/build-simple-trusted-cohort-report.js
@@ -7,10 +7,24 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const {
   buildSimpleTrustedCohortFromRepo,
   DEFAULT_BAR,
 } = require('../lib/task-platform/simple-trusted-cohort');
+const { buildReportProvenance } = require('../lib/task-platform/simple-trusted-cohort-report');
+
+const STABLE_REPORT_PATH = 'docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.md';
+
+function revisionFor(root) {
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim();
+}
+
+function writeJsonAtomic(filePath, value) {
+  const temporary = `${filePath}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`);
+  fs.renameSync(temporary, filePath);
+}
 
 function cohortRow(row) {
   const reasons = Array.isArray(row.trustedReason)
@@ -23,6 +37,8 @@ function buildCohortMarkdown(cohort, jsonRelativePath) {
   return [
     '# Simple Operator-Trusted Cohort Report', '',
     `**Generated:** ${cohort.generatedAt}`, `**Policy:** ${cohort.policy_version}`,
+    `**Revision:** \`${cohort.provenance.revision}\``,
+    `**Source set:** \`${cohort.provenance.sourceSetSha256}\``,
     '**Issue:** GitLab #276 / factory autonomy Q1 bar', '', '## Bar', '',
     '| Metric | Target | Actual |', '| --- | --- | --- |',
     `| Trusted Simple closes | ≥ ${cohort.bar.minTrustedCloses} | **${cohort.summary.trustedCloses}** |`,
@@ -42,20 +58,31 @@ function buildCohortMarkdown(cohort, jsonRelativePath) {
     '## Artifacts', '', `- JSON: \`${jsonRelativePath}\``, '', '## Residual', '',
     cohort.summary.barMet
       ? '- Q1 near-term bar is met for this evidence snapshot.'
-      : `- Bar not met: need ${Math.max(0, cohort.bar.minTrustedCloses - cohort.summary.trustedCloses)} more trusted Simple closes with live session evidence.`,
+      : `- Bar not met: need ${cohort.summary.residual.additionalTrustedClosesRequired} additional trusted Simple closes to satisfy both count and rate, assuming every added close is trusted.`,
+    '', '## Provenance', '',
+    `- Generator: \`${cohort.provenance.generator}\``,
+    `- Inputs: ${cohort.provenance.inputCount}`,
+    `- Source-set SHA-256: \`${cohort.provenance.sourceSetSha256}\``,
+    '', '| Input | SHA-256 | Bytes |', '| --- | --- | --- |',
+    ...cohort.provenance.inputs.map((input) => `| \`${input.path}\` | \`${input.sha256}\` | ${input.bytes} |`),
     '',
   ];
 }
 
-function main() {
-  const root = process.cwd();
+function main(options = {}) {
+  const root = options.root || process.cwd();
+  const generatedAt = options.generatedAt || process.env.COHORT_REPORT_GENERATED_AT || new Date().toISOString();
   const cohort = buildSimpleTrustedCohortFromRepo(root, { bar: DEFAULT_BAR });
+  cohort.generatedAt = generatedAt;
+  cohort.provenance = buildReportProvenance(cohort, {
+    root, generatedAt, revision: options.revision || revisionFor(root),
+  });
   const outDir = path.join(root, 'observability', 'trusted-simple-close');
   fs.mkdirSync(outDir, { recursive: true });
   const jsonPath = path.join(outDir, 'cohort-report.json');
-  fs.writeFileSync(jsonPath, `${JSON.stringify(cohort, null, 2)}\n`);
+  writeJsonAtomic(jsonPath, cohort);
 
-  const mdPath = path.join(root, 'docs', 'reports', 'SIMPLE_TRUSTED_COHORT_REPORT_2026-07-13.md');
+  const mdPath = path.join(root, STABLE_REPORT_PATH);
   const lines = buildCohortMarkdown(cohort, path.relative(root, jsonPath));
   fs.writeFileSync(mdPath, `${lines.join('\n')}\n`);
 
@@ -67,7 +94,10 @@ function main() {
     jsonPath,
     mdPath,
   }, null, 2)}\n`);
-  process.exit(cohort.summary.barMet ? 0 : 2);
+  if (options.setExitCode !== false) process.exitCode = cohort.summary.barMet ? 0 : 2;
+  return { cohort, jsonPath, mdPath };
 }
 
-main();
+if (require.main === module) main();
+
+module.exports = { STABLE_REPORT_PATH, buildCohortMarkdown, main, revisionFor, writeJsonAtomic };

--- a/tests/contract/simple-trusted-cohort-v2.contract.test.js
+++ b/tests/contract/simple-trusted-cohort-v2.contract.test.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { buildSimpleTrustedCohortFromRepo } = require('../../lib/task-platform/simple-trusted-cohort');
 const { buildTrustedSimpleCloseEvidence } = require('../../lib/task-platform/trusted-simple-close-evidence');
+const { buildReportProvenance } = require('../../lib/task-platform/simple-trusted-cohort-report');
 
 function writeProspectiveCohort(root, expectedDigest) {
   const closeoutDir = path.join(root, 'observability', 'factory-closeout');
@@ -62,6 +63,11 @@ it('joins immutable task-bound PR evidence and rejects a changed package', () =>
   let cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
   assert.equal(cohort.rows[0].trusted, true);
   assert.equal(cohort.summary.residual.additionalTrustedClosesRequired, 9);
+  const provenance = buildReportProvenance(cohort, {
+    root, revision: 'a'.repeat(40), generatedAt: '2026-08-19T19:00:00.000Z',
+  });
+  assert.equal(provenance.inputCount, 3);
+  assert.match(provenance.sourceSetSha256, /^[a-f0-9]{64}$/);
   fs.appendFileSync(evidencePath, ' ');
   cohort = buildSimpleTrustedCohortFromRepo(root, { closeoutDir });
   assert.equal(cohort.rows[0].trusted, false);

--- a/tests/unit/simple-trusted-cohort-report.test.js
+++ b/tests/unit/simple-trusted-cohort-report.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { buildReportProvenance } = require('../../lib/task-platform/simple-trusted-cohort-report');
+const { buildCohortMarkdown, STABLE_REPORT_PATH } = require('../../scripts/build-simple-trusted-cohort-report');
+
+it('builds sorted per-input and aggregate provenance for the stable report', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cohort-report-'));
+  fs.writeFileSync(path.join(root, 'a.json'), '{}\n');
+  fs.writeFileSync(path.join(root, 'b.json'), '{"ok":true}\n');
+  const cohort = {
+    policy_version: 'simple-trusted-cohort.v2',
+    rows: [{ closeoutPath: path.join(root, 'b.json'), factoryEvidencePath: path.join(root, 'a.json') }],
+  };
+  const provenance = buildReportProvenance(cohort, {
+    root, revision: 'a'.repeat(40), generatedAt: '2026-08-19T19:00:00.000Z',
+  });
+  assert.deepEqual(provenance.inputs.map((input) => input.path), ['a.json', 'b.json']);
+  assert.match(provenance.sourceSetSha256, /^[a-f0-9]{64}$/);
+  assert.equal(STABLE_REPORT_PATH, 'docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.md');
+});
+
+it('renders revision, source digest, and joint residual', () => {
+  const cohort = {
+    generatedAt: '2026-08-19T19:00:00.000Z', policy_version: 'simple-trusted-cohort.v2',
+    provenance: { revision: 'a'.repeat(40), sourceSetSha256: 'b'.repeat(64), generator: 'generator.js', inputCount: 0, inputs: [] },
+    bar: { minTrustedCloses: 10, minAutonomousRate: 0.8 },
+    summary: { trustedCloses: 6, autonomous_delivery_rate: 0.6667, barMet: false, residual: { additionalTrustedClosesRequired: 6 } },
+    trustedTaskIds: [], rows: [], metrics: { summary: {} },
+  };
+  const markdown = buildCohortMarkdown(cohort, 'cohort-report.json').join('\n');
+  assert.match(markdown, /need 6 additional trusted Simple closes/);
+  assert.match(markdown, new RegExp('a{40}'));
+  assert.match(markdown, /Source-set SHA-256/);
+});


### PR DESCRIPTION
## Summary

Generate the trusted Simple cohort at a stable canonical path and embed exact source-file digests, revision, and generation provenance so the release decision is reproducible.

## Linked Task

- Task: GitHub #323, Simple

## Standards Compliance

- Standards baseline reviewed: `AGENTS.md`, architecture and golden-path runbooks
- Checklist completed or updated: Yes
- Compliance checklist path: `docs/runbooks/simple-trusted-cohort.md`
- Relevant standards areas: report reproducibility, immutable provenance, autonomous-delivery measurement
- Standards gaps or exceptions: The canonical report is generated only after trusted closeout evidence exists; this change does not manufacture or backfill cohort inputs.

## Required Evidence

- Standards check result: Pass (`npm run standards:check`)
- Lint result: Pass (`npm run lint`)
- Tests: Pass (`node --test tests/contract/simple-trusted-cohort-v2.contract.test.js tests/unit/simple-trusted-cohort-report.test.js`)
- Test evidence paths: `tests/contract/simple-trusted-cohort-v2.contract.test.js`, `tests/unit/simple-trusted-cohort-report.test.js`
- Docs updated: Yes
- Doc evidence paths: `docs/runbooks/simple-trusted-cohort.md`, `docs/runbooks/golden-path-autonomous-delivery.md`, `docs/architecture.md`

## Risk and Rollback

- Risk level: Low
- Rollback path: Revert this commit; the dated historical report path remains readable and no runtime state is mutated.

## Notes

The parent arithmetic change merged in #328; this PR is now retargeted to `main` and contains only the stable-report change.

Closes #323


