### PR TITLE
Fix truthful host-local evidence provenance

### DIFF
--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -33,7 +33,9 @@ The `runtime-hosted-evidence` job executes every pre-soak gate from the persiste
 checkout, stores each raw result for two weeks, and normalizes only parser-verified results with redacted
 command provenance and source SHA-256 digests. Its endpoint normalizer enforces the same explicit
 `hosted` or `host-local` scope as the deployer, preventing either mode from being downgraded while
-evidence is collected. The 24-hour job consumes that exact deployment;
+evidence is collected. Hosted mode requires HTTP(S) CI provenance. Host-local mode may instead use a
+code-owned `local:` automation identifier, so evidence never claims a remote runner that cannot reach
+this host. The 24-hour job consumes that exact deployment;
 `seal-runtime-release-manifests` then adds the soak components, seals both manifests, and runs both
 release verifiers. Missing protected variables suppress the hosted jobs instead of falling back to
 an implicit endpoint mode. CI never runs the apply command.

--- a/scripts/normalize-runtime-gate-evidence.js
+++ b/scripts/normalize-runtime-gate-evidence.js
@@ -92,6 +92,15 @@ function deployedStagingUrl(valueToParse, name, endpointMode) {
   return parsed;
 }
 
+function stagingAutomation(valueToParse, endpointMode) {
+  const automation = String(valueToParse || '').trim();
+  if (/^https?:\/\/[^\s]+$/.test(automation)) return automation;
+  if (endpointMode === 'host-local' && /^local:[a-z0-9][a-z0-9._/-]*$/i.test(automation)) return automation;
+  throw new Error(endpointMode === 'host-local'
+    ? 'RUNTIME_EVIDENCE_AUTOMATION must be an HTTP(S) URL or a local automation identifier in host-local mode.'
+    : 'CI_JOB_URL or RUNTIME_EVIDENCE_AUTOMATION must be an HTTP(S) URL in hosted mode.');
+}
+
 function configuration(argv = process.argv.slice(2), env = process.env) {
   const runtime = value(argv, 'runtime');
   const kind = value(argv, 'kind');
@@ -101,8 +110,7 @@ function configuration(argv = process.argv.slice(2), env = process.env) {
   if (kind === 'browser') deployedStagingUrl(env.STAGING_BROWSER_BASE_URL, 'STAGING_BROWSER_BASE_URL', endpointMode);
   if (revision !== exactRevision()) throw new Error('STAGING_REVISION must equal the exact checked-out revision.');
   if (!COMMANDS[runtime]?.[kind]) throw new Error(`Unsupported executable gate: ${runtime || 'missing'}:${kind || 'missing'}.`);
-  const automation = String(env.CI_JOB_URL || '').trim();
-  if (!/^https?:\/\//.test(automation)) throw new Error('CI_JOB_URL is required for hosted evidence provenance.');
+  const automation = stagingAutomation(env.RUNTIME_EVIDENCE_AUTOMATION || env.CI_JOB_URL, endpointMode);
   return Object.freeze({
     runtime, kind, revision, automation, endpointMode,
     deploymentId: String(env.STAGING_DEPLOYMENT_ID || '').trim(),
@@ -136,4 +144,6 @@ if (require.main === module) {
   }
 }
 
-module.exports = { COMMAND_LINES, COMMANDS, THRESHOLDS, configuration, deployedStagingUrl, main, value, values, writeJson };
+module.exports = {
+  COMMAND_LINES, COMMANDS, THRESHOLDS, configuration, deployedStagingUrl, main, stagingAutomation, value, values, writeJson,
+};

--- a/tests/integration/runtime-release-manifest.integration.test.js
+++ b/tests/integration/runtime-release-manifest.integration.test.js
@@ -68,11 +68,12 @@ it('binds host-local executable gates to the same explicit endpoint scope as dep
       STAGING_ENDPOINT_MODE: 'host-local',
       STAGING_BASE_URL: 'http://127.0.0.1:23000',
       STAGING_DEPLOYMENT_ID: 'staging-host-local',
-      CI_JOB_URL: 'https://ci.example.test/jobs/host-local',
+      RUNTIME_EVIDENCE_AUTOMATION: 'local:runtime-hosted-evidence',
     },
   );
   assert.equal(configuration.endpointMode, 'host-local');
   assert.equal(configuration.deploymentId, 'staging-host-local');
+  assert.equal(configuration.automation, 'local:runtime-hosted-evidence');
 });
 
 it('admits LangGraph load evidence only with exact side effects and zero residual state', () => {

--- a/tests/security/runtime-release-manifest.security.test.js
+++ b/tests/security/runtime-release-manifest.security.test.js
@@ -90,4 +90,8 @@ it('rejects endpoint-scope downgrades while normalizing executable release evide
   assert.throws(() => executableGateConfiguration(['--runtime', 'graphile', '--kind', 'contract'], {
     ...base, STAGING_ENDPOINT_MODE: 'host-local', STAGING_BASE_URL: 'http://user@127.0.0.1:23000',
   }), /host-local mode/);
+  assert.throws(() => executableGateConfiguration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...base, CI_JOB_URL: undefined, RUNTIME_EVIDENCE_AUTOMATION: 'local:runtime-hosted-evidence',
+    STAGING_BASE_URL: 'https://staging.example.test',
+  }), /hosted mode/);
 });

--- a/tests/unit/executable-runtime-evidence.test.js
+++ b/tests/unit/executable-runtime-evidence.test.js
@@ -133,16 +133,20 @@ test('normalizer accepts loopback evidence only in explicit host-local mode', ()
     STAGING_BASE_URL: 'http://127.0.0.1:23000',
     STAGING_BROWSER_BASE_URL: 'http://127.0.0.1:25173',
     STAGING_DEPLOYMENT_ID: 'staging-host-local',
-    CI_JOB_URL: 'https://gitlab.example.test/jobs/host-local',
+    RUNTIME_EVIDENCE_AUTOMATION: 'local:runtime-hosted-evidence',
   };
   const config = configuration(['--runtime', 'langgraph', '--kind', 'browser', '--source', 'result.json'], env);
   assert.equal(config.endpointMode, 'host-local');
+  assert.equal(config.automation, 'local:runtime-hosted-evidence');
   assert.throws(() => configuration(['--runtime', 'graphile', '--kind', 'contract'], {
     ...env, STAGING_ENDPOINT_MODE: undefined,
   }), /hosted mode/);
   assert.throws(() => configuration(['--runtime', 'graphile', '--kind', 'contract'], {
     ...env, STAGING_BASE_URL: 'https://staging.example.test',
   }), /host-local mode/);
+  assert.throws(() => configuration(['--runtime', 'graphile', '--kind', 'contract'], {
+    ...env, RUNTIME_EVIDENCE_AUTOMATION: 'local:../../untrusted',
+  }), /automation identifier/);
 });
 
 test('hosted synthetic receipts retain the source digest but remove task content and URLs', () => {


### PR DESCRIPTION
## Summary

Permit a code-owned local automation identifier for release evidence only when staging explicitly runs in host-local mode. Hosted mode continues to require HTTP(S) CI provenance. This lets the only host describe the real executor without fabricating a remote job URL.

## Linked Task
- Task: Collect truthful Stage 4 release evidence on the host-only infrastructure architecture

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/runtime-hardening-cutover.md
- Relevant standards areas: architecture and design; coding and code quality; testing and quality assurance; deployment and release; security; observability and monitoring
- Standards gaps or exceptions: The endpoint boundary allowed host-local execution but provenance still required a remote job URL; this change adds a narrowly scoped local automation identity without weakening hosted mode.
- [ ] UI changes use generated DESIGN.md tokens.
- [x] npm run design:tokens:check passed.
- [x] npm run design:tokens:enforce passed.
- [ ] DESIGN.md was updated when visual semantics changed.
- [ ] Any one-off visual exception is documented with DESIGN-TOKEN-EXCEPTION.

## Required Evidence
- Standards check result: npm run standards:check passed; maintainability and 98.165% coverage policy passed.
- Lint result: npm run lint passed as part of make verify.
- Tests: make verify passed, including Python, Node unit, integration, security, UI, browser, build, provenance, secrets, and policy validation; focused provenance tests passed 18 of 18.
- Test evidence paths: tests/unit/executable-runtime-evidence.test.js, tests/integration/runtime-release-manifest.integration.test.js, tests/security/runtime-release-manifest.security.test.js
- Docs updated: The runtime-hardening runbook now distinguishes hosted CI provenance from truthful host-local automation provenance.
- Doc evidence paths: docs/runbooks/runtime-hardening-cutover.md

## Risk and Rollback
- Risk level: medium; release evidence admission changes only in explicit host-local mode and unsafe identifiers remain rejected.
- Rollback path: Revert this merge commit and stop local evidence collection; staging remains isolated at the previous exact revision.

## Notes

No pre-soak artifact was normalized with fabricated or ambiguous provenance.