### PR TITLE
docs: add markdown anchor conventions

### DIFF
--- a/docs/reference/markdown-anchor-conventions.md
+++ b/docs/reference/markdown-anchor-conventions.md
@@ -1,0 +1,65 @@
+# Markdown anchor conventions
+
+## Purpose
+
+Use these conventions to keep heading anchors and fragment links stable across repository documentation.
+
+## Heading-derived anchors
+
+Prefer links to anchors generated from Markdown headings when the target section has a clear, stable heading.
+
+Write unique headings so generated anchors resolve to one intended section. Use sentence-case heading text and avoid punctuation that makes anchors harder to read or remember.
+
+Example:
+
+```markdown
+See [validation guidance](#validation-guidance) before opening a documentation pull request.
+
+## Validation guidance
+```
+
+## Explicit HTML anchors
+
+Use explicit HTML anchors only when a stable fragment must survive a heading rename or when external documents already depend on a published fragment.
+
+Place the anchor immediately before the target heading and use a short, descriptive lowercase name.
+
+Example:
+
+```markdown
+<a id="stable-validation"></a>
+
+## Validation guidance
+```
+
+Do not add explicit anchors for routine internal links when a stable heading-derived anchor is sufficient.
+
+## Renaming risks
+
+Renaming a heading can break existing fragment links because most Markdown renderers derive the anchor from the heading text.
+
+Before renaming a linked heading, search for links to the old fragment and update them in the same change. If external links may exist, keep a justified explicit HTML anchor for the old fragment.
+
+## Fragment link examples
+
+Use relative links with fragments for sections in repository documents.
+
+Examples:
+
+```markdown
+[Markdown heading conventions](./markdown-heading-conventions.md)
+[Logical nesting](./markdown-heading-conventions.md#logical-nesting)
+[Validation guidance](#validation-guidance)
+```
+
+Avoid raw fragments without clear link text unless the fragment itself is the subject of the sentence.
+
+## Validation guidance
+
+Validate anchor changes by checking that changed fragment links point to existing headings or justified explicit anchors.
+
+For documentation-only changes, review rendered Markdown when practical and use repository link or documentation validation checks when they are available.
+
+## Rollback
+
+Revert the documentation commit to remove these conventions.


### PR DESCRIPTION
## Summary
- Add a concise reference for stable Markdown heading anchors and fragment links in repository documentation.

## Required fields
- Task: TSK-074 / GitHub issue #425 markdown anchor conventions reference.
- Standards baseline reviewed: Existing docs/reference markdown convention files and repository PR body validation requirements reviewed before PR creation.
- Checklist completed or updated: Completed documentation-only delivery checklist through source integrity, repo lint, docs freshness, and diff whitespace validation.
- Compliance checklist path: docs/reference/markdown-anchor-conventions.md
- Relevant standards areas: Markdown headings, repository links, documentation freshness, PR evidence paths, and docs-only rollback guidance.
- Standards gaps or exceptions: No gaps or exceptions; rationale: this change adds only the approved reference file and follows the existing docs/reference structure with purpose, focused guidance, examples, validation, and rollback.
- Standards check result: PASS - CHANGE_KIND=docs-only CHANGE_REFERENCE=https://github.com/wiinc1/engineering-team/issues/425 python3 dev-standards/tooling/validate_docs_freshness.py --repo-root . --base-ref github/main; PASS - npm run source:integrity.
- Lint result: PASS - node scripts/lint-repo.js; PASS - git diff --cached --check before commit.
- Tests: PASS - documentation validation via docs freshness, source integrity, repository lint, and whitespace diff checks for docs/reference/markdown-anchor-conventions.md.
- Test evidence paths: docs/reference/markdown-anchor-conventions.md
- Docs updated: docs/reference/markdown-anchor-conventions.md
- Doc evidence paths: docs/reference/markdown-anchor-conventions.md
- Risk level: Low; docs-only additive reference with no runtime, dependency, configuration, generated artifact, or existing documentation edits.
- Rollback path: Revert commit 6163139b5a664cbf4aa2cec34c32562a74468b4a to remove docs/reference/markdown-anchor-conventions.md.
- Risk class: Documentation-only additive change confined to docs/reference/markdown-anchor-conventions.md.
- Automation gap: No dedicated anchor-link checker exists for this new reference; coverage relies on repo lint, source integrity, docs freshness, and review of the documented examples.
- Test evidence: docs/reference/markdown-anchor-conventions.md validated by docs freshness, source integrity, repo lint, and whitespace diff checks in the isolated worktree.
- CI result: Pending at PR creation; all protected checks are required before merge.

Closes #425
