### PR TITLE
test(ui): stabilize board owner filter navigation

### DIFF
--- a/docs/standards/change-governance-maintenance.md
+++ b/docs/standards/change-governance-maintenance.md
@@ -96,6 +96,13 @@ React development-mode effect replay from being mistaken for a second logical
 poll. When an update triggers a follow-up read, tests should await a response
 that actually contains the updated payload before asserting rendered content.
 
+URL-driven integration tests must also wait for any required initial navigation
+to settle before triggering a second navigation. For example, when a queue
+selects its initial task through a `selectedTask` query parameter, assert that
+query state before changing a filter that also rewrites the URL. This prevents
+two valid state transitions from replacing each other according to runner
+timing.
+
 ## Dual remotes (GitLab primary)
 Canonical ship path is GitLab (`origin`). GitHub (`github`) is the backup / public CI mirror. Prefer basing work on `origin/main`, push `origin` first, then `github`. Operator status: `npm run remotes:sync-status`. Full procedure: `docs/runbooks/dual-remote-gitlab-primary.md`.
 

--- a/tests/integration/board-owner-filtering.integration.test.js
+++ b/tests/integration/board-owner-filtering.integration.test.js
@@ -129,7 +129,7 @@ describe('board owner filtering integration', () => {
     installBoardFetchMock();
     render(React.createElement(App));
 
-    await screen.findByText('5 cards shown.');
+    await waitForInitialBoardSelection();
     expect(screen.getByRole('heading', { name: 'Intake Draft' })).toBeInTheDocument();
     expect(screen.getByLabelText('Coverage Audit column')).toHaveTextContent('No matching tasks in this column.');
     expect(screen.getByText('Owner hidden')).toBeInTheDocument();
@@ -261,3 +261,12 @@ describe('board owner filtering integration', () => {
     expect(screen.getByText(/governed close review or escalation handling/i)).toBeInTheDocument();
   });
 });
+
+async function waitForInitialBoardSelection() {
+  await screen.findByText('5 cards shown.');
+  // The inspector selects its initial task through a URL navigation. Let that
+  // settle before the test triggers a second navigation from the owner filter.
+  await waitFor(() => {
+    expect(new URLSearchParams(window.location.search).get('selectedTask')).toBe('TSK-BOARD-1');
+  });
+}


### PR DESCRIPTION
## Summary

- wait for the required initial selectedTask URL navigation before changing the board owner filter
- remove the hosted timing race that invalidated PR #404 and its six-task cohort
- document deterministic ordering for integration tests that perform consecutive URL rewrites

Closes #405

- Task: #405
- Standards baseline reviewed: yes — integration testing, UI state, change governance, and maintainability policies reviewed
- Checklist completed or updated: yes — test determinism and hosted-validation evidence covered
- Compliance checklist path: docs/standards/change-governance-maintenance.md
- Relevant standards areas: deterministic integration testing, URL-driven React state, hosted PR validation, strict cohort integrity
- Standards gaps or exceptions: No exceptions; existing dependency audit findings are unchanged
- Standards check result: PASS — full make verify completed successfully
- Lint result: PASS — source integrity, repository lint, and browser readability passed
- Tests: PASS — 100 consecutive focused runs; exact coverage; 1,090 unit tests; full UI and browser suites; build, standards, policy, and maintainability gates
- Test evidence paths: tests/integration/board-owner-filtering.integration.test.js
- Docs updated: URL-driven integration tests now wait for required initial navigation before a second rewrite
- Doc evidence paths: docs/standards/change-governance-maintenance.md
- Risk level: Low; test synchronization and guidance only
- Rollback path: Revert commit 28222c0191947681ecea587121db4a4fd968c4ea
- Risk class: Low-risk test reliability bugfix
- Automation gap: The original race reproduced only under hosted runner timing; repeated focused execution and all repository gates cover the repaired ordering
- Test evidence: Full local make verify passed at commit 28222c0191947681ecea587121db4a4fd968c4ea
- CI result: Pending at PR creation; all protected checks are required before merge