### PR TITLE
feat(release): deploy exact revision to isolated staging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,8 @@ stages:
   - performance
   - test
   - verify
+  - staging
+  - soak
   - deploy
 
 .node-job:
@@ -149,6 +151,72 @@ langgraph-01-verify:
       - playwright-report/
     expire_in: 2 weeks
 
+# Deploy the exact main revision into a persistent, isolated launchd profile.
+# Protected variables are mandatory; no local/default-stack fallback is allowed.
+deploy-runtime-staging:
+  extends: .node-job
+  stage: staging
+  interruptible: false
+  resource_group: runtime-staging
+  timeout: 45 minutes
+  needs:
+    - build
+    - graphile-02-verify
+    - langgraph-01-verify
+  environment:
+    name: staging
+    url: $STAGING_BASE_URL
+  script:
+    - export STAGING_REVISION="$CI_COMMIT_SHA"
+    - export STAGING_DEPLOYMENT_ID="staging-${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export STAGING_REPOSITORY_URL="$CI_PROJECT_DIR"
+    - npm run release:staging:deploy
+    - mkdir -p .artifacts/runtime-release
+    - cp "$STAGING_RELEASE_ROOT/artifacts/$STAGING_DEPLOYMENT_ID/"*.json .artifacts/runtime-release/
+    - printf 'STAGING_DEPLOYMENT_ID=%s\nSTAGING_REVISION=%s\n' "$STAGING_DEPLOYMENT_ID" "$STAGING_REVISION" > .artifacts/runtime-release/deployment.env
+  artifacts:
+    paths:
+      - .artifacts/runtime-release/
+    reports:
+      dotenv: .artifacts/runtime-release/deployment.env
+    expire_in: 2 weeks
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $STAGING_BASE_URL && $STAGING_DATABASE_URL && $STAGING_RELEASE_ROOT'
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+      when: manual
+      allow_failure: true
+    - when: never
+
+# This is intentionally a real 24-hour gate. Shortened harness runs cannot
+# satisfy the sealed runtime release manifest threshold.
+runtime-soak-24h:
+  extends: .node-job
+  stage: soak
+  interruptible: false
+  resource_group: runtime-staging
+  timeout: 26 hours
+  needs:
+    - job: deploy-runtime-staging
+      artifacts: true
+  variables:
+    SOAK_DURATION_SECONDS: "86400"
+    SOAK_ENVIRONMENT: staging
+    SOAK_OUTPUT_DIR: .artifacts/runtime-soak
+  script:
+    - export DATABASE_URL="$STAGING_DATABASE_URL"
+    - export SOAK_DEPLOYMENT_ID="$STAGING_DEPLOYMENT_ID"
+    - export SOAK_REVISION="$STAGING_REVISION"
+    - npm run test:runtime:soak
+  artifacts:
+    when: always
+    paths:
+      - .artifacts/runtime-release/
+      - .artifacts/runtime-soak/
+    expire_in: 2 weeks
+  rules:
+    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $STAGING_BASE_URL && $STAGING_DATABASE_URL && $STAGING_RELEASE_ROOT'
+    - when: never
+
 # Preserve an explicit deploy stage without performing an automatic production mutation.
 deploy-review:
   stage: deploy
@@ -156,6 +224,8 @@ deploy-review:
     - build
     - graphile-02-verify
     - langgraph-01-verify
+    - job: runtime-soak-24h
+      optional: true
   script:
     - echo "All verified artifacts are ready for an operator-owned production review."
   rules:

--- a/config/change-ownership-map.json
+++ b/config/change-ownership-map.json
@@ -846,10 +846,10 @@
       "runtime_patterns": [
         "^lib/software-factory/langgraph/",
         "^lib/task-platform/langgraph-",
-        "^lib/release-gates/(?:evidence-collector|runtime-evidence)\\.js$",
+        "^lib/release-gates/(?:evidence-collector|runtime-evidence|staging-deployment)\\.js$",
         "^lib/runtime-cutover/",
         "^db/migrations/(?:018_langgraph_runtime_persistence|019_job_runtime_operations|020_langgraph_interrupts|021_runtime_cutover_ownership|022_langgraph_lifecycle_events)(?:\\.down)?\\.sql$",
-        "^scripts/(?:collect-runtime-release-evidence|generate-runtime-sbom|run-browser-gates|run-langgraph-load|run-runtime-soak|setup-langgraph-postgres|verify-langgraph-lifecycle-equivalence|verify-legacy-runtime-removal|verify-runtime-cutover|verify-runtime-release-evidence|wait-for-performance-host)\\.js$",
+        "^scripts/(?:collect-runtime-release-evidence|deploy-runtime-staging|generate-runtime-sbom|run-browser-gates|run-langgraph-load|run-runtime-soak|setup-langgraph-postgres|verify-langgraph-lifecycle-equivalence|verify-legacy-runtime-removal|verify-runtime-cutover|verify-runtime-release-evidence|wait-for-performance-host)\\.js$",
         "^scripts/run-langgraph-load-docker\\.sh$"
       ],
       "test_requirements": [
@@ -858,6 +858,7 @@
           "patterns": [
             "^tests/unit/langgraph-.+\\.test\\.js$",
             "^tests/unit/runtime-release-evidence\\.test\\.js$",
+            "^tests/unit/staging-deployment\\.test\\.js$",
             "^tests/contract/langgraph-(?:runtime|alerts)\\.contract\\.test\\.js$",
             "^tests/e2e/langgraph-runtime\\.e2e\\.test\\.js$",
             "^src/app/LangGraphRunPanel\\.test\\.tsx$"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,3 +207,11 @@ The canonical cohort report lives at `docs/reports/SIMPLE_TRUSTED_COHORT_REPORT.
 ### Dependency installation boundary
 
 The repository commits `package.json` and `package-lock.json`, not `node_modules/`. Persistent launchd and staging deployments install dependencies with `npm ci` at the exact revision. This prevents stale native binaries or package metadata from silently changing startup behavior while preserving reproducible dependency resolution.
+
+### Isolated staging factory profile
+
+The hosted staging release uses `FACTORY_STACK_PROFILE=staging`. That profile has independent launchd
+labels, ports, root binding, state, logs, and database configuration; it cannot replace the default
+factory-of-record binding. The deployer accepts only an exact commit SHA in a persistent release root,
+then requires both local topology health and a non-local HTTPS `/health` response before it emits
+revision-bound staging evidence.

--- a/docs/architecture/exclusive-runtime-cutover.md
+++ b/docs/architecture/exclusive-runtime-cutover.md
@@ -4,6 +4,11 @@ Issues #283 and #289 use the same ownership primitive from migration `021_runtim
 
 This is one full switch: no pilot, percentage rollout, shadow side effect, or permanent fallback is permitted.
 
+Staging is a distinct launchd profile, not a second binding of the default factory services. The release
+checkout, root binding, labels, state, logs, ports, database, and hosted health proof are isolated and tied
+to one exact 40-character revision plus deployment ID. The cutover gate rejects staging evidence unless
+both local and hosted health passed from this isolated profile.
+
 ## Reconciliation matrices
 
 | Scope | Legacy state | Disposition |

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -1156,3 +1156,11 @@ Use `summary.residual.additionalTrustedClosesRequired`, not only the distance to
 ### Reproduce dependencies for persistent services
 
 `node_modules/` is intentionally untracked. A clean checkout or exact-revision staging release must run `npm ci` from the committed `package-lock.json` before installing or restarting launchd services. Never copy an installed dependency tree between revisions; native binaries and Vite/Rolldown package metadata must come from the lockfile on the target host.
+
+### Keep staging separate from the factory of record
+
+Configure staging through the protected `STAGING_BASE_URL`, `STAGING_DATABASE_URL`, and
+`STAGING_RELEASE_ROOT` variables. `release:staging:deploy` installs the exact revision beneath the
+persistent release root and starts only the `staging` launchd profile. Do not point these variables at
+the default ports, database, state directory, or root binding. A missing HTTPS host or unhealthy local
+or hosted probe blocks evidence creation and the 24-hour soak.

--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -2,6 +2,25 @@
 
 ## Evidence collection
 
+### Exact-revision isolated staging
+
+The default factory stack and staging are separate launchd profiles. Staging uses independent labels,
+ports, logs, state, and root binding, so an approved release cannot rebind or interrupt the host's
+factory of record. Configure protected CI variables `STAGING_BASE_URL`, `STAGING_DATABASE_URL`, and
+`STAGING_RELEASE_ROOT`; the base URL must be non-local HTTPS and the release root must be an absolute,
+persistent path outside temporary and `_checkouts` directories.
+
+On protected `main`, `deploy-runtime-staging` clones the exact `CI_COMMIT_SHA` into
+`$STAGING_RELEASE_ROOT/releases/<sha>`, removes the credential-bearing remote, installs from the lockfile,
+starts only the `staging` launchd profile, and verifies local plus hosted `/health`. It emits revision-bound
+Graphile and LangGraph `staging_deploy` components. An existing release directory with another revision,
+an unhealthy local stack, a redirect, or unhealthy hosted endpoint blocks deployment.
+
+The staging and soak jobs share the `runtime-staging` resource group and are non-interruptible. This
+prevents concurrent releases from sharing the dedicated staging database or contaminating the 24-hour
+window. Their artifacts and deployment dotenv are retained for two weeks. Production remains a separate
+manual review; the pipeline never applies a runtime cutover.
+
 Collect immutable artifacts from the same revision and staging deployment. Run focused Graphile/LangGraph tests, Docker integration, contracts, security/SBOM/secrets, 2× load for ten minutes, deterministic chaos, browser/accessibility, rollback, three lifecycle synthetics, 24-hour soak, and disposable backup/restore/reconcile. Exercise alert delivery and both kill switches. Do not copy raw jobs, checkpoints, tokens, database URLs, or task content into evidence.
 
 Validate with:

--- a/lib/release-gates/runtime-evidence.js
+++ b/lib/release-gates/runtime-evidence.js
@@ -64,6 +64,10 @@ function artifactReasons(artifact, input) {
   if (!Number.isFinite(expires) || expires <= input.now) reasons.push(`${prefix}:stale`);
 
   const summary = artifact.summary || {};
+  if (prefix === 'staging_deploy' && (
+    summary.exactRevision !== true || summary.hostedHealth !== true
+    || summary.isolatedProfile !== true || summary.localHealth !== true
+  )) reasons.push(`${prefix}:deployment`);
   if (prefix === 'security' && (positiveNumber(summary.high) !== 0 || positiveNumber(summary.critical) !== 0)) reasons.push(`${prefix}:findings`);
   if (prefix === 'performance_2x_10m') {
     if (positiveNumber(summary.durationSeconds) < 600 || positiveNumber(summary.loadFactor) < 2) reasons.push(`${prefix}:duration_or_load`);

--- a/lib/release-gates/staging-deployment.js
+++ b/lib/release-gates/staging-deployment.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const path = require('node:path');
+const os = require('node:os');
+const { evidenceDigest } = require('./evidence-collector');
+
+const SHA_PATTERN = /^[0-9a-f]{40}$/;
+const DEPLOYMENT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{2,127}$/;
+
+function realPathCandidate(value) {
+  return path.resolve(String(value || ''));
+}
+
+function isTemporaryPath(value) {
+  const candidate = realPathCandidate(value);
+  const temporaryRoots = [...new Set(['/tmp', '/private/tmp', os.tmpdir()].map((entry) => path.resolve(entry)))];
+  return temporaryRoots.some((entry) => candidate === entry || candidate.startsWith(`${entry}${path.sep}`))
+    || candidate.split(path.sep).includes('_checkouts');
+}
+
+function protectedHttpsUrl(value) {
+  let parsed;
+  try { parsed = new URL(value); } catch { return null; }
+  const hostname = parsed.hostname.toLowerCase();
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
+  if (['localhost', '127.0.0.1', '::1'].includes(hostname) || hostname.endsWith('.local')) return null;
+  return parsed;
+}
+
+function stagingConfiguration(env = process.env) {
+  const revision = String(env.STAGING_REVISION || env.CI_COMMIT_SHA || '').trim();
+  const deploymentId = String(env.STAGING_DEPLOYMENT_ID || '').trim();
+  const releaseRoot = realPathCandidate(env.STAGING_RELEASE_ROOT);
+  const baseUrl = protectedHttpsUrl(String(env.STAGING_BASE_URL || '').trim());
+  const databaseUrl = String(env.STAGING_DATABASE_URL || '').trim();
+  const repositoryUrl = String(env.STAGING_REPOSITORY_URL || env.CI_PROJECT_DIR || '').trim();
+  const errors = [];
+  if (!SHA_PATTERN.test(revision)) errors.push('STAGING_REVISION must be an exact lowercase 40-character commit SHA.');
+  if (!DEPLOYMENT_PATTERN.test(deploymentId)) errors.push('STAGING_DEPLOYMENT_ID must be a stable 3-128 character identifier.');
+  if (!env.STAGING_RELEASE_ROOT || !path.isAbsolute(env.STAGING_RELEASE_ROOT) || isTemporaryPath(releaseRoot)) {
+    errors.push('STAGING_RELEASE_ROOT must be an absolute persistent path outside temporary and _checkouts directories.');
+  }
+  if (!baseUrl) errors.push('STAGING_BASE_URL must be a credential-free, non-local HTTPS URL.');
+  let parsedDatabase;
+  try { parsedDatabase = new URL(databaseUrl); } catch { parsedDatabase = null; }
+  if (!parsedDatabase || !['postgres:', 'postgresql:'].includes(parsedDatabase.protocol)) {
+    errors.push('STAGING_DATABASE_URL must be an explicit PostgreSQL URL for the dedicated staging database.');
+  }
+  if (!repositoryUrl) errors.push('STAGING_REPOSITORY_URL or CI_PROJECT_DIR is required.');
+  if (repositoryUrl && !path.isAbsolute(repositoryUrl)) {
+    let parsedRepository;
+    try { parsedRepository = new URL(repositoryUrl); } catch { parsedRepository = null; }
+    if (!parsedRepository || parsedRepository.username || parsedRepository.password) {
+      errors.push('The staging repository source must be an absolute checkout path or a credential-free URL.');
+    }
+  }
+  if (errors.length) {
+    const error = new Error(errors.join(' '));
+    error.code = 'staging_configuration_invalid';
+    error.reasons = errors;
+    throw error;
+  }
+  return Object.freeze({
+    baseUrl: baseUrl.toString().replace(/\/$/, ''),
+    databaseUrl,
+    deploymentId,
+    releaseDir: path.join(releaseRoot, 'releases', revision),
+    releaseRoot,
+    repositoryUrl,
+    revision,
+    stateDir: path.join(releaseRoot, 'state', 'staging'),
+    artifactDir: path.join(releaseRoot, 'artifacts', deploymentId),
+  });
+}
+
+function stagingServiceEnvironment(configuration, env = process.env) {
+  return Object.freeze({
+    ...env,
+    DATABASE_URL: configuration.databaseUrl,
+    FACTORY_STACK_DATABASE_URL: configuration.databaseUrl,
+    FACTORY_STACK_PROFILE: 'staging',
+    FACTORY_STACK_STATE_DIR: configuration.stateDir,
+    FACTORY_STACK_ROOT_BINDING_FILE: path.join(configuration.stateDir, 'repo-root.json'),
+    FACTORY_STACK_LOG_DIR: path.join(configuration.releaseRoot, 'logs', 'staging'),
+    FACTORY_STACK_NODE_ENV: 'production',
+    STAGING_DEPLOYMENT_ID: configuration.deploymentId,
+    STAGING_REVISION: configuration.revision,
+  });
+}
+
+function buildStagingDeployComponent(input) {
+  const generatedAt = input.generatedAt || new Date().toISOString();
+  const evidence = Object.freeze({
+    checkoutRevision: input.revision,
+    deploymentId: input.deploymentId,
+    healthUrl: input.healthUrl,
+    localHealth: input.localHealth,
+    profile: input.profile,
+    releaseDirectory: input.releaseDirectory,
+  });
+  return Object.freeze({
+    schemaVersion: 1,
+    runtime: input.runtime,
+    kind: 'staging_deploy',
+    status: input.hostedHealth === true && input.localHealth === true ? 'passed' : 'failed',
+    revision: input.revision,
+    redacted: true,
+    digest: evidenceDigest(evidence),
+    generatedAt,
+    expiresAt: input.expiresAt || new Date(Date.parse(generatedAt) + 7 * 86_400_000).toISOString(),
+    provenance: { automation: input.automation, environment: 'staging' },
+    summary: {
+      deploymentId: input.deploymentId,
+      exactRevision: true,
+      hostedHealth: input.hostedHealth === true,
+      isolatedProfile: input.profile === 'staging',
+      localHealth: input.localHealth === true,
+    },
+    evidence,
+  });
+}
+
+module.exports = {
+  buildStagingDeployComponent,
+  isTemporaryPath,
+  protectedHttpsUrl,
+  stagingConfiguration,
+  stagingServiceEnvironment,
+};

--- a/lib/task-platform/factory-stack/defaults.js
+++ b/lib/task-platform/factory-stack/defaults.js
@@ -8,30 +8,44 @@ const os = require('node:os');
 // services are host-persistent, so allowing cwd to select their checkout lets a
 // disposable staging worktree become the host's factory of record.
 const ROOT = path.resolve(__dirname, '..', '..', '..');
-const STATE_DIR = path.join(ROOT, 'observability', 'factory-stack');
+const PROFILE = String(process.env.FACTORY_STACK_PROFILE || 'default').trim().toLowerCase();
+if (!/^[a-z][a-z0-9-]{0,31}$/.test(PROFILE)) {
+  throw new Error(`Invalid FACTORY_STACK_PROFILE: ${PROFILE || 'empty'}`);
+}
+const PROFILE_SUFFIX = PROFILE === 'default' ? '' : `-${PROFILE}`;
+const PROFILE_HOME = path.join(
+  os.homedir(), 'Library', 'Application Support', 'engineering-team-factory', 'profiles', PROFILE,
+);
+const STATE_DIR = process.env.FACTORY_STACK_STATE_DIR
+  || (PROFILE === 'default' ? path.join(ROOT, 'observability', 'factory-stack') : PROFILE_HOME);
 const LOG_DIR = path.join(STATE_DIR, 'logs');
 const ENV_FILE = path.join(STATE_DIR, 'service.env');
 const ENV_EXAMPLE = path.join(ROOT, 'deploy', 'launchd', 'factory-stack.env.example');
 const FA_STATE_DIR = path.join(STATE_DIR, 'forgeadapter');
 const ROOT_BINDING_FILE = process.env.FACTORY_STACK_ROOT_BINDING_FILE
-  || path.join(os.homedir(), 'Library', 'Application Support', 'engineering-team-factory', 'repo-root.json');
+  || (PROFILE === 'default'
+    ? path.join(os.homedir(), 'Library', 'Application Support', 'engineering-team-factory', 'repo-root.json')
+    : path.join(PROFILE_HOME, 'repo-root.json'));
 
 const LABELS = Object.freeze({
-  postgresEnsure: 'com.engineering-team.factory-postgres-ensure',
-  api: 'com.engineering-team.factory-audit-api',
-  workers: 'com.engineering-team.factory-audit-workers',
-  ui: 'com.engineering-team.factory-ui',
-  forgeadapter: 'com.engineering-team.factory-forgeadapter',
+  postgresEnsure: `com.engineering-team.factory${PROFILE_SUFFIX}-postgres-ensure`,
+  api: `com.engineering-team.factory${PROFILE_SUFFIX}-audit-api`,
+  workers: `com.engineering-team.factory${PROFILE_SUFFIX}-audit-workers`,
+  ui: `com.engineering-team.factory${PROFILE_SUFFIX}-ui`,
+  forgeadapter: `com.engineering-team.factory${PROFILE_SUFFIX}-forgeadapter`,
 });
 
+const PROFILE_PORTS = PROFILE === 'staging'
+  ? { api: 23000, ui: 25173, forgeadapter: 24010, postgres: 25432 }
+  : { api: 13000, ui: 15173, forgeadapter: 14010, postgres: 15432 };
 const DEFAULT_PORTS = Object.freeze({
-  api: Number(process.env.FACTORY_STACK_API_PORT || process.env.GOLDEN_PATH_ET_API_PORT || 13000),
-  ui: Number(process.env.FACTORY_STACK_UI_PORT || process.env.GOLDEN_PATH_UI_PORT || 15173),
+  api: Number(process.env.FACTORY_STACK_API_PORT || process.env.GOLDEN_PATH_ET_API_PORT || PROFILE_PORTS.api),
+  ui: Number(process.env.FACTORY_STACK_UI_PORT || process.env.GOLDEN_PATH_UI_PORT || PROFILE_PORTS.ui),
   openclawLive: Number(process.env.FACTORY_STACK_OPENCLAW_PORT || 18789),
   openclawMock: 14001,
   hermesMock: 14002,
-  forgeadapter: Number(process.env.FACTORY_STACK_FA_PORT || process.env.GOLDEN_PATH_FA_PORT || 14010),
-  postgres: Number(process.env.FACTORY_STACK_PG_PORT || 15432),
+  forgeadapter: Number(process.env.FACTORY_STACK_FA_PORT || process.env.GOLDEN_PATH_FA_PORT || PROFILE_PORTS.forgeadapter),
+  postgres: Number(process.env.FACTORY_STACK_PG_PORT || PROFILE_PORTS.postgres),
 });
 
 function defaultDatabaseUrl() {
@@ -60,7 +74,7 @@ function launchAgentsDir() {
 
 function logsHomeDir() {
   return process.env.FACTORY_STACK_LOG_DIR
-    || path.join(os.homedir(), 'Library', 'Logs', 'engineering-team-factory');
+    || path.join(os.homedir(), 'Library', 'Logs', `engineering-team-factory${PROFILE_SUFFIX}`);
 }
 
 function resolveForgeadapterDir(explicit) {
@@ -87,20 +101,18 @@ function forgeadapterServiceToken() {
 }
 
 function buildServiceEnv(overrides = {}) {
-  const apiPort = DEFAULT_PORTS.api;
-  const uiPort = DEFAULT_PORTS.ui;
   const openclawUrl = defaultOpenclawUrl();
   const databaseUrl = defaultDatabaseUrl();
   const runner = process.env.SPECIALIST_DELEGATION_RUNNER
     || `node ${path.join(ROOT, 'scripts', 'openclaw-specialist-runner.js')}`;
-  const etApiUrl = `http://127.0.0.1:${apiPort}`;
+  const etApiUrl = `http://127.0.0.1:${DEFAULT_PORTS.api}`;
   const forgeadapterUrl = `http://127.0.0.1:${DEFAULT_PORTS.forgeadapter}`;
   return {
-    NODE_ENV: process.env.NODE_ENV || 'development',
+    NODE_ENV: process.env.FACTORY_STACK_NODE_ENV || process.env.NODE_ENV || 'development',
     PATH: process.env.PATH || '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin',
-    PORT: String(apiPort),
+    PORT: String(DEFAULT_PORTS.api),
     DATABASE_URL: databaseUrl,
-    PGSSLMODE: 'disable',
+    PGSSLMODE: process.env.PGSSLMODE || 'disable',
     AUDIT_STORE_BACKEND: 'postgres',
     AUTH_JWT_SECRET: process.env.AUTH_JWT_SECRET || 'golden-path-local-dev-secret',
     AUTH_SESSION_SECRET: process.env.AUTH_SESSION_SECRET || 'golden-path-local-session-secret',
@@ -108,7 +120,7 @@ function buildServiceEnv(overrides = {}) {
     AUTH_EMAIL_PROVIDER: 'test',
     AUTH_REGISTRATION_MODE: 'admin-approved',
     AUTH_REGISTRATION_DEFAULT_TENANT: 'engineering-team',
-    AUTH_PUBLIC_APP_URL: process.env.AUTH_PUBLIC_APP_URL || `http://127.0.0.1:${uiPort}`,
+    AUTH_PUBLIC_APP_URL: process.env.AUTH_PUBLIC_APP_URL || `http://127.0.0.1:${DEFAULT_PORTS.ui}`,
     AUTH_REQUIRE_EMAIL_VERIFICATION: 'false',
     FF_AUDIT_FOUNDATION: 'true',
     FF_WORKFLOW_ENGINE: 'true',
@@ -119,6 +131,7 @@ function buildServiceEnv(overrides = {}) {
     FACTORY_USE_FIXTURE_DELEGATION: 'false',
     FACTORY_PROOF_PROFILE: process.env.FACTORY_PROOF_PROFILE || 'live',
     FACTORY_STACK_REPO_ROOT: ROOT,
+    FACTORY_STACK_PROFILE: PROFILE,
     OPENCLAW_BASE_URL: openclawUrl,
     SPECIALIST_DELEGATION_RUNNER: runner,
     OPENCLAW_DELEGATION_TIMEOUT_SEC: process.env.OPENCLAW_DELEGATION_TIMEOUT_SEC || '90',
@@ -266,6 +279,7 @@ function buildForgeadapterEnv(baseEnv = buildServiceEnv(), forgeadapterDir) {
 
 module.exports = {
   ROOT,
+  PROFILE,
   STATE_DIR,
   LOG_DIR,
   ENV_FILE,

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:langgraph:docker": "LANGGRAPH_INTEGRATION_SCOPE=focused bash scripts/run-postgres-integration-docker.sh",
     "release:langgraph:verify": "node scripts/verify-runtime-release-evidence.js --runtime langgraph --evidence",
     "release:langgraph:collect": "node scripts/collect-runtime-release-evidence.js --runtime langgraph",
+    "release:staging:deploy": "node scripts/deploy-runtime-staging.js",
     "cutover:langgraph:preflight": "node scripts/verify-runtime-cutover.js",
     "cutover:langgraph:legacy-zero": "node scripts/verify-legacy-runtime-removal.js --scope factory",
     "test:integration:postgres": "node --test --test-concurrency=1 tests/integration/audit-postgres-e2e.test.js tests/integration/registration-auth-migration-postgres.integration.test.js tests/integration/factory-delivery-queue-postgres.integration.test.js tests/integration/job-runtime-postgres.integration.test.js tests/integration/langgraph-postgres.integration.test.js tests/integration/langgraph-process-recovery-postgres.integration.test.js",

--- a/scripts/deploy-runtime-staging.js
+++ b/scripts/deploy-runtime-staging.js
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const {
+  buildStagingDeployComponent,
+  stagingConfiguration,
+  stagingServiceEnvironment,
+} = require('../lib/release-gates/staging-deployment');
+
+function run(command, args, options = {}) {
+  const output = execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...options });
+  return typeof output === 'string' ? output.trim() : '';
+}
+
+function writeJson(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const temporary = `${file}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, file);
+}
+
+function checkoutRevision(directory) {
+  return run('git', ['rev-parse', 'HEAD'], { cwd: directory });
+}
+
+function verifyRelease(directory, revision) {
+  if (checkoutRevision(directory) !== revision) {
+    throw new Error(`Staging release does not match requested revision: ${directory}`);
+  }
+  run('git', ['fsck', '--no-dangling'], { cwd: directory });
+  run('git', ['diff-index', '--quiet', 'HEAD', '--'], { cwd: directory });
+  return true;
+}
+
+function prepareRelease(configuration) {
+  fs.mkdirSync(path.dirname(configuration.releaseDir), { recursive: true });
+  if (fs.existsSync(configuration.releaseDir)) {
+    verifyRelease(configuration.releaseDir, configuration.revision);
+    return { created: false, releaseDir: configuration.releaseDir };
+  }
+  const preparing = `${configuration.releaseDir}.preparing-${process.pid}`;
+  run('git', ['clone', '--no-checkout', configuration.repositoryUrl, preparing]);
+  try {
+    run('git', ['checkout', '--detach', configuration.revision], { cwd: preparing });
+    run('git', ['remote', 'remove', 'origin'], { cwd: preparing });
+    run('npm', ['ci', '--cache', path.join(configuration.releaseRoot, '.npm'), '--prefer-offline'], {
+      cwd: preparing,
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    verifyRelease(preparing, configuration.revision);
+    fs.renameSync(preparing, configuration.releaseDir);
+  } catch (error) {
+    error.message = `Failed to prepare exact staging release ${configuration.revision}: ${error.message}`;
+    throw error;
+  }
+  return { created: true, releaseDir: configuration.releaseDir };
+}
+
+async function hostedHealth(baseUrl) {
+  const response = await fetch(`${baseUrl}/health`, {
+    headers: { accept: 'application/json', 'user-agent': 'engineering-team-staging-deployer/1' },
+    redirect: 'error',
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`Hosted staging health returned HTTP ${response.status}.`);
+  return { ok: true, status: response.status, url: `${baseUrl}/health` };
+}
+
+async function activateRelease(configuration) {
+  const env = stagingServiceEnvironment(configuration);
+  run(process.execPath, ['scripts/factory-stack.js', 'up', '--json', '--rebind-root'], {
+    cwd: configuration.releaseDir,
+    env,
+    maxBuffer: 32 * 1024 * 1024,
+    stdio: 'inherit',
+  });
+  const output = run(process.execPath, ['scripts/factory-stack.js', 'status', '--json'], {
+    cwd: configuration.releaseDir,
+    env,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  const status = JSON.parse(output);
+  if (status.ok !== true || status.health?.ok !== true) throw new Error('Local isolated staging stack did not become healthy.');
+  const hosted = await hostedHealth(configuration.baseUrl);
+  const automation = process.env.CI_JOB_URL || 'local:scripts/deploy-runtime-staging.js';
+  for (const runtime of ['graphile', 'langgraph']) {
+    writeJson(path.join(configuration.artifactDir, `${runtime}-staging-deploy.json`), buildStagingDeployComponent({
+      automation,
+      deploymentId: configuration.deploymentId,
+      healthUrl: hosted.url,
+      hostedHealth: hosted.ok,
+      localHealth: status.health.ok,
+      profile: 'staging',
+      releaseDirectory: `releases/${configuration.revision}`,
+      revision: configuration.revision,
+      runtime,
+    }));
+  }
+  return { artifactDir: configuration.artifactDir, hosted, status };
+}
+
+async function main() {
+  const configuration = stagingConfiguration();
+  const prepared = prepareRelease(configuration);
+  const activated = await activateRelease(configuration);
+  process.stdout.write(`${JSON.stringify({
+    ok: true,
+    deploymentId: configuration.deploymentId,
+    revision: configuration.revision,
+    prepared,
+    artifactDir: activated.artifactDir,
+    hosted: activated.hosted,
+  })}\n`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`${JSON.stringify({
+      ok: false, code: error.code || 'staging_deploy_failed', message: error.message, reasons: error.reasons || [],
+    })}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  activateRelease, checkoutRevision, hostedHealth, main, prepareRelease, verifyRelease, writeJson,
+};

--- a/tests/contract/factory-stack-root-binding.contract.test.js
+++ b/tests/contract/factory-stack-root-binding.contract.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { execFileSync } = require('node:child_process');
 const {
   ROOT,
   assertPersistentRepoRoot,
@@ -45,4 +46,27 @@ it('accepts a canonical generated plist as configuration evidence', () => {
     workingDirectory: ROOT,
   }));
   assert.equal(inspectLaunchdPlist(plist).ok, true);
+});
+
+it('gives staging independent persistent identity, ports, state, and logs', () => {
+  const script = `
+    const value = require('./lib/task-platform/factory-stack/defaults');
+    process.stdout.write(JSON.stringify({
+      profile: value.PROFILE, labels: value.LABELS, ports: value.DEFAULT_PORTS,
+      stateDir: value.STATE_DIR, binding: value.ROOT_BINDING_FILE, logs: value.logsHomeDir(),
+    }));
+  `;
+  const env = {
+    ...process.env, FACTORY_STACK_PROFILE: 'staging', FACTORY_STACK_STATE_DIR: '',
+    FACTORY_STACK_ROOT_BINDING_FILE: '', FACTORY_STACK_LOG_DIR: '', FACTORY_STACK_API_PORT: '',
+    FACTORY_STACK_UI_PORT: '', FACTORY_STACK_FA_PORT: '', FACTORY_STACK_PG_PORT: '',
+  };
+  const isolated = JSON.parse(execFileSync(process.execPath, ['-e', script], { cwd: ROOT, encoding: 'utf8', env }));
+  assert.equal(isolated.profile, 'staging');
+  assert.equal(isolated.ports.api, 23000);
+  assert.equal(isolated.ports.postgres, 25432);
+  assert.ok(Object.values(isolated.labels).every((label) => label.includes('factory-staging-')));
+  assert.match(isolated.stateDir, /engineering-team-factory\/profiles\/staging$/);
+  assert.match(isolated.binding, /profiles\/staging\/repo-root\.json$/);
+  assert.match(isolated.logs, /engineering-team-factory-staging$/);
 });

--- a/tests/integration/runtime-release-manifest.integration.test.js
+++ b/tests/integration/runtime-release-manifest.integration.test.js
@@ -5,6 +5,8 @@ const assert = require('node:assert/strict');
 const {
   evaluateRuntimeEvidence, sealRuntimeManifest,
 } = require('../../lib/release-gates/runtime-evidence');
+const { collectArtifact } = require('../../lib/release-gates/evidence-collector');
+const { buildStagingDeployComponent } = require('../../lib/release-gates/staging-deployment');
 
 it('preserves an immutable manifest seal through JSON artifact transport', () => {
   const revision = 'a'.repeat(40);
@@ -17,4 +19,17 @@ it('preserves an immutable manifest seal through JSON artifact transport', () =>
   });
   assert.equal(decision.manifestDigest, manifest.manifestDigest);
   assert.equal(decision.reasons.includes('manifest:digest'), false);
+});
+
+it('preserves exact staging deployment evidence through the component collector boundary', () => {
+  const revision = 'b'.repeat(40);
+  const component = buildStagingDeployComponent({
+    automation: 'pipeline-42', deploymentId: 'staging-42', generatedAt: '2026-08-19T18:00:00.000Z',
+    healthUrl: 'https://factory-staging.example.com/health', hostedHealth: true, localHealth: true,
+    profile: 'staging', releaseDirectory: '/var/lib/releases/revision', revision, runtime: 'langgraph',
+  });
+  const transported = JSON.parse(JSON.stringify(component));
+  const artifact = collectArtifact(transported, { runtime: 'langgraph', revision });
+  assert.equal(artifact.kind, 'staging_deploy');
+  assert.equal(artifact.summary.hostedHealth, true);
 });

--- a/tests/security/runtime-release-manifest.security.test.js
+++ b/tests/security/runtime-release-manifest.security.test.js
@@ -5,6 +5,7 @@ const assert = require('node:assert/strict');
 const {
   evaluateRuntimeEvidence, sealRuntimeManifest,
 } = require('../../lib/release-gates/runtime-evidence');
+const { stagingConfiguration } = require('../../lib/release-gates/staging-deployment');
 
 it('fails closed when deployment identity is changed after a manifest is sealed', () => {
   const revision = 'a'.repeat(40);
@@ -17,4 +18,16 @@ it('fails closed when deployment identity is changed after a manifest is sealed'
   });
   assert.ok(decision.reasons.includes('manifest:digest'));
   assert.equal(decision.allowed, false);
+});
+
+it('rejects local hosted targets and credential-bearing repository URLs before staging mutation', () => {
+  const base = {
+    STAGING_BASE_URL: 'https://127.0.0.1',
+    STAGING_DATABASE_URL: 'postgres://staging@db.internal/staging',
+    STAGING_DEPLOYMENT_ID: 'staging-secure',
+    STAGING_RELEASE_ROOT: '/var/lib/engineering-team-staging',
+    STAGING_REPOSITORY_URL: 'https://token@example.com/engineering-team.git',
+    STAGING_REVISION: 'a'.repeat(40),
+  };
+  assert.throws(() => stagingConfiguration(base), { code: 'staging_configuration_invalid' });
 });

--- a/tests/unit/factory-stack-service.test.js
+++ b/tests/unit/factory-stack-service.test.js
@@ -41,6 +41,7 @@ describe('factory-stack defaults', () => {
     assert.equal(LABELS.forgeadapter, 'com.engineering-team.factory-forgeadapter');
     assert.equal(LABELS.postgresEnsure, 'com.engineering-team.factory-postgres-ensure');
   });
+
 });
 
 describe('factory-stack persistent root binding', () => {

--- a/tests/unit/runtime-release-evidence.test.js
+++ b/tests/unit/runtime-release-evidence.test.js
@@ -12,6 +12,9 @@ const revision = 'a'.repeat(40);
 const now = Date.parse('2026-07-18T12:00:00.000Z');
 
 function summary(kind, runtime) {
+  if (kind === 'staging_deploy') return {
+    exactRevision: true, hostedHealth: true, isolatedProfile: true, localHealth: true,
+  };
   if (kind === 'security') return { high: 0, critical: 0 };
   if (kind === 'performance_2x_10m') return runtime === 'graphile'
     ? { durationSeconds: 600, loadFactor: 2, enqueueP95Ms: 99, enqueueP99Ms: 249, readP95Ms: 249 }
@@ -87,6 +90,15 @@ test('threshold failures block security performance chaos soak DR synthetic aler
   for (const expected of ['security:findings', 'performance_2x_10m:latency', 'chaos:recovery', 'soak_24h:threshold', 'dr_restore:recovery', 'synthetic_lifecycle:synthetic', 'alerts:routing', 'kill_switch:shutdown', 'rollback:ownership']) {
     assert.ok(reasons.includes(expected), expected);
   }
+});
+
+test('staging evidence requires exact-revision local and hosted health from an isolated profile', () => {
+  const value = manifest('graphile');
+  const artifact = value.artifacts.find((candidate) => candidate.kind === 'staging_deploy');
+  artifact.summary = {
+    exactRevision: true, hostedHealth: true, isolatedProfile: true, localHealth: false,
+  };
+  assert.ok(evaluateRuntimeEvidence(value, { runtime: 'graphile', revision, now }).reasons.includes('staging_deploy:deployment'));
 });
 
 function reasonsFor(runtime, kind, mutate) {

--- a/tests/unit/staging-deployment.test.js
+++ b/tests/unit/staging-deployment.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { test } = require('node:test');
+const {
+  buildStagingDeployComponent,
+  stagingConfiguration,
+  stagingServiceEnvironment,
+} = require('../../lib/release-gates/staging-deployment');
+
+const revision = 'a'.repeat(40);
+
+function validEnvironment() {
+  return {
+    STAGING_BASE_URL: 'https://factory-staging.example.com',
+    STAGING_DATABASE_URL: 'postgres://staging:secret@db.internal/staging_factory?sslmode=require',
+    STAGING_DEPLOYMENT_ID: 'staging-20260819-1',
+    STAGING_RELEASE_ROOT: '/var/lib/engineering-team-staging',
+    STAGING_REPOSITORY_URL: 'https://example.com/engineering-team.git',
+    STAGING_REVISION: revision,
+  };
+}
+
+test('requires an exact revision, protected HTTPS host, dedicated database, and persistent root', () => {
+  const configuration = stagingConfiguration(validEnvironment());
+  assert.equal(configuration.revision, revision);
+  assert.equal(configuration.baseUrl, 'https://factory-staging.example.com');
+  assert.equal(configuration.releaseDir, path.join('/var/lib/engineering-team-staging', 'releases', revision));
+
+  for (const override of [
+    { STAGING_REVISION: 'main' },
+    { STAGING_BASE_URL: 'http://factory-staging.example.com' },
+    { STAGING_BASE_URL: 'https://127.0.0.1' },
+    { STAGING_DATABASE_URL: '' },
+    { STAGING_RELEASE_ROOT: '/private/tmp/staging' },
+  ]) {
+    assert.throws(() => stagingConfiguration({ ...validEnvironment(), ...override }), { code: 'staging_configuration_invalid' });
+  }
+});
+
+test('builds an isolated production-mode service environment without changing default labels', () => {
+  const configuration = stagingConfiguration(validEnvironment());
+  const env = stagingServiceEnvironment(configuration, { PATH: '/usr/bin' });
+  assert.equal(env.FACTORY_STACK_PROFILE, 'staging');
+  assert.equal(env.FACTORY_STACK_NODE_ENV, 'production');
+  assert.equal(env.DATABASE_URL, validEnvironment().STAGING_DATABASE_URL);
+  assert.match(env.FACTORY_STACK_ROOT_BINDING_FILE, /state\/staging\/repo-root\.json$/);
+});
+
+test('emits revision-bound staging components and fails status when either health proof fails', () => {
+  const base = {
+    automation: 'pipeline-1', deploymentId: 'staging-20260819-1',
+    generatedAt: '2026-08-19T12:00:00.000Z', healthUrl: 'https://factory-staging.example.com/health',
+    hostedHealth: true, localHealth: true, profile: 'staging', releaseDirectory: '/var/lib/release',
+    revision, runtime: 'graphile',
+  };
+  const passing = buildStagingDeployComponent(base);
+  assert.equal(passing.status, 'passed');
+  assert.equal(passing.summary.exactRevision, true);
+  assert.match(passing.digest, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(buildStagingDeployComponent({ ...base, hostedHealth: false }).status, 'failed');
+});


### PR DESCRIPTION
## Summary

Add an isolated launchd staging profile and a fail-closed deployment command that clones the exact approved SHA into persistent storage, installs from the lockfile, verifies a clean revision, and proves both local and protected hosted health. Wire the exact deployment into protected GitLab staging and 24-hour soak jobs.

## Linked Task

- Task: GitHub #327, Simple

## Standards Compliance

- Standards baseline reviewed: `AGENTS.md`, exclusive-runtime architecture and runtime hardening runbook
- Checklist completed or updated: Yes
- Compliance checklist path: `docs/runbooks/runtime-hardening-cutover.md`
- Relevant standards areas: exact-revision deployment, environment isolation, protected variables, retained evidence, deployment serialization
- Standards gaps or exceptions: Protected staging hostname, database URL, and persistent release root must be supplied by the operator environment; the implementation intentionally provides no insecure fallback.

## Required Evidence

- Standards check result: Pass (`npm run standards:check`)
- Lint result: Pass (`npm run lint`)
- Tests: Pass (`node --test tests/unit/staging-deployment.test.js tests/unit/factory-stack-service.test.js tests/contract/factory-stack-root-binding.contract.test.js tests/unit/runtime-release-evidence.test.js tests/integration/runtime-release-manifest.integration.test.js tests/security/runtime-release-manifest.security.test.js`)
- Test evidence paths: `tests/unit/staging-deployment.test.js`, `tests/unit/factory-stack-service.test.js`, `tests/contract/factory-stack-root-binding.contract.test.js`, `tests/unit/runtime-release-evidence.test.js`, `tests/integration/runtime-release-manifest.integration.test.js`, `tests/security/runtime-release-manifest.security.test.js`
- Docs updated: Yes
- Doc evidence paths: `docs/architecture.md`, `docs/architecture/exclusive-runtime-cutover.md`, `docs/runbooks/golden-path-autonomous-delivery.md`, `docs/runbooks/runtime-hardening-cutover.md`

## Risk and Rollback

- Risk level: High
- Rollback path: Stop only the staging profile and revert this commit. The default coordinated stack has distinct labels, ports, logs, state, and root binding and is not rebound by staging deployment.

## Notes

This PR is stacked on #332 so its diff contains only staging isolation and deployment automation. Production cutover remains a separate manual action.

Closes #327
