### PR TITLE
docs: add command example formatting reference

### DIFF
--- a/docs/reference/command-example-formatting.md
+++ b/docs/reference/command-example-formatting.md
@@ -1,0 +1,81 @@
+# Command example formatting
+
+## Purpose
+
+Use these conventions to keep command examples readable, copy-paste safe, and easy to verify.
+
+## Shell fence labels
+
+Label shell command fences with the shell a reader should use.
+
+Use `sh` for portable POSIX shell commands and `bash` only when the example depends on Bash syntax. Use the specific tool or format label, such as `json` or `yaml`, for non-shell content.
+
+```sh
+npm run lint
+```
+
+Do not include prompt characters such as `$`, `>`, or `#` inside copyable command fences.
+
+## Copy-paste-safe commands
+
+Write command examples so a reader can paste them directly into a terminal when the placeholders are replaced.
+
+Prefer complete commands over fragments. Include required flags, quote arguments that may contain spaces, and avoid hidden setup steps unless the surrounding text names them explicitly.
+
+```sh
+git switch -c docs/command-example-formatting
+```
+
+Do not combine unrelated commands in one line. Use separate lines when the sequence matters.
+
+## Placeholder notation
+
+Use angle-bracket placeholders for values the reader must replace.
+
+Name placeholders with lowercase words separated by hyphens. Keep placeholders descriptive enough to show the expected value.
+
+```sh
+git remote add <remote-name> <repository-url>
+```
+
+Explain placeholders before or after the command when the expected value is not obvious from the name.
+
+## Command and output separation
+
+Keep commands and expected output in separate fences.
+
+Use a shell-labeled fence for commands and a `text` fence for output. This keeps the command fence copyable and makes it clear which lines are evidence.
+
+```sh
+node --version
+```
+
+```text
+v22.16.0
+```
+
+Use short output excerpts when full output is noisy. Mark omitted sections with plain prose outside the output fence.
+
+## Multiline examples
+
+Use multiline command examples when a command is too long to scan on one line or when the sequence is safer as ordered steps.
+
+For one logical command split across lines, use trailing backslashes in `sh` examples.
+
+```sh
+curl --fail \
+  --header "Authorization: Bearer <token>" \
+  --url "<api-url>/health"
+```
+
+For multiple commands, put one command per line in the order the reader should run them.
+
+```sh
+npm ci
+npm run lint
+npm test
+```
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
- Task: TSK-045
- Risk class: Documentation-only
- Automation gap: None; repository validation and lint were run locally.
- Test evidence: npm run coverage (1080 tests passed, coverage artifact written); npm run standards:check (passed).
- Lint result: npm run lint (passed).
- CI result: Pending after PR metadata update.
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/reference/command-example-formatting.md
- Relevant standards areas: Markdown documentation command examples
- Standards gaps or exceptions: No exceptions
- Standards check result: npm run standards:check passed
- Tests: npm run coverage passed; npm run standards:check passed
- Test evidence paths: docs/reference/command-example-formatting.md
- Docs updated: yes
- Doc evidence paths: docs/reference/command-example-formatting.md
- Risk level: Low
- Rollback path: Revert commit 297e8e46b2e339568324c9a3fcbc17aecc2f356e to remove docs/reference/command-example-formatting.md.