### PR TITLE
fix(factory): recover Postgres after OrbStack engine stops

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ those checks to the real local commands:
 |---|---|---|
 | Operator-hosted coordinated stack | Browser UI, API, workers, forgeadapter, OpenClaw | Restart stack services, fix env, rerun auth/build and factory smokes |
 | Operator-hosted PostgreSQL | Auth, audit, task platform, projections | Stop rollout, inspect migrations/backfill, run rebuild/verify scripts before retry |
-| Docker Compose Postgres | Local development, integration tests, factory proofs | Reset with `npm run dev:postgres:reset` if local state is disposable |
+| Docker Compose Postgres | Local development, integration tests, factory proofs | The launchd watcher starts a stopped active OrbStack VM with `orbctl start --all`, waits for Docker, and restores the named-volume container; fail closed if engine recovery fails |
 | Resend | Registration email verification and password reset when configured | Preserve generic responses; inspect redacted auth smoke and registration alert metrics |
 | OIDC provider | Explicit OIDC production strategy only | Registration remains canonical unless production switches to OIDC with fresh evidence |
 | GitHub | Issues, PRs, merge-readiness checks, branch protection evidence | GitHub check emission must fail closed; branch-protection verifier is read-only |

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -207,7 +207,13 @@ npm run factory:stack:up -- --skip-ui --skip-forgeadapter
 
 Logs: `~/Library/Logs/engineering-team-factory/`. Env example: `deploy/launchd/factory-stack.env.example`. Runtime env copy: `observability/factory-stack/service.env`.
 
-**Postgres durability:** compose uses `restart: unless-stopped` and a named volume (`factory_pgdata`). `factory:stack:up` starts compose when nothing listens on `:15432` and Docker/OrbStack is available. The `factory-postgres-ensure` KeepAlive watcher re-ensures Postgres after reboot. If Docker is missing and nothing listens, up fails with remediation steps.
+**Postgres durability:** compose uses `restart: unless-stopped` and a named volume (`factory_pgdata`). `factory:stack:up` starts compose when nothing listens on `:15432` and Docker/OrbStack is available. The `factory-postgres-ensure` KeepAlive watcher re-ensures Postgres after reboot. When the active Docker context is OrbStack but its VM is stopped, the watcher runs `orbctl start --all`, waits for the Docker engine, and then restores the named Postgres container. If the engine cannot be recovered or Docker is missing, startup fails closed with structured remediation instead of repeatedly throwing compose errors.
+
+Before admitting a zero-intervention cohort, confirm that the host has adequate
+free disk space as well as a healthy stack. A full filesystem can stop the
+OrbStack VM while leaving the GUI process present; `orbctl status` is the
+authoritative engine check. An engine or database failure after policy approval
+invalidates the whole cohort even when infrastructure later recovers.
 
 **Recovery drill (AC1):** kill API/workers/UI/forge processes (or `factory:stack:down` then reboot). Run `npm run factory:stack:up` once — required health (postgres, API, workers heartbeat, live OpenClaw, UI, forgeadapter when present) should return ok without tribal manual steps. Hermes is not part of required recovery health (Q7 / #272).
 

--- a/lib/task-platform/factory-stack/container-engine.js
+++ b/lib/task-platform/factory-stack/container-engine.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+
+function dockerEngineAvailable(dockerBin, execFileSyncImpl = execFileSync) {
+  try {
+    execFileSyncImpl(dockerBin, ['info'], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 8000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveOrbctlBin({ env = process.env, existsSyncImpl = fs.existsSync } = {}) {
+  const candidates = [env.ORBCTL_BIN, '/usr/local/bin/orbctl', '/opt/homebrew/bin/orbctl']
+    .filter(Boolean);
+  return candidates.find((candidate) => existsSyncImpl(candidate)) || null;
+}
+
+function usesOrbStack(dockerBin, execFileSyncImpl = execFileSync) {
+  try {
+    const context = execFileSyncImpl(dockerBin, ['context', 'show'], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000,
+    });
+    return String(context).trim().toLowerCase() === 'orbstack';
+  } catch {
+    return false;
+  }
+}
+
+async function ensureContainerEngine({
+  dockerBin,
+  timeoutMs = 45000,
+  pollIntervalMs = 500,
+  platform = process.platform,
+  execFileSyncImpl = execFileSync,
+  existsSyncImpl = fs.existsSync,
+  sleepImpl = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  nowImpl = Date.now,
+  env = process.env,
+} = {}) {
+  if (dockerEngineAvailable(dockerBin, execFileSyncImpl)) {
+    return { ok: true, action: 'engine_already_running', dockerBin };
+  }
+  const orbctlBin = platform === 'darwin' && usesOrbStack(dockerBin, execFileSyncImpl)
+    ? resolveOrbctlBin({ env, existsSyncImpl })
+    : null;
+  if (!orbctlBin) {
+    return { ok: false, action: 'engine_unavailable', error: 'Docker engine is unavailable and no active OrbStack context can be recovered.' };
+  }
+  try {
+    execFileSyncImpl(orbctlBin, ['start', '--all'], {
+      encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: Math.min(timeoutMs, 30000),
+    });
+  } catch (error) {
+    return { ok: false, action: 'orbstack_start_failed', error: error.message, orbctlBin };
+  }
+  const deadline = nowImpl() + timeoutMs;
+  do {
+    if (dockerEngineAvailable(dockerBin, execFileSyncImpl)) {
+      return { ok: true, action: 'orbstack_started', dockerBin, orbctlBin };
+    }
+    await sleepImpl(pollIntervalMs);
+  } while (nowImpl() < deadline);
+  return { ok: false, action: 'orbstack_start_timeout', error: 'OrbStack started but its Docker engine did not become ready in time.', orbctlBin };
+}
+
+module.exports = {
+  dockerEngineAvailable,
+  ensureContainerEngine,
+  resolveOrbctlBin,
+  usesOrbStack,
+};

--- a/lib/task-platform/factory-stack/postgres.js
+++ b/lib/task-platform/factory-stack/postgres.js
@@ -3,6 +3,7 @@
 const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
+const { ensureContainerEngine } = require('./container-engine');
 const { ROOT, defaultDatabaseUrl } = require('./defaults');
 const { probePostgres } = require('./health');
 
@@ -55,8 +56,34 @@ function composeArgs() {
   ];
 }
 
-async function ensurePostgres({ timeoutMs = 60000 } = {}) {
-  const existing = await probePostgres(defaultDatabaseUrl());
+async function startPostgresContainer({ timeoutMs, ensureContainerEngineImpl }) {
+  const dockerBin = resolveDockerBin();
+  if (!dockerBin) {
+    return {
+      ok: false, action: 'missing',
+      error: 'Postgres is not reachable and Docker is unavailable. Start Postgres on 15432 or install Docker/OrbStack.',
+      remediation: ['Ensure something listens on 127.0.0.1:15432.', 'Install Docker Desktop/OrbStack, then run npm run factory:stack:up.'],
+    };
+  }
+  const engine = await ensureContainerEngineImpl({ dockerBin, timeoutMs: Math.min(timeoutMs, 45000) });
+  if (!engine.ok) {
+    return {
+      ok: false, action: engine.action, error: engine.error,
+      remediation: ['Start the configured container engine.', 'For OrbStack: orbctl start --all', 'Then: npm run factory:stack:up'],
+    };
+  }
+  try {
+    execFileSync(dockerBin, ['compose', ...composeArgs(), 'up', '-d', 'postgres'], { cwd: ROOT, stdio: 'inherit' });
+  } catch (error) {
+    return { ok: false, action: 'docker_compose_failed', error: error.message, dockerBin };
+  }
+  return { ok: true, dockerBin, engineAction: engine.action };
+}
+
+async function ensurePostgres({
+  timeoutMs = 60000, ensureContainerEngineImpl = ensureContainerEngine, probePostgresImpl = probePostgres,
+} = {}) {
+  const existing = await probePostgresImpl(defaultDatabaseUrl());
   if (existing.ok) {
     return {
       ok: true,
@@ -66,34 +93,17 @@ async function ensurePostgres({ timeoutMs = 60000 } = {}) {
     };
   }
 
-  const dockerBin = resolveDockerBin();
-  if (!dockerBin) {
-    return {
-      ok: false,
-      action: 'missing',
-      error: 'Postgres is not reachable and Docker is unavailable. Start Postgres on 15432 (OrbStack/Docker compose golden-path, or any durable listener), or install Docker Desktop/OrbStack and re-run factory:stack:up.',
-      remediation: [
-        'Ensure something listens on 127.0.0.1:15432 with DATABASE_URL credentials.',
-        'With Docker/OrbStack: docker compose -p engineering-team-golden-path -f docker-compose.golden-path.yml up -d postgres',
-        'Then: npm run factory:stack:up',
-      ],
-      ...existing,
-    };
-  }
-
-  execFileSync(dockerBin, ['compose', ...composeArgs(), 'up', '-d', 'postgres'], {
-    cwd: ROOT,
-    stdio: 'inherit',
-  });
+  const container = await startPostgresContainer({ timeoutMs, ensureContainerEngineImpl });
+  if (!container.ok) return { ...existing, ...container, ok: false };
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const probe = await probePostgres(defaultDatabaseUrl());
+    const probe = await probePostgresImpl(defaultDatabaseUrl());
     if (probe.ok) {
       return {
         ok: true,
-        action: 'docker_started',
-        dockerBin,
+        action: container.engineAction === 'orbstack_started' ? 'orbstack_and_postgres_started' : 'docker_started',
+        dockerBin: container.dockerBin,
         durableNote: 'Postgres started via docker compose; keep the engine (Docker/OrbStack) running so :15432 survives host use. API+workers are launchd KeepAlive.',
         ...probe,
       };

--- a/tests/contract/factory-stack-root-binding.contract.test.js
+++ b/tests/contract/factory-stack-root-binding.contract.test.js
@@ -68,6 +68,23 @@ it('keeps every persistent service spec on the bound canonical checkout', () => 
   }
 });
 
+it('binds Postgres recovery to an autonomous OrbStack engine start', () => {
+  const engineSource = fs.readFileSync(
+    path.join(ROOT, 'lib/task-platform/factory-stack/container-engine.js'),
+    'utf8',
+  );
+  const postgresSource = fs.readFileSync(
+    path.join(ROOT, 'lib/task-platform/factory-stack/postgres.js'),
+    'utf8',
+  );
+
+  assert.match(engineSource, /\['start', '--all'\]/);
+  assert.match(engineSource, /orbstack_start_failed/);
+  assert.match(engineSource, /orbstack_start_timeout/);
+  assert.match(postgresSource, /await ensureContainerEngineImpl/);
+  assert.match(postgresSource, /docker_compose_failed/);
+});
+
 it('keeps GP-023 child validation isolated from persistent factory runtime state', () => {
   const env = validationSubprocessEnv({
     PATH: process.env.PATH,

--- a/tests/unit/factory-stack-service.test.js
+++ b/tests/unit/factory-stack-service.test.js
@@ -21,7 +21,8 @@ const {
   evaluateFactoryStackAcceptance,
   probeWorkersHeartbeat,
 } = require('../../lib/task-platform/factory-stack/health');
-const { resolveDockerBin, dockerAvailable } = require('../../lib/task-platform/factory-stack/postgres');
+const { resolveDockerBin, dockerAvailable, ensurePostgres } = require('../../lib/task-platform/factory-stack/postgres');
+const { ensureContainerEngine } = require('../../lib/task-platform/factory-stack/container-engine');
 
 describe('factory-stack defaults', () => {
   it('builds live OpenClaw-oriented service env', () => {
@@ -154,6 +155,71 @@ describe('factory-stack postgres docker resolution', () => {
     const bin = resolveDockerBin();
     assert.ok(bin === null || typeof bin === 'string');
     assert.equal(typeof dockerAvailable(), 'boolean');
+  });
+});
+
+describe('factory-stack container engine recovery', () => {
+  it('returns immediately when the configured Docker engine is running', async () => {
+    const calls = [];
+    const result = await ensureContainerEngine({
+      dockerBin: '/mock/docker',
+      execFileSyncImpl: (bin, args) => { calls.push([bin, args]); return 'running'; },
+    });
+    assert.equal(result.action, 'engine_already_running');
+    assert.deepEqual(calls, [['/mock/docker', ['info']]]);
+  });
+
+  it('starts the OrbStack VM and waits for Docker readiness', async () => {
+    let infoAttempts = 0;
+    const calls = [];
+    const result = await ensureContainerEngine({
+      dockerBin: '/mock/docker',
+      platform: 'darwin',
+      env: { ORBCTL_BIN: '/mock/orbctl' },
+      existsSyncImpl: () => true,
+      sleepImpl: async () => {},
+      execFileSyncImpl: (bin, args) => {
+        calls.push([bin, args]);
+        if (args[0] === 'info' && infoAttempts++ === 0) throw new Error('socket missing');
+        if (args[0] === 'context') return 'orbstack\n';
+        return 'ok';
+      },
+    });
+    assert.equal(result.action, 'orbstack_started');
+    assert.ok(calls.some(([bin, args]) => bin === '/mock/orbctl' && args.join(' ') === 'start --all'));
+  });
+
+  it('returns structured failure when OrbStack cannot start', async () => {
+    const result = await ensureContainerEngine({
+      dockerBin: '/mock/docker',
+      platform: 'darwin',
+      env: { ORBCTL_BIN: '/mock/orbctl' },
+      existsSyncImpl: () => true,
+      execFileSyncImpl: (bin, args) => {
+        if (args[0] === 'info') throw new Error('socket missing');
+        if (args[0] === 'context') return 'orbstack\n';
+        if (bin === '/mock/orbctl') throw new Error('start denied');
+        return 'ok';
+      },
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.action, 'orbstack_start_failed');
+    assert.match(result.error, /start denied/);
+  });
+});
+
+describe('factory-stack postgres recovery failure', () => {
+  it('returns a structured engine failure instead of throwing', async () => {
+    const result = await ensurePostgres({
+      probePostgresImpl: async () => ({ ok: false, error: 'database unavailable' }),
+      ensureContainerEngineImpl: async () => ({
+        ok: false, action: 'orbstack_start_failed', error: 'start denied',
+      }),
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.action, 'orbstack_start_failed');
+    assert.equal(result.error, 'start denied');
+    assert.ok(result.remediation.some((line) => line.includes('orbctl start --all')));
   });
 });
 


### PR DESCRIPTION
## Summary

- detect a stopped active OrbStack Docker context when factory PostgreSQL is unreachable
- run orbctl start --all and wait for Docker readiness before restoring the named-volume container
- return structured fail-closed engine and Compose failures instead of watcher stack traces
- document disk-pressure and strict cohort invalidation behavior

Closes #396

- Task: #396
- Standards baseline reviewed: yes — factory-stack, task-platform, runtime recovery, and maintainability policies reviewed
- Checklist completed or updated: yes — autonomous engine recovery and fail-closed paths covered
- Compliance checklist path: docs/runbooks/golden-path-autonomous-delivery.md
- Relevant standards areas: runtime resilience, persistent launchd services, PostgreSQL durability, trusted cohort integrity
- Standards gaps or exceptions: No exceptions; existing dependency audit findings are unchanged
- Standards check result: PASS — full make verify completed successfully
- Lint result: PASS — source integrity, repository lint, and browser readability passed
- Tests: PASS — six focused recovery tests; 1,090 unit, 174 UI, 193 browser, and 100 Python tests; full build and policy gates
- Test evidence paths: tests/unit/factory-stack-service.test.js, tests/contract/factory-stack-root-binding.contract.test.js
- Docs updated: architecture and golden-path recovery runbook now specify OrbStack recovery, disk headroom, and cohort invalidation
- Doc evidence paths: docs/architecture.md, docs/runbooks/golden-path-autonomous-delivery.md
- Risk level: Low; local container-engine recovery path only
- Rollback path: Revert this PR merge commit to restore the prior Docker Compose-only watcher
- Risk class: Low-risk infrastructure resilience bugfix
- Automation gap: A destructive live VM-stop drill is intentionally not run against shared host containers; engine transitions are dependency-injected in tests
- Test evidence: Full local make verify passed at commit a0f19e8
- CI result: Pending at PR creation; all protected checks are required before merge