### PR TITLE
docs: add repository link conventions

### DIFF
--- a/docs/reference/repository-link-conventions.md
+++ b/docs/reference/repository-link-conventions.md
@@ -1,0 +1,39 @@
+# Repository link conventions
+
+## Purpose
+
+Use these conventions to keep repository links durable, readable, and easy to review.
+
+## Relative repository links
+
+Use relative links for files and directories that live in this repository.
+
+Relative links keep documentation portable across branches, forks, local checkouts, and hosted repository views. Prefer `../runbook.md` or `./markdown-heading-conventions.md` over a hosted repository URL when the target is versioned with the source document.
+
+## Anchored links
+
+Use anchored links when a reader needs to land on a specific section instead of the top of a document.
+
+Anchor links should point to stable headings. If a heading is likely to change during routine editing, link to the document instead and describe the section in nearby text.
+
+## Absolute hosted links
+
+Use absolute hosted links when the target is outside the repository, outside the current documentation tree, or intentionally tied to a hosted review, issue, pull request, release, or external source of record.
+
+Hosted links are also appropriate when documentation must refer to an immutable remote artifact that is not available through a relative repository path.
+
+## Stable targets
+
+Prefer stable targets for links that appear in standards, runbooks, architecture documents, or other long-lived references.
+
+For repository content, link to documents, sections, or directories that are expected to remain in place. For external or hosted content, prefer canonical pages, issue or pull request URLs, release pages, or commit-specific links when the exact historical state matters.
+
+## Link-text clarity
+
+Write link text that names the destination or action clearly without depending on surrounding words.
+
+Avoid vague link text such as "here", "this", or raw URLs unless the URL itself is the subject. Prefer text such as "change governance maintenance standard", "Markdown heading conventions", or "pull request #123".
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
- Task: TSK-044 - Add docs/reference/repository-link-conventions.md describing relative repository links, anchored links, absolute hosted links, stable targets, and link-text clarity.
- Risk class: Low, documentation-only.
- Automation gap: No new automated coverage added; existing repository validation covers docs-only policy, lint, build, and test gates.
- Test evidence: PASS - make verify BASE_REF=github/main CHANGE_RISK=low CHANGE_KIND=docs-only CHANGE_REVERSIBILITY=reversible CHANGE_REFERENCE=LOCAL-TSK CHANGE_REVIEW_MODE=human-plus-evidence CHANGE_PROVENANCE=agent CHANGE_HUMAN_INSTRUCTION=true. First run had one transient browser assertion failure; exact failed Chromium test passed on focused rerun, and full make verify passed on rerun.
- Lint result: PASS - npm run lint completed as part of make verify.
- CI result: Pending at PR creation.
- Standards baseline reviewed: yes - repo-contract.yaml and Makefile validation path reviewed.
- Checklist completed or updated: yes - docs-only change verified through repository validation.
- Compliance checklist path: docs/reference/repository-link-conventions.md
- Relevant standards areas: documentation quality, repository references, link durability.
- Standards gaps or exceptions: No exceptions requested. npm ci reported existing audit findings; make verify passed.
- Standards check result: PASS - npm run standards:check completed as part of make verify.
- Tests: PASS - make verify completed successfully on rerun.
- Test evidence paths: docs/reference/repository-link-conventions.md
- Docs updated: docs/reference/repository-link-conventions.md
- Doc evidence paths: docs/reference/repository-link-conventions.md
- Risk level: Low
- Rollback path: Revert commit add042efceefcff1d95638ff271314ba5fea3ba9 to remove the documentation change.
- Rollback: Revert commit add042efceefcff1d95638ff271314ba5fea3ba9 to remove the documentation change.