### PR TITLE
Fix staging for host-only architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -267,8 +267,10 @@ The repository commits `package.json` and `package-lock.json`, not `node_modules
 
 ### Isolated staging factory profile
 
-The hosted staging release uses `FACTORY_STACK_PROFILE=staging`. That profile has independent launchd
+The same-host staging release uses `FACTORY_STACK_PROFILE=staging`. That profile has independent launchd
 labels, ports, root binding, state, logs, and database configuration; it cannot replace the default
 factory-of-record binding. The deployer accepts only an exact commit SHA in a persistent release root,
-then requires both local topology health and a non-local HTTPS `/health` response before it emits
-revision-bound staging evidence.
+then requires local topology health plus a deployed `/health` response before it emits revision-bound
+staging evidence. `STAGING_ENDPOINT_MODE=host-local` permits only explicit loopback HTTP(S) endpoints;
+the default hosted mode still requires non-local HTTPS. This keeps the deployment on the operator host
+without weakening profile, database, credential, or exact-revision isolation.

--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -7,15 +7,20 @@
 The default factory stack and staging are separate launchd profiles. Staging uses independent labels,
 ports, logs, state, and root binding, so an approved release cannot rebind or interrupt the host's
 factory of record. Configure protected CI variables `STAGING_BASE_URL`, `STAGING_BROWSER_BASE_URL`,
-`STAGING_DATABASE_URL`, `STAGING_JWT_SECRET`, and `STAGING_RELEASE_ROOT`; both URLs must be non-local
-HTTPS and the release root must be an absolute, persistent path outside temporary and `_checkouts`
-directories.
+`STAGING_DATABASE_URL`, `STAGING_JWT_SECRET`, and `STAGING_RELEASE_ROOT`; the release root must be an
+absolute, persistent path outside temporary and `_checkouts` directories. The default `hosted` endpoint
+mode requires non-local HTTPS. The host-only architecture instead sets
+`STAGING_ENDPOINT_MODE=host-local` and uses explicit loopback HTTP(S) URLs. Host-local mode rejects
+external hosts, and hosted mode continues to reject loopback, so neither mode can silently fall back to
+the other.
 
 On protected `main`, `deploy-runtime-staging` clones the exact `CI_COMMIT_SHA` into
 `$STAGING_RELEASE_ROOT/releases/<sha>`, removes the credential-bearing remote, installs from the lockfile,
-starts only the `staging` launchd profile, and verifies local plus hosted `/health`. It emits revision-bound
+starts only the `staging` launchd profile, and verifies local plus deployed `/health`. Host-local staging
+uses the profile ports (`127.0.0.1:23000` for the API and `127.0.0.1:25173` for the browser) on this same
+operator host. It emits revision-bound
 Graphile and LangGraph `staging_deploy` components. An existing release directory with another revision,
-an unhealthy local stack, a redirect, or unhealthy hosted endpoint blocks deployment.
+an unhealthy local stack, a redirect, or unhealthy deployed endpoint blocks deployment.
 
 The staging and soak jobs share the `runtime-staging` resource group and are non-interruptible. This
 prevents concurrent releases from sharing the dedicated staging database or contaminating the 24-hour
@@ -29,7 +34,7 @@ checkout, stores each raw result for two weeks, and normalizes only parser-verif
 command provenance and source SHA-256 digests. The 24-hour job consumes that exact deployment;
 `seal-runtime-release-manifests` then adds the soak components, seals both manifests, and runs both
 release verifiers. Missing protected variables suppress the hosted jobs instead of falling back to
-localhost. CI never runs the apply command.
+an implicit endpoint mode. CI never runs the apply command.
 
 Validate with:
 

--- a/lib/release-gates/staging-deployment.js
+++ b/lib/release-gates/staging-deployment.js
@@ -1,11 +1,14 @@
 'use strict';
 
+const crypto = require('node:crypto');
 const path = require('node:path');
 const os = require('node:os');
 const { evidenceDigest } = require('./evidence-collector');
 
 const SHA_PATTERN = /^[0-9a-f]{40}$/;
 const DEPLOYMENT_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{2,127}$/;
+const ENDPOINT_MODES = new Set(['hosted', 'host-local']);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
 function realPathCandidate(value) {
   return path.resolve(String(value || ''));
@@ -23,37 +26,74 @@ function protectedHttpsUrl(value) {
   try { parsed = new URL(value); } catch { return null; }
   const hostname = parsed.hostname.toLowerCase();
   if (parsed.protocol !== 'https:' || parsed.username || parsed.password) return null;
-  if (['localhost', '127.0.0.1', '::1'].includes(hostname) || hostname.endsWith('.local')) return null;
+  if (LOOPBACK_HOSTS.has(hostname) || hostname.endsWith('.local')) return null;
   return parsed;
+}
+
+function hostLocalUrl(value) {
+  let parsed;
+  try { parsed = new URL(value); } catch { return null; }
+  if (!['http:', 'https:'].includes(parsed.protocol) || parsed.username || parsed.password) return null;
+  return LOOPBACK_HOSTS.has(parsed.hostname.toLowerCase()) ? parsed : null;
+}
+
+function stagingEndpointUrl(value, mode) {
+  return mode === 'host-local' ? hostLocalUrl(value) : protectedHttpsUrl(value);
+}
+
+function stagingSessionSecret(jwtSecret) {
+  return crypto.createHash('sha256').update(`engineering-team-staging-session\0${jwtSecret}`).digest('hex');
+}
+
+function hasPostgresProtocol(value) {
+  try { return ['postgres:', 'postgresql:'].includes(new URL(value).protocol); } catch { return false; }
+}
+
+function validRepositorySource(value) {
+  if (!value) return false;
+  if (path.isAbsolute(value)) return true;
+  try {
+    const parsed = new URL(value);
+    return !parsed.username && !parsed.password;
+  } catch { return false; }
+}
+
+function stagingConfigurationErrors(input) {
+  const errors = [];
+  if (!SHA_PATTERN.test(input.revision)) errors.push('STAGING_REVISION must be an exact lowercase 40-character commit SHA.');
+  if (!DEPLOYMENT_PATTERN.test(input.deploymentId)) errors.push('STAGING_DEPLOYMENT_ID must be a stable 3-128 character identifier.');
+  if (!input.releaseRootInput || !path.isAbsolute(input.releaseRootInput) || isTemporaryPath(input.releaseRoot)) {
+    errors.push('STAGING_RELEASE_ROOT must be an absolute persistent path outside temporary and _checkouts directories.');
+  }
+  if (!ENDPOINT_MODES.has(input.endpointMode)) errors.push('STAGING_ENDPOINT_MODE must be hosted or host-local.');
+  else if (!input.baseUrl) errors.push(input.endpointMode === 'host-local'
+    ? 'STAGING_BASE_URL must be a credential-free HTTP(S) loopback URL in host-local mode.'
+    : 'STAGING_BASE_URL must be a credential-free, non-local HTTPS URL in hosted mode.');
+  if (!hasPostgresProtocol(input.databaseUrl)) {
+    errors.push('STAGING_DATABASE_URL must be an explicit PostgreSQL URL for the dedicated staging database.');
+  }
+  if (input.jwtSecret.trim().length < 32) errors.push('STAGING_JWT_SECRET must contain at least 32 characters.');
+  if (!validRepositorySource(input.repositoryUrl)) {
+    errors.push(input.repositoryUrl ? 'The staging repository source must be an absolute checkout path or a credential-free URL.'
+      : 'STAGING_REPOSITORY_URL or CI_PROJECT_DIR is required.');
+  }
+  return errors;
 }
 
 function stagingConfiguration(env = process.env) {
   const revision = String(env.STAGING_REVISION || env.CI_COMMIT_SHA || '').trim();
   const deploymentId = String(env.STAGING_DEPLOYMENT_ID || '').trim();
   const releaseRoot = realPathCandidate(env.STAGING_RELEASE_ROOT);
-  const baseUrl = protectedHttpsUrl(String(env.STAGING_BASE_URL || '').trim());
+  const endpointMode = String(env.STAGING_ENDPOINT_MODE || 'hosted').trim().toLowerCase();
+  const baseUrl = ENDPOINT_MODES.has(endpointMode)
+    ? stagingEndpointUrl(String(env.STAGING_BASE_URL || '').trim(), endpointMode) : null;
   const databaseUrl = String(env.STAGING_DATABASE_URL || '').trim();
+  const jwtSecret = String(env.STAGING_JWT_SECRET || '');
   const repositoryUrl = String(env.STAGING_REPOSITORY_URL || env.CI_PROJECT_DIR || '').trim();
-  const errors = [];
-  if (!SHA_PATTERN.test(revision)) errors.push('STAGING_REVISION must be an exact lowercase 40-character commit SHA.');
-  if (!DEPLOYMENT_PATTERN.test(deploymentId)) errors.push('STAGING_DEPLOYMENT_ID must be a stable 3-128 character identifier.');
-  if (!env.STAGING_RELEASE_ROOT || !path.isAbsolute(env.STAGING_RELEASE_ROOT) || isTemporaryPath(releaseRoot)) {
-    errors.push('STAGING_RELEASE_ROOT must be an absolute persistent path outside temporary and _checkouts directories.');
-  }
-  if (!baseUrl) errors.push('STAGING_BASE_URL must be a credential-free, non-local HTTPS URL.');
-  let parsedDatabase;
-  try { parsedDatabase = new URL(databaseUrl); } catch { parsedDatabase = null; }
-  if (!parsedDatabase || !['postgres:', 'postgresql:'].includes(parsedDatabase.protocol)) {
-    errors.push('STAGING_DATABASE_URL must be an explicit PostgreSQL URL for the dedicated staging database.');
-  }
-  if (!repositoryUrl) errors.push('STAGING_REPOSITORY_URL or CI_PROJECT_DIR is required.');
-  if (repositoryUrl && !path.isAbsolute(repositoryUrl)) {
-    let parsedRepository;
-    try { parsedRepository = new URL(repositoryUrl); } catch { parsedRepository = null; }
-    if (!parsedRepository || parsedRepository.username || parsedRepository.password) {
-      errors.push('The staging repository source must be an absolute checkout path or a credential-free URL.');
-    }
-  }
+  const errors = stagingConfigurationErrors({
+    baseUrl, databaseUrl, deploymentId, endpointMode, jwtSecret,
+    releaseRoot, releaseRootInput: env.STAGING_RELEASE_ROOT, repositoryUrl, revision,
+  });
   if (errors.length) {
     const error = new Error(errors.join(' '));
     error.code = 'staging_configuration_invalid';
@@ -64,6 +104,8 @@ function stagingConfiguration(env = process.env) {
     baseUrl: baseUrl.toString().replace(/\/$/, ''),
     databaseUrl,
     deploymentId,
+    endpointMode,
+    jwtSecret,
     releaseDir: path.join(releaseRoot, 'releases', revision),
     releaseRoot,
     repositoryUrl,
@@ -76,6 +118,8 @@ function stagingConfiguration(env = process.env) {
 function stagingServiceEnvironment(configuration, env = process.env) {
   return Object.freeze({
     ...env,
+    AUTH_JWT_SECRET: configuration.jwtSecret,
+    AUTH_SESSION_SECRET: stagingSessionSecret(configuration.jwtSecret),
     DATABASE_URL: configuration.databaseUrl,
     FACTORY_STACK_DATABASE_URL: configuration.databaseUrl,
     FACTORY_STACK_PROFILE: 'staging',
@@ -83,7 +127,9 @@ function stagingServiceEnvironment(configuration, env = process.env) {
     FACTORY_STACK_ROOT_BINDING_FILE: path.join(configuration.stateDir, 'repo-root.json'),
     FACTORY_STACK_LOG_DIR: path.join(configuration.releaseRoot, 'logs', 'staging'),
     FACTORY_STACK_NODE_ENV: 'production',
+    GOLDEN_PATH_JWT_SECRET: configuration.jwtSecret,
     STAGING_DEPLOYMENT_ID: configuration.deploymentId,
+    STAGING_ENDPOINT_MODE: configuration.endpointMode,
     STAGING_REVISION: configuration.revision,
   });
 }
@@ -93,6 +139,7 @@ function buildStagingDeployComponent(input) {
   const evidence = Object.freeze({
     checkoutRevision: input.revision,
     deploymentId: input.deploymentId,
+    endpointMode: input.endpointMode || 'hosted',
     healthUrl: input.healthUrl,
     localHealth: input.localHealth,
     profile: input.profile,
@@ -113,6 +160,7 @@ function buildStagingDeployComponent(input) {
       deploymentId: input.deploymentId,
       exactRevision: true,
       hostedHealth: input.hostedHealth === true,
+      hostLocalEndpoint: input.endpointMode === 'host-local',
       isolatedProfile: input.profile === 'staging',
       localHealth: input.localHealth === true,
     },
@@ -122,8 +170,12 @@ function buildStagingDeployComponent(input) {
 
 module.exports = {
   buildStagingDeployComponent,
+  hostLocalUrl,
   isTemporaryPath,
   protectedHttpsUrl,
+  stagingEndpointUrl,
   stagingConfiguration,
+  stagingConfigurationErrors,
+  stagingSessionSecret,
   stagingServiceEnvironment,
 };

--- a/scripts/deploy-runtime-staging.js
+++ b/scripts/deploy-runtime-staging.js
@@ -90,6 +90,7 @@ async function activateRelease(configuration) {
     writeJson(path.join(configuration.artifactDir, `${runtime}-staging-deploy.json`), buildStagingDeployComponent({
       automation,
       deploymentId: configuration.deploymentId,
+      endpointMode: configuration.endpointMode,
       healthUrl: hosted.url,
       hostedHealth: hosted.ok,
       localHealth: status.health.ok,

--- a/tests/integration/runtime-release-manifest.integration.test.js
+++ b/tests/integration/runtime-release-manifest.integration.test.js
@@ -46,6 +46,7 @@ it('preserves exact staging deployment evidence through the component collector 
   const revision = 'b'.repeat(40);
   const component = buildStagingDeployComponent({
     automation: 'pipeline-42', deploymentId: 'staging-42', generatedAt: '2026-08-19T18:00:00.000Z',
+    endpointMode: 'host-local',
     healthUrl: 'https://factory-staging.example.com/health', hostedHealth: true, localHealth: true,
     profile: 'staging', releaseDirectory: '/var/lib/releases/revision', revision, runtime: 'langgraph',
   });
@@ -53,6 +54,8 @@ it('preserves exact staging deployment evidence through the component collector 
   const artifact = collectArtifact(transported, { runtime: 'langgraph', revision });
   assert.equal(artifact.kind, 'staging_deploy');
   assert.equal(artifact.summary.hostedHealth, true);
+  assert.equal(artifact.summary.hostLocalEndpoint, true);
+  assert.equal(transported.evidence.endpointMode, 'host-local');
 });
 
 it('admits LangGraph load evidence only with exact side effects and zero residual state', () => {

--- a/tests/security/runtime-release-manifest.security.test.js
+++ b/tests/security/runtime-release-manifest.security.test.js
@@ -47,14 +47,28 @@ it('does not accept a cutover confirmation copied from a differently scoped appr
   assert.ok(result.reasons.includes('approval_confirmation_mismatch'));
 });
 
-it('rejects local hosted targets and credential-bearing repository URLs before staging mutation', () => {
+it('requires explicit host-local scope and rejects credential-bearing staging inputs before mutation', () => {
   const base = {
     STAGING_BASE_URL: 'https://127.0.0.1',
     STAGING_DATABASE_URL: 'postgres://staging@db.internal/staging',
     STAGING_DEPLOYMENT_ID: 'staging-secure',
+    STAGING_JWT_SECRET: 'staging-jwt-secret-with-at-least-32-characters',
     STAGING_RELEASE_ROOT: '/var/lib/engineering-team-staging',
     STAGING_REPOSITORY_URL: 'https://token@example.com/engineering-team.git',
     STAGING_REVISION: 'a'.repeat(40),
   };
   assert.throws(() => stagingConfiguration(base), { code: 'staging_configuration_invalid' });
+  assert.throws(() => stagingConfiguration({
+    ...base,
+    STAGING_BASE_URL: 'https://staging.example.com',
+    STAGING_ENDPOINT_MODE: 'host-local',
+    STAGING_REPOSITORY_URL: 'https://example.com/engineering-team.git',
+  }), { code: 'staging_configuration_invalid' });
+  const local = stagingConfiguration({
+    ...base,
+    STAGING_BASE_URL: 'http://127.0.0.1:23000',
+    STAGING_ENDPOINT_MODE: 'host-local',
+    STAGING_REPOSITORY_URL: '/srv/engineering-team',
+  });
+  assert.equal(local.endpointMode, 'host-local');
 });

--- a/tests/unit/staging-deployment.test.js
+++ b/tests/unit/staging-deployment.test.js
@@ -16,6 +16,7 @@ function validEnvironment() {
     STAGING_BASE_URL: 'https://factory-staging.example.com',
     STAGING_DATABASE_URL: 'postgres://staging:secret@db.internal/staging_factory?sslmode=require',
     STAGING_DEPLOYMENT_ID: 'staging-20260819-1',
+    STAGING_JWT_SECRET: 'staging-jwt-secret-with-at-least-32-characters',
     STAGING_RELEASE_ROOT: '/var/lib/engineering-team-staging',
     STAGING_REPOSITORY_URL: 'https://example.com/engineering-team.git',
     STAGING_REVISION: revision,
@@ -33,10 +34,28 @@ test('requires an exact revision, protected HTTPS host, dedicated database, and 
     { STAGING_BASE_URL: 'http://factory-staging.example.com' },
     { STAGING_BASE_URL: 'https://127.0.0.1' },
     { STAGING_DATABASE_URL: '' },
+    { STAGING_JWT_SECRET: 'short' },
     { STAGING_RELEASE_ROOT: '/private/tmp/staging' },
   ]) {
     assert.throws(() => stagingConfiguration({ ...validEnvironment(), ...override }), { code: 'staging_configuration_invalid' });
   }
+});
+
+test('allows only explicit loopback endpoints in host-local staging mode', () => {
+  const configuration = stagingConfiguration({
+    ...validEnvironment(),
+    STAGING_BASE_URL: 'http://127.0.0.1:23000',
+    STAGING_ENDPOINT_MODE: 'host-local',
+  });
+  assert.equal(configuration.baseUrl, 'http://127.0.0.1:23000');
+  assert.equal(configuration.endpointMode, 'host-local');
+  assert.throws(() => stagingConfiguration({
+    ...validEnvironment(), STAGING_BASE_URL: 'http://127.0.0.1:23000',
+  }), { code: 'staging_configuration_invalid' });
+  assert.throws(() => stagingConfiguration({
+    ...validEnvironment(), STAGING_BASE_URL: 'https://staging.example.com',
+    STAGING_ENDPOINT_MODE: 'host-local',
+  }), { code: 'staging_configuration_invalid' });
 });
 
 test('builds an isolated production-mode service environment without changing default labels', () => {
@@ -45,12 +64,16 @@ test('builds an isolated production-mode service environment without changing de
   assert.equal(env.FACTORY_STACK_PROFILE, 'staging');
   assert.equal(env.FACTORY_STACK_NODE_ENV, 'production');
   assert.equal(env.DATABASE_URL, validEnvironment().STAGING_DATABASE_URL);
+  assert.equal(env.AUTH_JWT_SECRET, validEnvironment().STAGING_JWT_SECRET);
+  assert.equal(env.GOLDEN_PATH_JWT_SECRET, validEnvironment().STAGING_JWT_SECRET);
+  assert.notEqual(env.AUTH_SESSION_SECRET, validEnvironment().STAGING_JWT_SECRET);
   assert.match(env.FACTORY_STACK_ROOT_BINDING_FILE, /state\/staging\/repo-root\.json$/);
 });
 
 test('emits revision-bound staging components and fails status when either health proof fails', () => {
   const base = {
     automation: 'pipeline-1', deploymentId: 'staging-20260819-1',
+    endpointMode: 'host-local',
     generatedAt: '2026-08-19T12:00:00.000Z', healthUrl: 'https://factory-staging.example.com/health',
     hostedHealth: true, localHealth: true, profile: 'staging', releaseDirectory: '/var/lib/release',
     revision, runtime: 'graphile',
@@ -58,6 +81,7 @@ test('emits revision-bound staging components and fails status when either healt
   const passing = buildStagingDeployComponent(base);
   assert.equal(passing.status, 'passed');
   assert.equal(passing.summary.exactRevision, true);
+  assert.equal(passing.summary.hostLocalEndpoint, true);
   assert.match(passing.digest, /^sha256:[0-9a-f]{64}$/);
   assert.equal(buildStagingDeployComponent({ ...base, hostedHealth: false }).status, 'failed');
 });


### PR DESCRIPTION
## Summary

Allow the isolated staging profile to run on this architecture's only host without weakening deployment boundaries. Host-local mode accepts only explicit loopback HTTP(S), while hosted mode continues to require non-local HTTPS. Staging credentials are isolated and release evidence records the endpoint scope.

## Linked Task
- Task: Align Stage 4 with the host-only infrastructure architecture

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/runtime-hardening-cutover.md
- Relevant standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; observability and monitoring; team and process
- Standards gaps or exceptions: The prior staging policy required a non-local HTTPS endpoint even though this infrastructure can execute only on this host; this change resolves the mismatch through explicit mutually exclusive endpoint modes with no waiver.
- [ ] UI changes use generated DESIGN.md tokens.
- [x] npm run design:tokens:check passed.
- [x] npm run design:tokens:enforce passed.
- [ ] DESIGN.md was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with DESIGN-TOKEN-EXCEPTION.

## Required Evidence
- Standards check result: npm run standards:check passed; maintainability and 98.165% coverage policy passed.
- Lint result: npm run lint passed as part of make verify.
- Tests: make verify passed, including Python, Node unit, integration, security, UI, browser, build, provenance, secrets, and policy validation.
- Test evidence paths: tests/unit/staging-deployment.test.js, tests/integration/runtime-release-manifest.integration.test.js, tests/security/runtime-release-manifest.security.test.js
- Docs updated: Same-host staging architecture and runtime-hardening cutover procedures now document the explicit host-local profile and ports.
- Doc evidence paths: docs/runbooks/runtime-hardening-cutover.md, docs/architecture.md

## Risk and Rollback
- Risk level: medium; this changes staging configuration validation and injected service credentials but leaves hosted mode strict by default.
- Rollback path: Revert this merge commit and redeploy the prior exact revision; the default factory profile is not rebound or modified.

## Notes

The staged diff is limited to seven implementation, test, and documentation files. Existing generated observability artifacts remain uncommitted.