### PR TITLE
fix(factory): forbid trusted PR metadata placeholders

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -237,8 +237,11 @@ first pull-request submission. Phase-runner options carry the repository,
 source issue URL, and expected changed-file list into the trusted OpenClaw
 prompt. The prompt requires the complete governed PR-body schema before the PR
 is opened, a closing reference to the source issue, and evidence paths drawn
-only from the real diff. This makes a passing initial metadata run part of the
-trusted execution contract instead of relying on a later body-repair cycle.
+only from the real diff. Required fields also forbid the same bare placeholder
+tokens rejected by `verify-pr-body.js`; a no-gap declaration must include a
+specific conformance rationale instead of `None`. This makes a passing initial
+metadata run part of the trusted execution contract instead of relying on a
+later body-repair cycle.
 
 Trusted QA is an evidence-review boundary, not a synthetic approval. The coordinator supplies the exact repository, branch, implementation SHA, PR URL, and expected file scope to the live QA agent. QA may inspect those artifacts through read-only Git and GitHub commands, but cannot mutate the PR or release gates; a rejection routes the same immutable PR identity to the Sr correction agent. Both runtime roles therefore require scoped unattended gateway execution while the coordinator continues to reject missing or malformed branch, SHA, and PR evidence.
 

--- a/docs/standards/change-governance-maintenance.md
+++ b/docs/standards/change-governance-maintenance.md
@@ -24,6 +24,10 @@ expected changed-file list, include a closing issue reference, and use only
 paths present in the actual diff for both evidence-path fields. For docs-only
 changes, the changed documentation path may serve as both test evidence and
 documentation evidence because repository validation is the exercised gate.
+Required fields must not use the bare placeholder tokens rejected by
+`verify-pr-body.js` (`None`, `N/A`, `TBD`, `TODO`, or `unknown`). When no
+standards gap exists, state that there are no gaps or exceptions and include a
+specific conformance rationale; a bare `None` is a failed initial submission.
 
 ## Coverage Artifacts
 `npm run standards:check` reads `.artifacts/coverage-summary.json`. That file may be produced by `npm run coverage` with per-suite JavaScript/UI coverage, or by `make verify` with Python coverage totals. The coverage policy checker accepts both schemas so developers can run the verification commands in either order without regenerating coverage only to satisfy a parser shape.

--- a/lib/task-platform/factory-implementer-pr-metadata.js
+++ b/lib/task-platform/factory-implementer-pr-metadata.js
@@ -30,6 +30,8 @@ function buildTrustedPrMetadataRules({ repository, githubIssueUrl, changedFiles 
     '- Automation gap:',
     '- Test evidence:',
     '- CI result:',
+    'Never use a bare placeholder value in a required field. The repository rejects `None`, `N/A`, `TBD`, `TODO`, and `unknown` (case-insensitive). For Standards gaps or exceptions when no gap exists, write `No gaps or exceptions; rationale: <specific reason this change conforms>`. Do not write only `None`.',
+    'Do not use bare `pending` for completed local evidence. The CI result may say `Pending at PR creation; all protected checks are required before merge` because hosted checks start after the PR is opened.',
     'Every Test evidence paths and Doc evidence paths entry must be a file actually changed in this PR. For a documentation-only change, use the changed documentation path for both fields because repository validation is the test evidence.',
     githubIssueUrl
       ? `Include a closing reference for the source issue (${githubIssueUrl}), such as \`Closes #${issueNumber || '<issue-number>'}\`.`

--- a/tests/integration/task-platform-branch-protection.integration.test.js
+++ b/tests/integration/task-platform-branch-protection.integration.test.js
@@ -86,5 +86,8 @@ test('propagates trusted queue scope into the first-pass implementer PR contract
   assert.match(prompt, /Repository: wiinc1\/engineering-team/);
   assert.match(prompt, /Source GitHub issue: https:\/\/github\.com\/wiinc1\/engineering-team\/issues\/388/);
   assert.match(prompt, /Expected changed files: docs\/reference\/example\.md/);
+  assert.match(prompt, /repository rejects `None`, `N\/A`, `TBD`, `TODO`, and `unknown`/);
+  assert.match(prompt, /No gaps or exceptions; rationale: <specific reason this change conforms>/);
+  assert.match(prompt, /Do not write only `None`/);
   assert.match(prompt, /Closes #388/);
 });

--- a/tests/unit/factory-agent-phases.test.js
+++ b/tests/unit/factory-agent-phases.test.js
@@ -86,6 +86,10 @@ test('buildImplementerPrompt labels session-proof vs trusted delivery', () => {
   assert.match(trusted, /Expected changed files: docs\/reference\/example\.md/);
   assert.match(trusted, /- Standards baseline reviewed:/);
   assert.match(trusted, /- Rollback path:/);
+  assert.match(trusted, /rejects `None`, `N\/A`, `TBD`, `TODO`, and `unknown`/);
+  assert.match(trusted, /No gaps or exceptions; rationale: <specific reason this change conforms>/);
+  assert.match(trusted, /Do not write only `None`/);
+  assert.match(trusted, /Pending at PR creation; all protected checks are required before merge/);
   assert.match(trusted, /documentation-only change, use the changed documentation path for both fields/);
   assert.match(trusted, /Closes #388/);
   assert.doesNotMatch(trusted, /attribution proof only/);


### PR DESCRIPTION
## Summary

Make the trusted implementer prompt explicitly forbid every placeholder token rejected by the hosted PR-body validator and provide valid first-submission wording for no-gap and pending-CI cases.

Add regression coverage for the exact `None` metadata failure that invalidated PR #422, and document the governed contract.

## Linked Task
- Task: Closes #423

## Standards Compliance
- Standards baseline reviewed: yes — architecture and change-governance standards were reviewed and updated
- Checklist completed or updated: yes — trusted first-head PR metadata contract is covered by unit and integration tests
- Compliance checklist path: docs/standards/change-governance-maintenance.md
- Relevant standards areas: pull-request metadata governance, trusted delivery, test evidence
- Standards gaps or exceptions: No gaps or exceptions; rationale: prompt guidance now matches the enforced hosted validator.
- [ ] UI changes use generated DESIGN.md tokens.
- [ ] `npm run design:tokens:check` passed.
- [ ] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: passed in `make verify`
- Lint result: passed in `make verify`
- Tests: focused unit/integration 15/15 passed; full `make verify` passed including 174 UI and 193 browser tests
- Test evidence paths: tests/unit/factory-agent-phases.test.js, tests/integration/task-platform-branch-protection.integration.test.js
- Docs updated: trusted implementer architecture and change-governance maintenance rules
- Doc evidence paths: docs/architecture.md, docs/standards/change-governance-maintenance.md

## Risk and Rollback
- Risk level: low — prompt text and regression assertions only; no runtime state or schema change
- Rollback path: revert commit 1aa37f4 if trusted prompt generation regresses

## Notes

- CI result: Pending at PR creation; all protected checks are required before merge.
- Automation gap: No automation gap; the live prompt now supplies the same constraints enforced by hosted validation.
