### PR TITLE
docs: add markdown list conventions

### DIFF
--- a/docs/reference/markdown-list-conventions.md
+++ b/docs/reference/markdown-list-conventions.md
@@ -1,0 +1,47 @@
+# Markdown list conventions
+
+## Purpose
+
+Use these conventions to keep Markdown lists easy to scan, maintain, and review.
+
+## Ordered lists
+
+Use ordered lists when sequence, priority, ranking, or step count matters.
+
+Start each item with `1.` unless a document generator or external format requires fixed numbering. Repeated `1.` markers make diffs smaller when items are added, removed, or reordered.
+
+## Unordered lists
+
+Use unordered lists when items are peers and the order does not change the meaning.
+
+Use `-` for unordered list markers. Do not mix `-`, `*`, and `+` markers in the same list.
+
+## Blank-line spacing
+
+Put one blank line before and after each list unless the list starts immediately after a heading.
+
+Keep multi-paragraph list items separated with blank lines and indent continuation paragraphs by two spaces so they remain part of the same item.
+
+## Parallel phrasing
+
+Write sibling list items with parallel grammar and similar detail.
+
+Start sibling items consistently, such as all noun phrases, all imperative verbs, or all complete sentences. Avoid mixing terse labels with full explanations unless the list intentionally uses a term-and-definition format.
+
+## Nesting
+
+Use nesting only when the child items depend on a parent item.
+
+Keep nested lists shallow. Prefer a new section or table when a list needs more than two levels of nesting or when sibling items become hard to compare.
+
+Indent nested list markers by two spaces under the parent item. Keep each nested list aligned with its siblings.
+
+## Task lists
+
+Use task lists for active work tracking, checklists, or review gates where completion state matters.
+
+Use `- [ ]` for incomplete items and `- [x]` for complete items. Do not use task lists for decorative bullets, historical summaries, or status that is better represented as prose.
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
- Task: TSK-047
- Standards baseline reviewed: Yes, documentation reference conventions were checked against existing docs/reference pages.
- Checklist completed or updated: Yes, documentation-only checklist satisfied in PR body.
- Compliance checklist path: docs/reference/markdown-list-conventions.md
- Relevant standards areas: Markdown documentation conventions, repository reference docs.
- Standards gaps or exceptions: No exceptions; this is a documentation-only reference addition.
- Standards check result: Local `make verify` passed with docs-only metadata.
- Lint result: Local `npm run lint` passed.
- Tests: Local `make verify` passed.
- Test evidence paths: docs/reference/markdown-list-conventions.md
- Docs updated: Added Markdown list conventions reference.
- Doc evidence paths: docs/reference/markdown-list-conventions.md
- Risk level: Low, documentation-only.
- Risk class: Low, documentation-only.
- Automation gap: None for implementation; no code behavior changed. CI passed after PR metadata rerun.
- CI result: Passed. GitHub checks passed: Pull request metadata, Repo validation, Browser validation, Specialist delegation verification, verify.
- Rollback path: Revert commit `06d097e86d9e23ff6ea085dab6254d41ce944ded` to remove `docs/reference/markdown-list-conventions.md`.
