### PR TITLE
Docs: add Markdown link title conventions

### DIFF
--- a/docs/reference/markdown-link-title-conventions.md
+++ b/docs/reference/markdown-link-title-conventions.md
@@ -1,0 +1,55 @@
+# Markdown link title conventions
+
+## Purpose
+
+Use these conventions to decide when Markdown link title attributes add useful context and when they only repeat information readers already have.
+
+## Useful title attributes
+
+Use a link title only when it adds short, nonessential context that helps a reader decide whether to follow the link.
+
+Good title attributes can clarify a linked artifact's source, status, format, or scope when that detail would interrupt the sentence. Examples include an external source name, an archived artifact note, or a warning that the target opens a large file.
+
+## Duplicated visible text
+
+Do not add a title when it repeats the visible link text or nearby sentence.
+
+Duplicated titles make Markdown noisier, add review churn, and can create repetitive output for assistive technology. Prefer clear link text such as `[repository link conventions](./repository-link-conventions.md)` over `[repository link conventions](./repository-link-conventions.md "repository link conventions")`.
+
+## Wording constraints
+
+Keep title text concise, factual, and stable.
+
+Use sentence case unless the title contains a proper noun, acronym, or quoted title. Avoid promotional wording, instructions that belong in visible text, and details likely to become stale such as temporary ownership, draft status, or expected completion dates.
+
+Do not use titles to hide required context. If the information is necessary for understanding the document, put it in visible prose instead.
+
+## Accessibility considerations
+
+Assume some readers will not receive title text at all.
+
+Browsers, mobile devices, Markdown renderers, and assistive technologies expose title attributes inconsistently. A title must never be the only place where a reader can learn what the link is, why it matters, or whether following it has a consequence.
+
+Write visible link text that stands on its own, then use a title only as optional supporting context.
+
+## Examples
+
+Preferred:
+
+```markdown
+[Markdown heading conventions](./markdown-heading-conventions.md)
+
+[external audit report](https://example.com/audit.pdf "PDF, published by the auditor")
+```
+
+Avoid:
+
+```markdown
+[Markdown heading conventions](./markdown-heading-conventions.md "Markdown heading conventions")
+
+[report](https://example.com/audit.pdf "Read the report")
+```
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
- Task: TSK-056 / GitHub issue #398, add Markdown link title conventions documentation.
- Standards baseline reviewed: docs/standards/software-development-standards.md and existing docs/reference Markdown convention pages.
- Checklist completed or updated: Pull request governance checklist completed in this PR body for a documentation-only change.
- Compliance checklist path: .github/PULL_REQUEST_TEMPLATE.md
- Relevant standards areas: Documentation-as-code, accessibility, reviewability, repository validation.
- Standards gaps or exceptions: No standards gaps or exceptions; scope is a single new reference document.
- Standards check result: Passed locally with `npm run standards:check` after generating the required coverage artifact with `npm run coverage`.
- Lint result: Passed locally with `npm run lint`.
- Tests: Documentation-only repository validation via `npm run lint`, `npm run coverage`, and `npm run standards:check`.
- Test evidence paths: docs/reference/markdown-link-title-conventions.md
- Docs updated: Added Markdown link title conventions reference page.
- Doc evidence paths: docs/reference/markdown-link-title-conventions.md
- Risk level: Low; documentation-only addition.
- Rollback path: Revert commit 905a0e1742e32725506e7c27ed611b7157b2ac15 to remove the new documentation file.
- Risk class: Documentation-only, reversible.
- Automation gap: No task-specific Markdown title linter exists; repository validation is the applicable automated check for this doc-only change.
- Test evidence: Local validation passed: `npm run lint`; `npm run coverage` generated .artifacts/coverage-summary.json with 1086 passing tests; `npm run standards:check` passed.
- CI result: Pending at PR creation; all attached pre-merge checks except factory-owned Merge readiness will be monitored before merge handoff.

Closes #398
