### PR TITLE
fix(factory): require PR metadata bullet prefixes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,9 +239,11 @@ prompt. The prompt requires the complete governed PR-body schema before the PR
 is opened, a closing reference to the source issue, and evidence paths drawn
 only from the real diff. Required fields also forbid the same bare placeholder
 tokens rejected by `verify-pr-body.js`; a no-gap declaration must include a
-specific conformance rationale instead of `None`. This makes a passing initial
-metadata run part of the trusted execution contract instead of relying on a
-later body-repair cycle.
+specific conformance rationale instead of `None`. Every governed field retains
+the literal `- ` prefix from the PR template because the hosted validator
+anchors on `- Label: value`; an unbulleted label is missing metadata. This makes
+a passing initial metadata run part of the trusted execution contract instead
+of relying on a later body-repair cycle.
 
 Trusted QA is an evidence-review boundary, not a synthetic approval. The coordinator supplies the exact repository, branch, implementation SHA, PR URL, and expected file scope to the live QA agent. QA may inspect those artifacts through read-only Git and GitHub commands, but cannot mutate the PR or release gates; a rejection routes the same immutable PR identity to the Sr correction agent. Both runtime roles therefore require scoped unattended gateway execution while the coordinator continues to reject missing or malformed branch, SHA, and PR evidence.
 

--- a/docs/standards/change-governance-maintenance.md
+++ b/docs/standards/change-governance-maintenance.md
@@ -28,6 +28,10 @@ Required fields must not use the bare placeholder tokens rejected by
 `verify-pr-body.js` (`None`, `N/A`, `TBD`, `TODO`, or `unknown`). When no
 standards gap exists, state that there are no gaps or exceptions and include a
 specific conformance rationale; a bare `None` is a failed initial submission.
+Each governed field line must also begin with the literal ASCII `- ` prefix
+shown in the pull-request template. `verify-pr-body.js` anchors on
+`- Label: value`, so an unbulleted `Label: value` line is treated as missing
+even when its value is otherwise complete.
 
 ## Coverage Artifacts
 `npm run standards:check` reads `.artifacts/coverage-summary.json`. That file may be produced by `npm run coverage` with per-suite JavaScript/UI coverage, or by `make verify` with Python coverage totals. The coverage policy checker accepts both schemas so developers can run the verification commands in either order without regenerating coverage only to satisfy a parser shape.

--- a/lib/task-platform/factory-implementer-pr-metadata.js
+++ b/lib/task-platform/factory-implementer-pr-metadata.js
@@ -12,6 +12,7 @@ function buildTrustedPrMetadataRules({ repository, githubIssueUrl, changedFiles 
     `Source GitHub issue: ${githubIssueUrl || '(not supplied)'}`,
     `Expected changed files: ${expectedChangedFiles.length ? expectedChangedFiles.join(', ') : '(not supplied)'}`,
     'Before opening the pull request, write a complete body with non-placeholder values for every line below. Do not open the PR with an incomplete body and repair it later:',
+    'Every governed field line MUST begin with the literal ASCII characters `- ` (hyphen followed by one space), exactly as shown below. The hosted validator matches `^- <label>:` at the start of a line; an unbulleted `Task: value` line is treated as missing. Preserve the `- ` prefix when replacing each blank value.',
     '- Task:',
     '- Standards baseline reviewed:',
     '- Checklist completed or updated:',

--- a/tests/integration/task-platform-branch-protection.integration.test.js
+++ b/tests/integration/task-platform-branch-protection.integration.test.js
@@ -86,6 +86,9 @@ test('propagates trusted queue scope into the first-pass implementer PR contract
   assert.match(prompt, /Repository: wiinc1\/engineering-team/);
   assert.match(prompt, /Source GitHub issue: https:\/\/github\.com\/wiinc1\/engineering-team\/issues\/388/);
   assert.match(prompt, /Expected changed files: docs\/reference\/example\.md/);
+  assert.match(prompt, /MUST begin with the literal ASCII characters `- `/);
+  assert.match(prompt, /hosted validator matches `\^- <label>:`/);
+  assert.match(prompt, /unbulleted `Task: value` line is treated as missing/);
   assert.match(prompt, /repository rejects `None`, `N\/A`, `TBD`, `TODO`, and `unknown`/);
   assert.match(prompt, /No gaps or exceptions; rationale: <specific reason this change conforms>/);
   assert.match(prompt, /Do not write only `None`/);

--- a/tests/unit/factory-agent-phases.test.js
+++ b/tests/unit/factory-agent-phases.test.js
@@ -112,6 +112,16 @@ test('buildImplementerPrompt labels session-proof vs trusted delivery', () => {
   assert.match(fix, /Do not open a second pull request/);
 });
 
+test('buildImplementerPrompt requires literal PR metadata bullet prefixes', () => {
+  const trusted = buildImplementerPrompt({
+    taskId: 'TSK-1', requirements: 'x', requireRealEvidence: true,
+  });
+  assert.match(trusted, /MUST begin with the literal ASCII characters `- `/);
+  assert.match(trusted, /hosted validator matches `\^- <label>:`/);
+  assert.match(trusted, /unbulleted `Task: value` line is treated as missing/);
+  assert.match(trusted, /Preserve the `- ` prefix/);
+});
+
 test('buildQaPrompt supplies exact read-only PR evidence for trusted delivery QA', () => {
   const prompt = buildQaPrompt({
     taskId: 'TSK-26',


### PR DESCRIPTION
## Summary

Require every governed trusted-delivery PR field to preserve the literal hyphen-space prefix expected by the hosted validator.

Add regression coverage for the exact unbulleted metadata failure on PR #432 and document the anchored first-head syntax.

## Linked Task
- Task: Closes #433

## Standards Compliance
- Standards baseline reviewed: yes — architecture and change-governance standards were reviewed and updated
- Checklist completed or updated: yes — literal first-head field syntax is covered by focused unit and integration tests
- Compliance checklist path: docs/standards/change-governance-maintenance.md
- Relevant standards areas: pull-request metadata governance, trusted delivery, hosted validation
- Standards gaps or exceptions: No gaps or exceptions; rationale: the live prompt now exactly matches the anchored hosted validator syntax.
- [ ] UI changes use generated DESIGN.md tokens.
- [ ] `npm run design:tokens:check` passed.
- [ ] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`.

## Required Evidence
- Standards check result: passed in the final `make verify` run
- Lint result: passed in the final `make verify` run
- Tests: focused regression tests 16/16 passed; full `make verify` passed with 1,091 unit, 174 UI, and 193 browser tests
- Test evidence paths: tests/unit/factory-agent-phases.test.js, tests/integration/task-platform-branch-protection.integration.test.js
- Docs updated: trusted implementer architecture and change-governance formatting rules
- Doc evidence paths: docs/architecture.md, docs/standards/change-governance-maintenance.md

## Risk and Rollback
- Risk level: low — prompt guidance and regression assertions only; no schema, dependency, or runtime state change
- Rollback path: revert commit 72017dd if trusted prompt generation regresses

## Notes

- Risk class: low-risk governance prompt repair
- Automation gap: No automation gap; unit and integration coverage assert the exact hosted validator prefix contract.
- Test evidence: final `make verify` passed after the maintainability-safe test split.
- CI result: Pending at PR creation; all protected checks are required before merge.
