### PR TITLE
test(ui): stabilize owner-filter integration timing

### DIFF
--- a/tests/integration/board-owner-filtering.integration.test.js
+++ b/tests/integration/board-owner-filtering.integration.test.js
@@ -137,7 +137,7 @@ describe('board owner filtering integration', () => {
     expect(screen.queryByText('Governance review task')).not.toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Owner filter'), { target: { value: '__unassigned__' } });
-    await screen.findByText('1 unassigned cards shown.');
+    await screen.findByText('1 unassigned cards shown.', {}, { timeout: 10000 });
     expect(within(screen.getByLabelText('Operator Approval column')).getByText('Board unassigned task')).toBeInTheDocument();
     expect(within(screen.getByLabelText('Implementation column')).getByText('No matching tasks in this column.')).toBeInTheDocument();
 


### PR DESCRIPTION
## Summary

Stabilize the route-backed Kanban owner-filter integration assertion under aggregate hosted CI load by applying an explicit bounded wait to the exact rendered count. The assertion remains unchanged; there are no retries and failures are not suppressed.

## Linked Task

- Task: GitHub #336, Simple

## Standards Compliance

- Standards baseline reviewed: `AGENTS.md` and the existing UI integration-test conventions
- Checklist completed or updated: Yes
- Compliance checklist path: `tests/integration/board-owner-filtering.integration.test.js`
- Relevant standards areas: deterministic integration tests, bounded asynchronous UI assertions, aggregate-suite reliability
- Standards gaps or exceptions: The in-app Browser runtime had no available browser, so rendered validation used the repository's established Vitest integration path; the change is test-only and does not alter UI production code.

## Required Evidence

- Standards check result: Pass (`npm run standards:check`)
- Lint result: Pass (`npm run lint`)
- Tests: Pass (10 consecutive focused runs; complete `npm run test:ui:vitest` aggregate: 174 passed, 2 skipped)
- Test evidence paths: `tests/integration/board-owner-filtering.integration.test.js`
- Docs updated: No; test-only timing correction
- Doc evidence paths: `tests/integration/board-owner-filtering.integration.test.js`

## Risk and Rollback

- Risk level: Low
- Rollback path: Revert this commit to restore Testing Library's one-second default for this single route-state transition.

## Notes

The failure reproduced independently on multiple unrelated PRs only in the aggregate hosted suite after 173 passing UI cases. The isolated test passed 20/20 before the change, identifying resource-sensitive timeout behavior rather than an owner-filter logic defect.

Closes #336
