### PR TITLE
fix(factory): make trusted PR metadata pass on first attempt

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,6 +232,14 @@ Trusted Simple execution is a PR lifecycle guarantee, not a hosted-deployment cl
 
 Durable queue ownership spans the complete trusted delivery attempt. The shared one-hour lease default exceeds the implementer's 31-minute runtime allowance, leaving headroom for hosted checks while preserving fail-closed release semantics if ownership is actually lost.
 
+The queued delivery scope is also the source of truth for the implementer's
+first pull-request submission. Phase-runner options carry the repository,
+source issue URL, and expected changed-file list into the trusted OpenClaw
+prompt. The prompt requires the complete governed PR-body schema before the PR
+is opened, a closing reference to the source issue, and evidence paths drawn
+only from the real diff. This makes a passing initial metadata run part of the
+trusted execution contract instead of relying on a later body-repair cycle.
+
 Trusted QA is an evidence-review boundary, not a synthetic approval. The coordinator supplies the exact repository, branch, implementation SHA, PR URL, and expected file scope to the live QA agent. QA may inspect those artifacts through read-only Git and GitHub commands, but cannot mutate the PR or release gates; a rejection routes the same immutable PR identity to the Sr correction agent. Both runtime roles therefore require scoped unattended gateway execution while the coordinator continues to reject missing or malformed branch, SHA, and PR evidence.
 
 ### Cohort residual arithmetic

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -146,6 +146,14 @@ the ephemeral GitHub Actions token to `scripts/verify-pr-body.js`. This lets the
 validator fetch the current pull-request body when a rerun receives a stale or
 empty event payload, without granting write access.
 
+For trusted autonomous factory delivery, the implementer must receive the
+queued source issue URL and expected changed-file list and must populate the
+complete governed PR body before opening the pull request. Treat an initial
+`Pull request metadata` failure as a failed delivery attempt even when a later
+autonomous edit passes. Documentation-only tasks may list the changed document
+under both evidence-path fields because repository validation is their test
+evidence.
+
 Read `DESIGN.md` before UI changes, change reusable visual semantics there
 first, and avoid hard-coded visual values in migrated CSS. A rare one-off must
 use `DESIGN-TOKEN-EXCEPTION: <short reason and follow-up if reusable>`.

--- a/docs/standards/change-governance-maintenance.md
+++ b/docs/standards/change-governance-maintenance.md
@@ -16,6 +16,15 @@ Canonical checks:
 
 `npm run pr:check` validates the required PR-body fields against the changed-file set. In CI, the checker prefers the current pull-request body fetched from GitHub when `GITHUB_TOKEN`, `GITHUB_REPOSITORY`, and the PR number are available; this prevents stale `pull_request` event payloads from failing a corrected PR description. If the API lookup is unavailable, the checker falls back to the event body.
 
+Trusted autonomous delivery must populate every required PR-body field before
+opening the pull request. A failed initial metadata check followed by an
+autonomous body edit is still a failed attempt and cannot count toward a clean
+zero-intervention cohort. The implementer must receive the source issue URL and
+expected changed-file list, include a closing issue reference, and use only
+paths present in the actual diff for both evidence-path fields. For docs-only
+changes, the changed documentation path may serve as both test evidence and
+documentation evidence because repository validation is the exercised gate.
+
 ## Coverage Artifacts
 `npm run standards:check` reads `.artifacts/coverage-summary.json`. That file may be produced by `npm run coverage` with per-suite JavaScript/UI coverage, or by `make verify` with Python coverage totals. The coverage policy checker accepts both schemas so developers can run the verification commands in either order without regenerating coverage only to satisfy a parser shape.
 

--- a/lib/task-platform/factory-agent-phases.js
+++ b/lib/task-platform/factory-agent-phases.js
@@ -1,6 +1,7 @@
 const crypto = require('node:crypto');
 const path = require('node:path');
 const { delegateFactorySpecialist } = require('./factory-orchestration');
+const { buildTrustedPrMetadataRules } = require('./factory-implementer-pr-metadata');
 const { commitShaEvidenceFailure } = require('./real-commit-sha');
 
 /**
@@ -21,6 +22,7 @@ function isTrustedDeliveryMode(options = {}, env = process.env) {
 function buildImplementerPrompt({
   taskId, requirements,
   engineerTier = 'Jr', runKind = 'initial',
+  repository, githubIssueUrl, changedFiles = [],
   requireRealEvidence = false, trustedDelivery = false, trustedSimpleClose = false,
   sessionProofOnly = false, allowSyntheticEvidence = false,
   collectRealEvidence = false, proofProfile,
@@ -37,6 +39,7 @@ function buildImplementerPrompt({
   const evidenceRule = trusted
     ? 'TRUSTED DELIVERY: Synthetic branch/commit/PR values are FORBIDDEN. Return only real git branchName, real 40-char commitSha, and a real https PR URL with pull number. Session-only mock JSON is not valid operator-trusted evidence.'
     : 'SESSION PROOF ONLY: Synthetic branch/commit/PR JSON is acceptable for local session attribution only. This is not operator-trusted autonomous delivery evidence.';
+  const prMetadataRules = buildTrustedPrMetadataRules({ repository, githubIssueUrl, changedFiles });
   const executionRules = trusted && runKind === 'fix_after_qa_fail' ? [
     'Use your filesystem, shell, git, and GitHub tools to correct the existing pull request now.',
     'Do not switch branches or edit the primary checkout. Create an isolated git worktree for the supplied existing branch and work only there.',
@@ -47,7 +50,7 @@ function buildImplementerPrompt({
     'Use your filesystem, shell, git, and GitHub tools to implement the approved requirement now.',
     'Do not switch branches or edit the primary checkout. Fetch and resolve the remote matching the supplied GitHub repository (prefer the `github` remote, otherwise `origin`), then create an isolated git worktree from that remote\'s current main revision and work only there.',
     'Create a unique task branch, make the smallest in-scope change, run focused tests, commit, push, and open a real pull request against main.',
-    'The pull request body must include Task, Risk class, Automation gap, Test evidence, Lint result, and CI result fields, and must link the supplied GitHub issue when one is present.',
+    ...prMetadataRules,
     'Wait for every pre-merge check already attached to the pull request, except the factory-owned Merge readiness check, to pass. Do not merge the pull request; phase 6 owns the merge.',
     'Clean up only the isolated worktree you created. Never discard unrelated changes or delete the primary checkout.',
   ] : [

--- a/lib/task-platform/factory-implementer-pr-metadata.js
+++ b/lib/task-platform/factory-implementer-pr-metadata.js
@@ -1,0 +1,40 @@
+function issueNumberFromUrl(issueUrl) {
+  return String(issueUrl || '').match(/\/(\d+)(?:$|[/?#])/)?.[1] || null;
+}
+
+function buildTrustedPrMetadataRules({ repository, githubIssueUrl, changedFiles = [] } = {}) {
+  const expectedChangedFiles = Array.isArray(changedFiles)
+    ? changedFiles.map(String).filter(Boolean)
+    : [];
+  const issueNumber = issueNumberFromUrl(githubIssueUrl);
+  return [
+    `Repository: ${repository || '(resolve from the supplied GitHub issue or checkout)'}`,
+    `Source GitHub issue: ${githubIssueUrl || '(not supplied)'}`,
+    `Expected changed files: ${expectedChangedFiles.length ? expectedChangedFiles.join(', ') : '(not supplied)'}`,
+    'Before opening the pull request, write a complete body with non-placeholder values for every line below. Do not open the PR with an incomplete body and repair it later:',
+    '- Task:',
+    '- Standards baseline reviewed:',
+    '- Checklist completed or updated:',
+    '- Compliance checklist path:',
+    '- Relevant standards areas:',
+    '- Standards gaps or exceptions:',
+    '- Standards check result:',
+    '- Lint result:',
+    '- Tests:',
+    '- Test evidence paths:',
+    '- Docs updated:',
+    '- Doc evidence paths:',
+    '- Risk level:',
+    '- Rollback path:',
+    '- Risk class:',
+    '- Automation gap:',
+    '- Test evidence:',
+    '- CI result:',
+    'Every Test evidence paths and Doc evidence paths entry must be a file actually changed in this PR. For a documentation-only change, use the changed documentation path for both fields because repository validation is the test evidence.',
+    githubIssueUrl
+      ? `Include a closing reference for the source issue (${githubIssueUrl}), such as \`Closes #${issueNumber || '<issue-number>'}\`.`
+      : 'If a source issue is discoverable from the task context, include a closing reference such as `Closes #<issue-number>`.',
+  ];
+}
+
+module.exports = { buildTrustedPrMetadataRules, issueNumberFromUrl };

--- a/lib/task-platform/factory-phase-runner-options.js
+++ b/lib/task-platform/factory-phase-runner-options.js
@@ -110,6 +110,7 @@ function basePhaseRunnerOptions(config, item, evidencePath, stackPersistDir) {
     changeReversibility: config.changeReversibility,
     templateTier: item.templateTier || config.templateTier,
     changedFiles: item.changedFiles || config.changedFiles,
+    githubIssueUrl: item.githubIssueUrl || config.githubIssueUrl,
     factoryRequirements: item.requirements || config.factoryRequirements || null,
     requirements: item.requirements || null,
   };

--- a/lib/task-platform/golden-path-phases.js
+++ b/lib/task-platform/golden-path-phases.js
@@ -930,8 +930,8 @@ async function runGoldenPathPhase2(ctx, evidence, options = {}) {
       requirements: evidence.engineeringTeam?.requirements || options.requirements,
       engineerTier: api.personaRouting?.assignedTier || 'Jr',
       specialist: 'jr-engineer',
-      openclawUrl: options.openclawUrl,
-      prUrl: options.prUrl,
+      openclawUrl: options.openclawUrl, repository: options.ciRepository,
+      prUrl: options.prUrl, githubIssueUrl: options.githubIssueUrl || evidence.githubIssueUrl, changedFiles: evidence.engineeringTeam?.changedFiles || options.changedFiles,
       branchName: options.branchName || options.branch || evidence.github?.branchName, commitSha: options.implementationCommitSha || options.commitSha, requireRealEvidence: isRealEvidenceRequired(options),
       trustedDelivery: options.trustedDelivery === true, trustedSimpleClose: options.trustedSimpleClose === true, proofProfile: options.proofProfile,
     });

--- a/tests/integration/task-platform-branch-protection.integration.test.js
+++ b/tests/integration/task-platform-branch-protection.integration.test.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { createTaskPlatformService } = require('../../lib/task-platform');
+const { buildImplementerPrompt } = require('../../lib/task-platform/factory-agent-phases');
+const { buildPhaseRunnerOptions } = require('../../lib/task-platform/factory-phase-runner-options');
 
 function serviceWithTask() {
   const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'task-platform-branch-protection-'));
@@ -56,4 +58,33 @@ test('persists policy_blocked branch-protection state when Merge readiness is no
   assert.equal(review.classification.branch_protection_policy.status, 'policy_blocked');
   assert.equal(review.classification.branch_protection_policy.enforced, false);
   assert.ok(review.findings.some(finding => finding.type === 'policy_blocked'));
+});
+
+test('propagates trusted queue scope into the first-pass implementer PR contract', () => {
+  const githubIssueUrl = 'https://github.com/wiinc1/engineering-team/issues/388';
+  const changedFiles = ['docs/reference/example.md'];
+  const options = buildPhaseRunnerOptions(
+    { deliveryDir: 'observability/factory-delivery', ciRepository: 'wiinc1/engineering-team' },
+    {
+      id: 'factory-metadata-context',
+      title: 'Document a repository convention',
+      requirements: 'Add one documentation reference.',
+      templateTier: 'Simple',
+      githubIssueUrl,
+      changedFiles,
+    },
+  );
+  const prompt = buildImplementerPrompt({
+    taskId: 'TSK-050',
+    requirements: options.requirements,
+    repository: options.ciRepository,
+    githubIssueUrl: options.githubIssueUrl,
+    changedFiles: options.changedFiles,
+    trustedSimpleClose: true,
+  });
+
+  assert.match(prompt, /Repository: wiinc1\/engineering-team/);
+  assert.match(prompt, /Source GitHub issue: https:\/\/github\.com\/wiinc1\/engineering-team\/issues\/388/);
+  assert.match(prompt, /Expected changed files: docs\/reference\/example\.md/);
+  assert.match(prompt, /Closes #388/);
 });

--- a/tests/unit/factory-agent-phases.test.js
+++ b/tests/unit/factory-agent-phases.test.js
@@ -70,6 +70,9 @@ test('buildImplementerPrompt labels session-proof vs trusted delivery', () => {
   const trusted = buildImplementerPrompt({
     taskId: 'TSK-1',
     requirements: 'x',
+    repository: 'wiinc1/engineering-team',
+    githubIssueUrl: 'https://github.com/wiinc1/engineering-team/issues/388',
+    changedFiles: ['docs/reference/example.md'],
     requireRealEvidence: true,
   });
   assert.match(trusted, /TRUSTED DELIVERY/);
@@ -78,6 +81,13 @@ test('buildImplementerPrompt labels session-proof vs trusted delivery', () => {
   assert.match(trusted, /prefer the `github` remote/);
   assert.match(trusted, /Do not merge the pull request/);
   assert.match(trusted, /filesystem, shell, git, and GitHub tools/);
+  assert.match(trusted, /Repository: wiinc1\/engineering-team/);
+  assert.match(trusted, /Source GitHub issue: https:\/\/github\.com\/wiinc1\/engineering-team\/issues\/388/);
+  assert.match(trusted, /Expected changed files: docs\/reference\/example\.md/);
+  assert.match(trusted, /- Standards baseline reviewed:/);
+  assert.match(trusted, /- Rollback path:/);
+  assert.match(trusted, /documentation-only change, use the changed documentation path for both fields/);
+  assert.match(trusted, /Closes #388/);
   assert.doesNotMatch(trusted, /attribution proof only/);
   assert.match(session, /attribution proof only/);
 

--- a/tests/unit/factory-submit-real-delivery-metadata.test.js
+++ b/tests/unit/factory-submit-real-delivery-metadata.test.js
@@ -13,6 +13,7 @@ const { buildPhaseRunnerOptions } = require('../../lib/task-platform/factory-pha
 const TEST_COMMAND = 'node --test tests/unit/factory-submit-real-delivery-metadata.test.js';
 const COMMIT_SHA = '3f4a7c9e12b84d6f90a1c2e3b4d5f6789012abcd';
 const PR_URL = 'https://github.com/wiinc1/engineering-team/pull/418';
+const ISSUE_URL = 'https://github.com/wiinc1/engineering-team/issues/388';
 const CHECKS = [{ name: 'unit tests', status: 'completed', conclusion: 'success', source: 'github_check_run' }];
 const REQUIRED_CHECKS = ['unit tests', 'Merge readiness'];
 const BRANCH_PROTECTION = {
@@ -114,6 +115,7 @@ function realDeliveryQueueInsert() {
       'lib/task-platform/golden-path-release-evidence-refresh.js',
       'tests/unit/golden-path-phase6-real-merge.test.js',
     ],
+    githubIssueUrl: ISSUE_URL,
     ciRepository: 'wiinc1/engineering-team',
     branchName: 'factory/release-evidence-refresh',
     implementationCommitSha: COMMIT_SHA,
@@ -290,6 +292,7 @@ test('factory phase runner receives queued branch-protection inventory', () => {
   assert.deepEqual(options.requiredChecks, REQUIRED_CHECKS);
   assert.deepEqual(options.branchProtection, BRANCH_PROTECTION);
   assert.equal(options.rollbackEvidence, ROLLBACK_EVIDENCE_PATH);
+  assert.equal(options.githubIssueUrl, ISSUE_URL);
   assert.equal(options.productionSafetyEvidence, PRODUCTION_SAFETY_PATH);
   assert.equal(options.riskLevel, 'low');
   assert.equal(options.productionSafe, true);


### PR DESCRIPTION
## Summary

- propagate the queued repository, GitHub issue URL, and expected changed-file list into trusted implementation sessions
- require the complete governed PR-body schema before a pull request is opened
- constrain evidence paths to the real diff and define docs-only evidence handling
- keep the legacy phase function and module within maintainability limits through a focused metadata helper

Closes #388

- Task: #388
- Standards baseline reviewed: yes — repository governance, factory delivery, and maintainability policies reviewed
- Checklist completed or updated: yes — clean first-attempt metadata invariant documented and tested
- Compliance checklist path: docs/standards/change-governance-maintenance.md
- Relevant standards areas: trusted autonomous delivery, pull-request governance, runtime orchestration, test maintainability
- Standards gaps or exceptions: No exceptions; existing dependency audit findings are unchanged
- Standards check result: PASS — `make verify` completed successfully
- Lint result: PASS — repository lint and source-integrity checks completed successfully
- Tests: PASS — 1,090 unit, 174 UI, and 193 browser tests; 100 Python tests; full build and policy gates
- Test evidence paths: tests/unit/factory-agent-phases.test.js, tests/unit/factory-submit-real-delivery-metadata.test.js
- Docs updated: trusted first-attempt metadata behavior added to the operator runbook and governance maintenance standard
- Doc evidence paths: docs/runbook.md, docs/standards/change-governance-maintenance.md
- Risk level: Low; prompt context and validation guidance only
- Rollback path: Revert this PR merge commit to restore the previous trusted implementer prompt
- Risk class: Low-risk orchestration bugfix
- Automation gap: Hosted branch-protection checks remain the authoritative first-attempt proof
- Test evidence: Full local `make verify` passed at commit f4e224b3809bdb4b68adf730333997b5d52c6ba1
- CI result: Pending at PR creation; all protected checks are required before merge