### PR TITLE
Docs: add API endpoint formatting reference

### DIFF
--- a/docs/reference/api-endpoint-formatting.md
+++ b/docs/reference/api-endpoint-formatting.md
@@ -1,0 +1,98 @@
+# API endpoint formatting
+
+## Purpose
+
+Use these conventions to document API endpoints consistently across repository docs, implementation notes, and review evidence.
+
+## Method and path notation
+
+Write the HTTP method in uppercase followed by one space and the absolute path.
+
+```text
+GET /api/tasks
+POST /api/tasks
+PATCH /api/tasks/{taskId}
+DELETE /api/tasks/{taskId}
+```
+
+Use backticks around inline endpoint references, such as `GET /api/tasks/{taskId}`. Do not include a host name unless the host is part of the decision being documented.
+
+Use `{name}` for path parameters. Keep parameter names descriptive, lower camel case, and aligned with the implementation or API contract.
+
+## Path parameters
+
+Name each path parameter near the endpoint description when the value is not obvious.
+
+Example:
+
+```markdown
+`GET /api/projects/{projectId}/tasks/{taskId}` returns one task in a project.
+
+- `projectId`: Stable project identifier.
+- `taskId`: Stable task identifier scoped to the project.
+```
+
+Do not document a placeholder as literal path text. Write `/api/tasks/{taskId}`, not `/api/tasks/taskId` or `/api/tasks/:taskId`, unless the API framework specifically exposes colon notation to readers.
+
+## Query strings
+
+Show query parameters after the path when a specific combination matters.
+
+```text
+GET /api/tasks?status=open&owner=jr-engineer
+```
+
+For optional or variable query strings, document the base endpoint first and list parameters separately.
+
+```markdown
+`GET /api/tasks` lists tasks.
+
+- `status`: Optional task status filter.
+- `owner`: Optional owner agent identifier.
+```
+
+Encode example values as they would appear in a real URL. Avoid placeholder-heavy query strings when a concrete example would be clearer.
+
+## Complete examples
+
+Include a complete request example when readers need to copy, test, or compare behavior.
+
+```sh
+curl --fail \
+  --request GET \
+  --header "Authorization: Bearer <token>" \
+  --url "https://example.com/api/tasks?status=open"
+```
+
+Keep commands copy-paste safe. Use angle-bracket placeholders only for values the reader must replace, and explain them when the surrounding text does not.
+
+When documenting a response shape, include the smallest complete response that proves the behavior.
+
+```json
+{
+  "tasks": [
+    {
+      "id": "task-123",
+      "status": "open"
+    }
+  ]
+}
+```
+
+## Accessible prose
+
+Introduce each endpoint with a plain-language sentence that says what the endpoint does and who or what it affects.
+
+Prefer "returns one task" over "fetches task object" and "creates a task for the project" over "hits task creation route." Spell out unusual abbreviations before using them repeatedly.
+
+Use link text that describes the destination, such as "task creation endpoint," instead of raw URLs or vague text such as "here."
+
+## Validation guidance
+
+Before publishing endpoint documentation, verify that each method, path segment, path parameter, query parameter, and example value matches the current API contract or implementation.
+
+For documentation-only changes, review the rendered Markdown when practical and run the repository documentation or standards checks available for the changed file. Confirm that fenced examples use the correct language labels and that command examples follow the command example formatting conventions.
+
+## Rollback
+
+Revert the documentation commit to remove this endpoint formatting reference.


### PR DESCRIPTION
## Summary

Adds a concise API endpoint formatting reference for method/path notation, path parameters, query strings, examples, accessible prose, and validation guidance.

- Task: TSK-080 / GitHub issue #435
- Standards baseline reviewed: yes - docs/standards/software-development-standards.md and repository reference documentation conventions reviewed
- Checklist completed or updated: yes - PR governance checklist completed in this pull request body
- Compliance checklist path: .github/PULL_REQUEST_TEMPLATE.md
- Relevant standards areas: Documentation clarity, Markdown formatting, command example formatting, validation evidence, rollback guidance
- Standards gaps or exceptions: No gaps or exceptions; rationale: docs-only reference follows existing docs/reference structure and repository Markdown conventions
- Standards check result: PASS - npm run standards:check after npm run coverage generated .artifacts/coverage-summary.json
- Lint result: PASS - npm run lint
- Tests: PASS - npm run coverage, 1089 tests passed; docs-only validation also covered by npm run standards:check
- Test evidence paths: docs/reference/api-endpoint-formatting.md
- Docs updated: docs/reference/api-endpoint-formatting.md added as the API endpoint formatting reference
- Doc evidence paths: docs/reference/api-endpoint-formatting.md
- Risk level: Low; documentation-only addition with no runtime, dependency, configuration, or generated artifact changes
- Rollback path: Revert commit a4bebab0b80a00816e2cb6232232b6f65c51ad86 to remove docs/reference/api-endpoint-formatting.md
- Risk class: Documentation-only, low operational risk
- Automation gap: No automation gap for this scope; repository lint, standards, and coverage checks completed locally
- Test evidence: npm run lint passed; npm run coverage passed with 1089 tests; npm run standards:check passed after coverage artifact generation
- CI result: Pending at PR creation; all protected checks are required before merge

Closes #435