### PR TITLE
Add Markdown heading conventions reference

### DIFF
--- a/docs/reference/markdown-heading-conventions.md
+++ b/docs/reference/markdown-heading-conventions.md
@@ -1,0 +1,39 @@
+# Markdown heading conventions
+
+## Purpose
+
+Use these conventions to keep Markdown documents easy to scan, link, and review.
+
+## One H1 per document
+
+Use exactly one H1 heading in each document. The H1 names the document and appears before other headings.
+
+Do not use additional H1 headings for sections inside the document. Use H2 and deeper headings for the document structure.
+
+## Sentence-case headings
+
+Write headings in sentence case. Capitalize the first word, proper nouns, acronyms, and terms that are normally capitalized.
+
+Avoid title case unless the heading is a product name, formal title, or quoted phrase that already uses title case.
+
+## Logical nesting
+
+Nest headings in order without skipping levels. An H3 belongs under an H2, an H4 belongs under an H3, and so on.
+
+Do not jump from an H2 directly to an H4. Add the missing H3 or choose the correct shallower heading level.
+
+## Unique headings
+
+Keep headings unique within a document. Unique headings make generated anchors, table-of-contents links, and review comments unambiguous.
+
+If two sections need similar names, add specific context to each heading.
+
+## Blank-line spacing
+
+Put one blank line before and after each heading unless the heading is the first line of the file.
+
+Keep body text, lists, and code fences separated from headings by a blank line so Markdown renderers and linters parse the structure consistently.
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
- Task: TSK-038 - Add Markdown heading conventions reference.
- Standards baseline reviewed: Yes; docs-only reference change reviewed against repository Markdown and governance conventions.
- Checklist completed or updated: Yes; documentation-only task validated with repository gates.
- Compliance checklist path: docs/reference/markdown-heading-conventions.md
- Relevant standards areas: Documentation structure, Markdown heading hierarchy, repository validation.
- Standards gaps or exceptions: Repository validation in fresh worktrees requires npm run coverage first to generate .artifacts/coverage-summary.json before npm run standards:check can complete.
- Standards check result: PASS - npm run standards:check passed after coverage artifact generation.
- Lint result: PASS - npm run lint passed.
- Tests: PASS - npm run coverage passed with 1079 tests passing and wrote .artifacts/coverage-summary.json.
- Test evidence paths: docs/reference/markdown-heading-conventions.md
- Docs updated: Added docs/reference/markdown-heading-conventions.md.
- Doc evidence paths: docs/reference/markdown-heading-conventions.md
- Risk level: Low; documentation-only change.
- Risk class: Low; documentation-only change under docs/reference.
- Automation gap: Fresh worktrees do not have .artifacts/coverage-summary.json, so npm run coverage must run before npm run standards:check.
- Test evidence: npm run coverage passed with 1079 tests passing; npm run standards:check passed after coverage artifact generation.
- CI result: PASS - Pull request metadata, Repo validation, Browser validation, Specialist delegation verification, and verify passed on PR #372.
- Rollback path: Revert commit ad69409e4193e233def0294dc837c107c44a495b to remove docs/reference/markdown-heading-conventions.md.
