### PR TITLE
test(browser): make project live refresh synchronization deterministic

### DIFF
--- a/docs/standards/change-governance-maintenance.md
+++ b/docs/standards/change-governance-maintenance.md
@@ -77,6 +77,16 @@ If a runtime file does not match any domain, `npm run change:check` fails with a
 - Do not silence failures by widening `doc_requirements` to unrelated docs.
 - Keep domain names stable so failure messages remain predictable.
 
+## Deterministic browser mocks
+
+Browser tests for polling or streaming behavior must synchronize on protocol
+boundaries rather than global request counts or short DOM-only timeouts. In
+particular, cursor-based polling mocks should return baseline data for requests
+without a cursor and updates only after the client sends a cursor. This keeps
+React development-mode effect replay from being mistaken for a second logical
+poll. When an update triggers a follow-up read, tests should await a response
+that actually contains the updated payload before asserting rendered content.
+
 ## Dual remotes (GitLab primary)
 Canonical ship path is GitLab (`origin`). GitHub (`github`) is the backup / public CI mirror. Prefer basing work on `origin/main`, push `origin` first, then `github`. Operator status: `npm run remotes:sync-status`. Full procedure: `docs/runbooks/dual-remote-gitlab-primary.md`.
 

--- a/tests/browser/live-task-freshness.browser.spec.ts
+++ b/tests/browser/live-task-freshness.browser.spec.ts
@@ -147,8 +147,13 @@ function projectPayload(updated: boolean) {
   };
 }
 
-async function installProjectRoutes(page, state: { updated: boolean; delayFirstProjectListMs?: number }) {
+async function installProjectRoutes(page, state: {
+  updated: boolean;
+  delayFirstProjectListMs?: number;
+  updatedProjectListResponseCount?: number;
+}) {
   let requestCount = 0;
+  state.updatedProjectListResponseCount = 0;
   await page.route('**/api/v1/projects**', async (route) => {
     requestCount += 1;
     const updatedAtRequest = state.updated;
@@ -158,17 +163,19 @@ async function installProjectRoutes(page, state: { updated: boolean; delayFirstP
     await route.fulfill({
       json: projectPayload(updatedAtRequest),
     });
+    if (updatedAtRequest) {
+      state.updatedProjectListResponseCount = (state.updatedProjectListResponseCount || 0) + 1;
+    }
   });
 }
 
-function liveUpdatePayload(state: { pollCount: number }) {
-  const secondPoll = state.pollCount > 1;
+function liveUpdatePayload(state: { pollCount: number }, includeUpdates: boolean) {
   return {
     data: {
       cursor: `cursor-${state.pollCount}`,
       pollAfterMs: 100,
       serverTime: new Date().toISOString(),
-      updates: secondPoll ? [
+      updates: includeUpdates ? [
         {
           entityType: 'task',
           entityId: 'TSK-LIVE',
@@ -190,12 +197,16 @@ function liveUpdatePayload(state: { pollCount: number }) {
   };
 }
 
-async function installUpdateRoute(page, state: { updated: boolean; pollCount: number }) {
+async function installUpdateRoute(page, state: { updated: boolean; pollCount: number; updatePollCount?: number }) {
+  state.updatePollCount = 0;
   await page.route('**/api/v1/tasks/updates**', async (route) => {
     state.pollCount += 1;
-    const secondPoll = state.pollCount > 1;
-    if (secondPoll) state.updated = true;
-    await route.fulfill({ json: liveUpdatePayload(state) });
+    const updatePoll = new URL(route.request().url()).searchParams.has('cursor');
+    if (updatePoll) {
+      state.updatePollCount = (state.updatePollCount || 0) + 1;
+      state.updated = true;
+    }
+    await route.fulfill({ json: liveUpdatePayload(state, updatePoll) });
   });
 }
 
@@ -244,11 +255,25 @@ test('task detail refreshes the active task summary from live updates', async ({
 });
 
 test('Projects refreshes planning containers from live project updates', async ({ page }) => {
-  const state = { updated: false, pollCount: 0, delayFirstProjectListMs: 250 };
+  const state = {
+    updated: false,
+    pollCount: 0,
+    updatePollCount: 0,
+    delayFirstProjectListMs: 250,
+    updatedProjectListResponseCount: 0,
+  };
   await installSharedRoutes(page, state);
 
   await page.goto('/projects', { waitUntil: 'domcontentloaded' });
 
-  await expect(page.getByText('Live Project Updated')).toBeVisible({ timeout: 5000 });
+  await expect.poll(() => state.updatePollCount, {
+    message: 'the live-update endpoint should receive a cursor-based update poll',
+    timeout: 15000,
+  }).toBeGreaterThan(0);
+  await expect.poll(() => state.updatedProjectListResponseCount, {
+    message: 'the Projects route should finish a reload with the updated payload',
+    timeout: 15000,
+  }).toBeGreaterThan(0);
+  await expect(page.getByText('Live Project Updated')).toBeVisible();
   await expect(page).toHaveURL(/\/projects/);
 });


### PR DESCRIPTION
## Summary

- make the live-update mock follow the real cursor protocol instead of treating a global request count as a logical poll count
- prevent React development-mode effect replay from consuming the mocked project update as baseline data
- wait for a cursor-based update poll and an updated project-list response before asserting rendered content
- codify protocol-bound browser-test synchronization in the governance maintenance standard
- leave production polling and Projects behavior unchanged

Closes #386

## Linked Task

- Task: #386

## Standards Compliance

- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/standards/change-governance-maintenance.md
- Relevant standards areas: testing and quality assurance, deterministic browser validation, maintainability
- Standards gaps or exceptions: No exceptions.
- [x] UI changes use generated DESIGN.md tokens. Not applicable; no UI change.
- [x] `npm run design:tokens:check` passed. Not applicable; no token change.
- [x] `npm run design:tokens:enforce` passed. Not applicable; no UI change.
- [x] `DESIGN.md` was updated when visual semantics changed. Not applicable.
- [x] Any one-off visual exception is documented. Not applicable.

## Required Evidence

- Standards check result: `npm run standards:check` passed.
- Lint result: `npm run lint` passed.
- Tests: exact Firefox Projects case passed 100/100 under four-worker load; the full live-freshness browser spec passed 12/12 across Chromium, Firefox, and mobile Chrome; unit and UI suites passed 1,090 and 174 tests respectively.
- Test evidence paths: tests/browser/live-task-freshness.browser.spec.ts
- Docs updated: The governance maintenance standard now requires cursor-aware mocks and updated-response synchronization for polling browser tests.
- Doc evidence paths: docs/standards/change-governance-maintenance.md

## Risk and Rollback

- Risk level: Low; only mocked browser-test timing, assertions, and testing guidance change.
- Risk class: Simple test reliability fix.
- Rollback path: Revert the PR merge commit to restore the prior global-request-count mock and remove the guidance.

## Notes

- The affected qualifying cohort was excluded after the first hosted verify failure, even though the unchanged autonomous retry passed.
- The in-app Browser runtime had no available instance, so verification used the repository's existing Playwright workflow.
- No production application behavior, runtime configuration, or data model changes.
