### PR TITLE
feat(release): seal runtime manifests against mutation

### DIFF
--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -857,6 +857,7 @@
           "name": "unit-contract-e2e",
           "patterns": [
             "^tests/unit/langgraph-.+\\.test\\.js$",
+            "^tests/unit/runtime-release-evidence\\.test\\.js$",
             "^tests/contract/langgraph-(?:runtime|alerts)\\.contract\\.test\\.js$",
             "^tests/e2e/langgraph-runtime\\.e2e\\.test\\.js$",
             "^src/app/LangGraphRunPanel\\.test\\.tsx$"
@@ -866,6 +867,7 @@
           "name": "integration-property",
           "patterns": [
             "^tests/integration/langgraph-(?:postgres|process-recovery-postgres)\\.integration\\.test\\.js$",
+            "^tests/integration/runtime-release-manifest\\.integration\\.test\\.js$",
             "^tests/property/langgraph-state\\.property\\.test\\.js$"
           ]
         },
@@ -873,6 +875,7 @@
           "name": "security-performance-chaos",
           "patterns": [
             "^tests/security/langgraph-runtime\\.security\\.test\\.js$",
+            "^tests/security/runtime-release-manifest\\.security\\.test\\.js$",
             "^tests/performance/langgraph-runtime\\.performance\\.test\\.js$",
             "^chaos/langgraph-resilience\\.test\\.js$"
           ]

--- a/docs/architecture/exclusive-runtime-cutover.md
+++ b/docs/architecture/exclusive-runtime-cutover.md
@@ -32,4 +32,6 @@ Rollback first freezes new work. It is permitted only with zero active target ex
 
 `scripts/verify-runtime-cutover.js` accepts sanitized inventory plus a release manifest and produces a deterministic signed decision. It does not mutate production. Epoch activation is an authenticated, audited database deployment operation after approval.
 
+Each release manifest carries `manifestDigest`, a deterministic SHA-256 over every other manifest field after stable key ordering. Collection seals the sorted exact-revision artifact set; evaluation recomputes the seal, and cutover rejects a decision without the verified digest. Any mutation to deployment identity, artifact status, threshold summary, provenance, expiry, or component digest therefore invalidates the handoff.
+
 After removal, `npm run cutover:graphile:legacy-zero` and `npm run cutover:langgraph:legacy-zero` must both pass. They intentionally fail in the pre-cutover repository while the inventoried executable paths remain.

--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -13,6 +13,8 @@ npm run release:langgraph:verify -- artifacts/langgraph-release-manifest.json
 
 Any nonzero exit blocks cutover. Re-run the failing automation; do not edit or waive the result.
 
+Do not edit a collected manifest. Its `manifestDigest` seals the deployment identity and complete artifact metadata. Copy the JSON byte-for-byte between stages; verification recomputes the canonical digest and cutover requires that verified digest in its release decision.
+
 Run the composed staging soak from the exact deployed revision. The command defaults to 86,400 seconds,
 uses five-minute concurrent Graphile/LangGraph windows, isolates Graphile rows by a generated tenant,
 cleans every window, and records connection/thread cleanup without persisting database credentials:

--- a/lib/release-gates/evidence-collector.js
+++ b/lib/release-gates/evidence-collector.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const crypto = require('node:crypto');
-const { RUNTIME_ARTIFACTS, evaluateRuntimeEvidence } = require('./runtime-evidence');
+const { RUNTIME_ARTIFACTS, evaluateRuntimeEvidence, sealRuntimeManifest } = require('./runtime-evidence');
 
 const COMPONENT_SCHEMA_VERSION = 1;
 
@@ -48,7 +48,7 @@ function collectRuntimeEvidence(input, options = {}) {
   const artifacts = input.components.map((component) => collectArtifact(component, input));
   const kinds = artifacts.map((artifact) => artifact.kind);
   if (new Set(kinds).size !== kinds.length) throw new Error('Duplicate release evidence kind.');
-  const manifest = Object.freeze({
+  const manifest = sealRuntimeManifest({
     schemaVersion: 1,
     runtime: input.runtime,
     revision: input.revision,

--- a/lib/release-gates/runtime-evidence.js
+++ b/lib/release-gates/runtime-evidence.js
@@ -26,6 +26,24 @@ class ReleaseGateError extends Error {
   }
 }
 
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+}
+
+function runtimeManifestDigest(manifest) {
+  const { manifestDigest: _ignored, ...payload } = manifest || {};
+  const body = JSON.stringify(stableValue(payload));
+  return `sha256:${crypto.createHash('sha256').update(body).digest('hex')}`;
+}
+
+function sealRuntimeManifest(manifest) {
+  const payload = { ...manifest };
+  delete payload.manifestDigest;
+  return { ...payload, manifestDigest: runtimeManifestDigest(payload) };
+}
+
 function positiveNumber(value) {
   const number = Number(value);
   return Number.isFinite(number) && number >= 0 ? number : null;
@@ -73,6 +91,8 @@ function evaluateRuntimeEvidence(manifest, options = {}) {
   if (manifest?.runtime !== runtime) reasons.push('manifest:runtime_mismatch');
   if (manifest?.revision !== revision) reasons.push('manifest:revision_mismatch');
   if (!manifest?.deploymentId || typeof manifest.deploymentId !== 'string') reasons.push('manifest:deployment');
+  const manifestDigest = runtimeManifestDigest(manifest);
+  if (manifest?.manifestDigest !== manifestDigest) reasons.push('manifest:digest');
   const artifacts = Array.isArray(manifest?.artifacts) ? manifest.artifacts : [];
   const byKind = new Map();
   for (const artifact of artifacts) {
@@ -90,7 +110,7 @@ function evaluateRuntimeEvidence(manifest, options = {}) {
     revision,
     deploymentId: manifest?.deploymentId || null,
     evaluatedAt: new Date(now).toISOString(),
-    manifestDigest: `sha256:${crypto.createHash('sha256').update(JSON.stringify(manifest || null)).digest('hex')}`,
+    manifestDigest,
     reasons: uniqueReasons,
   });
 }
@@ -101,4 +121,7 @@ function assertRuntimeEvidence(manifest, options = {}) {
   return decision;
 }
 
-module.exports = { COMMON_ARTIFACTS, RUNTIME_ARTIFACTS, ReleaseGateError, assertRuntimeEvidence, evaluateRuntimeEvidence };
+module.exports = {
+  COMMON_ARTIFACTS, RUNTIME_ARTIFACTS, ReleaseGateError, assertRuntimeEvidence,
+  evaluateRuntimeEvidence, runtimeManifestDigest, sealRuntimeManifest,
+};

--- a/lib/runtime-cutover/index.js
+++ b/lib/runtime-cutover/index.js
@@ -15,6 +15,7 @@ const MATRICES = Object.freeze({
   }),
 });
 const TARGETS = Object.freeze({ jobs: 'graphile', factory: 'langgraph' });
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 
 class CutoverError extends Error {
   constructor(code, reasons = []) {
@@ -46,7 +47,11 @@ function createCutoverPlan(input) {
   if (!/^[0-9a-f]{40}$/.test(String(input?.revision || ''))) reasons.push('cutover_revision_invalid');
   if (!['admin', 'platform_owner'].includes(input?.actorRole)) reasons.push('cutover_forbidden');
   if (input?.freezeConfirmed !== true) reasons.push('cutover_freeze_required');
-  if (input?.releaseDecision?.allowed !== true || input.releaseDecision.revision !== input.revision) reasons.push('cutover_release_gate_failed');
+  if (input?.releaseDecision?.allowed !== true
+    || input.releaseDecision.revision !== input.revision
+    || !DIGEST_PATTERN.test(String(input.releaseDecision.manifestDigest || ''))) {
+    reasons.push('cutover_release_gate_failed');
+  }
   const items = Array.isArray(input?.items) ? input.items : [];
   const records = items.map((item) => Object.freeze({
     tenantId: validateIdentity(item) ? item.tenantId : null,

--- a/tests/integration/runtime-release-manifest.integration.test.js
+++ b/tests/integration/runtime-release-manifest.integration.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  evaluateRuntimeEvidence, sealRuntimeManifest,
+} = require('../../lib/release-gates/runtime-evidence');
+
+it('preserves an immutable manifest seal through JSON artifact transport', () => {
+  const revision = 'a'.repeat(40);
+  const manifest = sealRuntimeManifest({
+    schemaVersion: 1, runtime: 'graphile', revision, deploymentId: 'staging-1', artifacts: [],
+  });
+  const transported = JSON.parse(JSON.stringify(manifest));
+  const decision = evaluateRuntimeEvidence(transported, {
+    runtime: 'graphile', revision, now: Date.parse('2026-08-19T18:00:00.000Z'),
+  });
+  assert.equal(decision.manifestDigest, manifest.manifestDigest);
+  assert.equal(decision.reasons.includes('manifest:digest'), false);
+});

--- a/tests/security/runtime-release-manifest.security.test.js
+++ b/tests/security/runtime-release-manifest.security.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { it } = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  evaluateRuntimeEvidence, sealRuntimeManifest,
+} = require('../../lib/release-gates/runtime-evidence');
+
+it('fails closed when deployment identity is changed after a manifest is sealed', () => {
+  const revision = 'a'.repeat(40);
+  const manifest = JSON.parse(JSON.stringify(sealRuntimeManifest({
+    schemaVersion: 1, runtime: 'langgraph', revision, deploymentId: 'staging-1', artifacts: [],
+  })));
+  manifest.deploymentId = 'attacker-controlled';
+  const decision = evaluateRuntimeEvidence(manifest, {
+    runtime: 'langgraph', revision, now: Date.parse('2026-08-19T18:00:00.000Z'),
+  });
+  assert.ok(decision.reasons.includes('manifest:digest'));
+  assert.equal(decision.allowed, false);
+});

--- a/tests/unit/runtime-cutover.test.js
+++ b/tests/unit/runtime-cutover.test.js
@@ -8,7 +8,9 @@ const { verify: verifyLegacyRemoval } = require('../../scripts/verify-legacy-run
 
 const base = {
   epoch: '98f48812-7aa6-4ce8-9e88-184ba4bcbb52', revision: 'a'.repeat(40), actorRole: 'admin',
-  freezeConfirmed: true, releaseDecision: { allowed: true, revision: 'a'.repeat(40) },
+  freezeConfirmed: true, releaseDecision: {
+    allowed: true, revision: 'a'.repeat(40), manifestDigest: `sha256:${'b'.repeat(64)}`,
+  },
 };
 
 test('approved matrices deterministically classify every supported legacy job and factory state', () => {

--- a/tests/unit/runtime-release-evidence.test.js
+++ b/tests/unit/runtime-release-evidence.test.js
@@ -2,7 +2,9 @@
 
 const assert = require('node:assert/strict');
 const { test } = require('node:test');
-const { RUNTIME_ARTIFACTS, assertRuntimeEvidence, evaluateRuntimeEvidence } = require('../../lib/release-gates/runtime-evidence');
+const {
+  RUNTIME_ARTIFACTS, assertRuntimeEvidence, evaluateRuntimeEvidence, sealRuntimeManifest,
+} = require('../../lib/release-gates/runtime-evidence');
 const { collectRuntimeEvidence, evidenceDigest, stableValue } = require('../../lib/release-gates/evidence-collector');
 const { buildSbomEvidence, validateSbom } = require('../../scripts/generate-runtime-sbom');
 
@@ -25,7 +27,7 @@ function summary(kind, runtime) {
 }
 
 function manifest(runtime = 'graphile') {
-  return {
+  return sealRuntimeManifest({
     schemaVersion: 1, runtime, revision, deploymentId: 'staging-20260718-1',
     artifacts: RUNTIME_ARTIFACTS[runtime].map((kind) => ({
       kind, status: 'passed', revision, redacted: true,
@@ -33,7 +35,7 @@ function manifest(runtime = 'graphile') {
       generatedAt: '2026-07-18T11:00:00.000Z', expiresAt: '2026-07-19T12:00:00.000Z',
       provenance: { automation: 'pipeline-123', environment: 'staging' }, summary: summary(kind, runtime),
     })),
-  };
+  });
 }
 
 function components(runtime = 'graphile') {
@@ -121,6 +123,13 @@ test('manifest and immutable artifact provenance fail closed at every trust boun
   const nullArtifact = manifest('graphile');
   nullArtifact.artifacts.push(null);
   assert.ok(evaluateRuntimeEvidence(nullArtifact, { runtime: 'graphile', revision, now }).reasons.includes('artifact_invalid'));
+});
+
+test('manifest seal rejects any post-collection mutation', () => {
+  const value = JSON.parse(JSON.stringify(manifest('graphile')));
+  value.artifacts.find((artifact) => artifact.kind === 'security').summary.high = 1;
+  const decision = evaluateRuntimeEvidence(value, { runtime: 'graphile', revision, now });
+  assert.ok(decision.reasons.includes('manifest:digest'));
 });
 
 test('every release threshold dimension independently blocks readiness', () => {


### PR DESCRIPTION
## Summary

Seal Graphile and LangGraph release manifests with a deterministic SHA-256 over the complete deployment-bound payload, and reject any post-collection mutation during verification and cutover planning.

## Linked Task

- Task: GitHub #324, Simple

## Standards Compliance

- Standards baseline reviewed: `AGENTS.md`, exclusive-runtime architecture and cutover runbook
- Checklist completed or updated: Yes
- Compliance checklist path: `docs/runbooks/runtime-hardening-cutover.md`
- Relevant standards areas: immutable release evidence, provenance, fail-closed cutover gates
- Standards gaps or exceptions: Existing unsealed manifests are intentionally rejected and must be regenerated by automation.

## Required Evidence

- Standards check result: Pass (`npm run standards:check`)
- Lint result: Pass (`npm run lint`)
- Tests: Pass (`node --test tests/unit/runtime-release-evidence.test.js tests/unit/runtime-cutover.test.js tests/integration/runtime-release-manifest.integration.test.js tests/security/runtime-release-manifest.security.test.js`)
- Test evidence paths: `tests/unit/runtime-release-evidence.test.js`, `tests/unit/runtime-cutover.test.js`, `tests/integration/runtime-release-manifest.integration.test.js`, `tests/security/runtime-release-manifest.security.test.js`
- Docs updated: Yes
- Doc evidence paths: `docs/architecture/exclusive-runtime-cutover.md`, `docs/runbooks/runtime-hardening-cutover.md`

## Risk and Rollback

- Risk level: Medium
- Rollback path: Revert this commit and regenerate manifests with the prior collector; no runtime ownership is changed by collection or verification.

## Notes

This PR is stacked on #330 so its diff contains only the manifest-sealing change. It will be retargeted after its parent merges.

Closes #324

