### PR TITLE
Fix host-local release evidence validation

### DIFF
--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -31,7 +31,9 @@ Collect immutable artifacts from the same revision and staging deployment. Run f
 
 The `runtime-hosted-evidence` job executes every pre-soak gate from the persistent exact-revision
 checkout, stores each raw result for two weeks, and normalizes only parser-verified results with redacted
-command provenance and source SHA-256 digests. The 24-hour job consumes that exact deployment;
+command provenance and source SHA-256 digests. Its endpoint normalizer enforces the same explicit
+`hosted` or `host-local` scope as the deployer, preventing either mode from being downgraded while
+evidence is collected. The 24-hour job consumes that exact deployment;
 `seal-runtime-release-manifests` then adds the soak components, seals both manifests, and runs both
 release verifiers. Missing protected variables suppress the hosted jobs instead of falling back to
 an implicit endpoint mode. CI never runs the apply command.

--- a/scripts/normalize-runtime-gate-evidence.js
+++ b/scripts/normalize-runtime-gate-evidence.js
@@ -5,6 +5,9 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { buildExecutableComponent } = require('../lib/release-gates/executable-evidence');
+const { stagingEndpointUrl } = require('../lib/release-gates/staging-deployment');
+
+const ENDPOINT_MODES = new Set(['hosted', 'host-local']);
 
 const COMMANDS = Object.freeze({
   graphile: Object.freeze({
@@ -78,11 +81,13 @@ function exactRevision() {
   return execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
 }
 
-function protectedHttpsUrl(valueToParse, name) {
-  let parsed;
-  try { parsed = new URL(String(valueToParse || '')); } catch { throw new Error(`${name} must be a protected non-local HTTPS endpoint.`); }
-  if (parsed.protocol !== 'https:' || ['localhost', '127.0.0.1', '::1'].includes(parsed.hostname)) {
-    throw new Error(`${name} must be a protected non-local HTTPS endpoint.`);
+function deployedStagingUrl(valueToParse, name, endpointMode) {
+  if (!ENDPOINT_MODES.has(endpointMode)) throw new Error('STAGING_ENDPOINT_MODE must be hosted or host-local.');
+  const parsed = stagingEndpointUrl(String(valueToParse || ''), endpointMode);
+  if (!parsed) {
+    throw new Error(endpointMode === 'host-local'
+      ? `${name} must be a credential-free HTTP(S) loopback endpoint in host-local mode.`
+      : `${name} must be a credential-free, non-local HTTPS endpoint in hosted mode.`);
   }
   return parsed;
 }
@@ -91,14 +96,15 @@ function configuration(argv = process.argv.slice(2), env = process.env) {
   const runtime = value(argv, 'runtime');
   const kind = value(argv, 'kind');
   const revision = String(env.STAGING_REVISION || '').trim();
-  protectedHttpsUrl(env.STAGING_BASE_URL, 'STAGING_BASE_URL');
-  if (kind === 'browser') protectedHttpsUrl(env.STAGING_BROWSER_BASE_URL, 'STAGING_BROWSER_BASE_URL');
+  const endpointMode = String(env.STAGING_ENDPOINT_MODE || 'hosted').trim().toLowerCase();
+  deployedStagingUrl(env.STAGING_BASE_URL, 'STAGING_BASE_URL', endpointMode);
+  if (kind === 'browser') deployedStagingUrl(env.STAGING_BROWSER_BASE_URL, 'STAGING_BROWSER_BASE_URL', endpointMode);
   if (revision !== exactRevision()) throw new Error('STAGING_REVISION must equal the exact checked-out revision.');
   if (!COMMANDS[runtime]?.[kind]) throw new Error(`Unsupported executable gate: ${runtime || 'missing'}:${kind || 'missing'}.`);
   const automation = String(env.CI_JOB_URL || '').trim();
   if (!/^https?:\/\//.test(automation)) throw new Error('CI_JOB_URL is required for hosted evidence provenance.');
   return Object.freeze({
-    runtime, kind, revision, automation,
+    runtime, kind, revision, automation, endpointMode,
     deploymentId: String(env.STAGING_DEPLOYMENT_ID || '').trim(),
     environment: 'staging',
     commandId: COMMANDS[runtime][kind],
@@ -130,4 +136,4 @@ if (require.main === module) {
   }
 }
 
-module.exports = { COMMAND_LINES, COMMANDS, THRESHOLDS, configuration, main, protectedHttpsUrl, value, values, writeJson };
+module.exports = { COMMAND_LINES, COMMANDS, THRESHOLDS, configuration, deployedStagingUrl, main, value, values, writeJson };

--- a/tests/integration/runtime-release-manifest.integration.test.js
+++ b/tests/integration/runtime-release-manifest.integration.test.js
@@ -9,6 +9,7 @@ const { collectArtifact } = require('../../lib/release-gates/evidence-collector'
 const { buildStagingDeployComponent } = require('../../lib/release-gates/staging-deployment');
 const { createCutoverPlan, cutoverPlanDigest } = require('../../lib/runtime-cutover');
 const { evaluateArtifact } = require('../../scripts/run-langgraph-load');
+const { configuration: executableGateConfiguration } = require('../../scripts/normalize-runtime-gate-evidence');
 
 it('preserves an immutable manifest seal through JSON artifact transport', () => {
   const revision = 'a'.repeat(40);
@@ -56,6 +57,22 @@ it('preserves exact staging deployment evidence through the component collector 
   assert.equal(artifact.summary.hostedHealth, true);
   assert.equal(artifact.summary.hostLocalEndpoint, true);
   assert.equal(transported.evidence.endpointMode, 'host-local');
+});
+
+it('binds host-local executable gates to the same explicit endpoint scope as deployment', () => {
+  const revision = require('node:child_process').execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const configuration = executableGateConfiguration(
+    ['--runtime', 'graphile', '--kind', 'contract', '--source', 'contract.tap'],
+    {
+      STAGING_REVISION: revision,
+      STAGING_ENDPOINT_MODE: 'host-local',
+      STAGING_BASE_URL: 'http://127.0.0.1:23000',
+      STAGING_DEPLOYMENT_ID: 'staging-host-local',
+      CI_JOB_URL: 'https://ci.example.test/jobs/host-local',
+    },
+  );
+  assert.equal(configuration.endpointMode, 'host-local');
+  assert.equal(configuration.deploymentId, 'staging-host-local');
 });
 
 it('admits LangGraph load evidence only with exact side effects and zero residual state', () => {

--- a/tests/security/runtime-release-manifest.security.test.js
+++ b/tests/security/runtime-release-manifest.security.test.js
@@ -7,6 +7,7 @@ const {
 } = require('../../lib/release-gates/runtime-evidence');
 const { stagingConfiguration } = require('../../lib/release-gates/staging-deployment');
 const { cutoverApprovalDigest, validateJointCutover } = require('../../lib/runtime-cutover');
+const { configuration: executableGateConfiguration } = require('../../scripts/normalize-runtime-gate-evidence');
 
 it('fails closed when deployment identity is changed after a manifest is sealed', () => {
   const revision = 'a'.repeat(40);
@@ -71,4 +72,22 @@ it('requires explicit host-local scope and rejects credential-bearing staging in
     STAGING_REPOSITORY_URL: '/srv/engineering-team',
   });
   assert.equal(local.endpointMode, 'host-local');
+});
+
+it('rejects endpoint-scope downgrades while normalizing executable release evidence', () => {
+  const revision = require('node:child_process').execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const base = {
+    STAGING_REVISION: revision,
+    STAGING_DEPLOYMENT_ID: 'staging-secure',
+    CI_JOB_URL: 'https://ci.example.test/jobs/security',
+  };
+  assert.throws(() => executableGateConfiguration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...base, STAGING_BASE_URL: 'http://127.0.0.1:23000',
+  }), /hosted mode/);
+  assert.throws(() => executableGateConfiguration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...base, STAGING_ENDPOINT_MODE: 'host-local', STAGING_BASE_URL: 'https://staging.example.test',
+  }), /host-local mode/);
+  assert.throws(() => executableGateConfiguration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...base, STAGING_ENDPOINT_MODE: 'host-local', STAGING_BASE_URL: 'http://user@127.0.0.1:23000',
+  }), /host-local mode/);
 });

--- a/tests/unit/executable-runtime-evidence.test.js
+++ b/tests/unit/executable-runtime-evidence.test.js
@@ -125,6 +125,26 @@ test('hosted normalizer binds command provenance to protected exact-revision sta
   assert.throws(() => configuration(['--runtime', 'langgraph', '--kind', 'browser'], env), /STAGING_BROWSER_BASE_URL/);
 });
 
+test('normalizer accepts loopback evidence only in explicit host-local mode', () => {
+  const currentRevision = require('node:child_process').execFileSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
+  const env = {
+    STAGING_REVISION: currentRevision,
+    STAGING_ENDPOINT_MODE: 'host-local',
+    STAGING_BASE_URL: 'http://127.0.0.1:23000',
+    STAGING_BROWSER_BASE_URL: 'http://127.0.0.1:25173',
+    STAGING_DEPLOYMENT_ID: 'staging-host-local',
+    CI_JOB_URL: 'https://gitlab.example.test/jobs/host-local',
+  };
+  const config = configuration(['--runtime', 'langgraph', '--kind', 'browser', '--source', 'result.json'], env);
+  assert.equal(config.endpointMode, 'host-local');
+  assert.throws(() => configuration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...env, STAGING_ENDPOINT_MODE: undefined,
+  }), /hosted mode/);
+  assert.throws(() => configuration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...env, STAGING_BASE_URL: 'https://staging.example.test',
+  }), /host-local mode/);
+});
+
 test('hosted synthetic receipts retain the source digest but remove task content and URLs', () => {
   const redacted = redactReleaseEvidence({
     generatedAt: '2026-08-19T12:00:00.000Z',


### PR DESCRIPTION
## Summary

Apply the explicit staging endpoint scope to pre-soak evidence normalization. Hosted mode still requires credential-free non-local HTTPS, while host-local mode accepts only credential-free loopback HTTP(S). Cross-mode and credential downgrade attempts fail closed.

## Linked Task
- Task: Complete Stage 4 evidence collection on the host-only infrastructure architecture

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/runtime-hardening-cutover.md
- Relevant standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; security; observability and monitoring
- Standards gaps or exceptions: The deployer supported explicit host-local scope but the executable evidence normalizer retained the old non-local HTTPS-only policy; this change aligns both trust boundaries without a waiver.
- [ ] UI changes use generated DESIGN.md tokens.
- [x] npm run design:tokens:check passed.
- [x] npm run design:tokens:enforce passed.
- [ ] DESIGN.md was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with DESIGN-TOKEN-EXCEPTION.

## Required Evidence
- Standards check result: npm run standards:check passed; maintainability and 98.165% coverage policy passed.
- Lint result: npm run lint passed as part of make verify.
- Tests: make verify passed, including Python, Node unit, integration, security, UI, browser, build, provenance, secrets, and policy validation; focused endpoint tests passed 18 of 18.
- Test evidence paths: tests/unit/executable-runtime-evidence.test.js, tests/integration/runtime-release-manifest.integration.test.js, tests/security/runtime-release-manifest.security.test.js
- Docs updated: The runtime-hardening runbook now states that normalization enforces the same explicit endpoint scope as deployment.
- Doc evidence paths: docs/runbooks/runtime-hardening-cutover.md

## Risk and Rollback
- Risk level: medium; this changes release-evidence admission but leaves hosted mode strict by default and adds fail-closed downgrade coverage.
- Rollback path: Revert this merge commit and stop host-local evidence collection; the active staging services remain isolated and can be redeployed from the prior exact revision.

## Notes

This issue was found before starting the long pre-soak gates, so no incomplete or incorrectly scoped evidence was admitted.