### PR TITLE
fix(staging): serve production UI from built assets

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -274,3 +274,9 @@ then requires local topology health plus a deployed `/health` response before it
 staging evidence. `STAGING_ENDPOINT_MODE=host-local` permits only explicit loopback HTTP(S) endpoints;
 the default hosted mode still requires non-local HTTPS. This keeps the deployment on the operator host
 without weakening profile, database, credential, or exact-revision isolation.
+
+Production-mode staging builds the browser bundle before launchd activation and serves `dist/` through
+Vite preview. The preview keeps `/backend` as a same-origin proxy to the profile-specific audit API.
+Development profiles retain the Vite development server, but a production profile must never enable
+React-refresh transforms; this separation makes the browser artifact reproducible and prevents a blank
+page caused by development-only refresh globals.

--- a/docs/runbooks/golden-path-autonomous-delivery.md
+++ b/docs/runbooks/golden-path-autonomous-delivery.md
@@ -1199,3 +1199,8 @@ Configure staging through the protected `STAGING_BASE_URL`, `STAGING_DATABASE_UR
 persistent release root and starts only the `staging` launchd profile. Do not point these variables at
 the default ports, database, state directory, or root binding. A missing HTTPS host or unhealthy local
 or hosted probe blocks evidence creation and the 24-hour soak.
+
+Staging uses a production browser build served by Vite preview with `/backend` proxied to the isolated
+staging API. If the page is blank and reports `$RefreshReg$ is not defined`, the production profile was
+incorrectly started with the Vite development server; rebuild and rebind the exact release before
+collecting browser evidence.

--- a/docs/runbooks/runtime-hardening-cutover.md
+++ b/docs/runbooks/runtime-hardening-cutover.md
@@ -16,7 +16,10 @@ the other.
 
 On protected `main`, `deploy-runtime-staging` clones the exact `CI_COMMIT_SHA` into
 `$STAGING_RELEASE_ROOT/releases/<sha>`, removes the credential-bearing remote, installs from the lockfile,
-starts only the `staging` launchd profile, and verifies local plus deployed `/health`. Host-local staging
+builds the browser assets, starts only the `staging` launchd profile, and verifies local plus deployed
+`/health`. Production-mode launchd serves the built browser through Vite preview with the same-origin
+`/backend` proxy; it must never launch the React-refresh development server under `NODE_ENV=production`.
+Host-local staging
 uses the profile ports (`127.0.0.1:23000` for the API and `127.0.0.1:25173` for the browser) on this same
 operator host. It emits revision-bound
 Graphile and LangGraph `staging_deploy` components. An existing release directory with another revision,

--- a/lib/task-platform/factory-stack/launchd.js
+++ b/lib/task-platform/factory-stack/launchd.js
@@ -96,20 +96,8 @@ function writeServiceEnv(env) {
   return ENV_FILE;
 }
 
-/**
- * Build launchd service specs for the factory of record.
- * options.skipUi / options.skipForgeadapter omit claim-topology units.
- */
-function buildServiceSpecs(env = buildServiceEnv(), options = {}) {
-  const node = nodeBinary();
-  const logs = logsHomeDir();
-  const forgeadapterDir = options.forgeadapterDir !== undefined
-    ? options.forgeadapterDir
-    : resolveForgeadapterDir(options.forgeadapterDirExplicit);
-  const skipUi = options.skipUi === true;
-  const skipForgeadapter = options.skipForgeadapter === true || !forgeadapterDir;
-
-  const specs = [
+function buildCoreServiceSpecs(node, logs, env) {
+  return [
     {
       key: 'postgresEnsure',
       label: LABELS.postgresEnsure,
@@ -142,39 +130,52 @@ function buildServiceSpecs(env = buildServiceEnv(), options = {}) {
       keepAlive: true,
     },
   ];
+}
 
-  if (!skipUi) {
-    const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js');
-    specs.push({
-      key: 'ui',
-      label: LABELS.ui,
-      programArgs: [
-        node,
-        viteBin,
-        '--host', '127.0.0.1',
-        '--port', String(DEFAULT_PORTS.ui),
-        '--strictPort',
-      ],
-      env: buildUiEnv(env),
-      workingDirectory: ROOT,
-      stdoutLog: path.join(logs, 'ui.out.log'),
-      stderrLog: path.join(logs, 'ui.err.log'),
-      keepAlive: true,
-    });
-  }
+function buildUiServiceSpec(node, logs, env) {
+  const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js');
+  const uiEnv = buildUiEnv(env);
+  const viteCommand = uiEnv.NODE_ENV === 'production' ? ['preview'] : [];
+  return {
+    key: 'ui',
+    label: LABELS.ui,
+    programArgs: [
+      node, viteBin, ...viteCommand,
+      '--host', '127.0.0.1', '--port', String(DEFAULT_PORTS.ui), '--strictPort',
+    ],
+    env: uiEnv,
+    workingDirectory: ROOT,
+    stdoutLog: path.join(logs, 'ui.out.log'),
+    stderrLog: path.join(logs, 'ui.err.log'),
+    keepAlive: true,
+  };
+}
 
-  if (!skipForgeadapter && forgeadapterDir) {
-    specs.push({
-      key: 'forgeadapter',
-      label: LABELS.forgeadapter,
-      programArgs: [node, 'src/index.js'],
-      env: buildForgeadapterEnv(env, forgeadapterDir),
-      workingDirectory: forgeadapterDir,
-      stdoutLog: path.join(logs, 'forgeadapter.out.log'),
-      stderrLog: path.join(logs, 'forgeadapter.err.log'),
-      keepAlive: true,
-    });
-  }
+function buildForgeadapterServiceSpec(node, logs, env, forgeadapterDir) {
+  return {
+    key: 'forgeadapter',
+    label: LABELS.forgeadapter,
+    programArgs: [node, 'src/index.js'],
+    env: buildForgeadapterEnv(env, forgeadapterDir),
+    workingDirectory: forgeadapterDir,
+    stdoutLog: path.join(logs, 'forgeadapter.out.log'),
+    stderrLog: path.join(logs, 'forgeadapter.err.log'),
+    keepAlive: true,
+  };
+}
+
+/** Build launchd service specs; skip flags omit claim-topology units. */
+function buildServiceSpecs(env = buildServiceEnv(), options = {}) {
+  const node = nodeBinary();
+  const logs = logsHomeDir();
+  const forgeadapterDir = options.forgeadapterDir !== undefined
+    ? options.forgeadapterDir
+    : resolveForgeadapterDir(options.forgeadapterDirExplicit);
+  const skipUi = options.skipUi === true;
+  const skipForgeadapter = options.skipForgeadapter === true || !forgeadapterDir;
+  const specs = buildCoreServiceSpecs(node, logs, env);
+  if (!skipUi) specs.push(buildUiServiceSpec(node, logs, env));
+  if (!skipForgeadapter) specs.push(buildForgeadapterServiceSpec(node, logs, env, forgeadapterDir));
 
   return {
     specs,

--- a/lib/task-platform/factory-stack/ui.js
+++ b/lib/task-platform/factory-stack/ui.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { ROOT, buildUiEnv } = require('./defaults');
+
+function prepareUiAssets(env, options = {}, dependencies = {}) {
+  if (options.skipUi === true) return Object.freeze({ built: false, reason: 'skipped' });
+  if (env.NODE_ENV !== 'production') return Object.freeze({ built: false, reason: 'development' });
+  const execute = dependencies.execFileSync || execFileSync;
+  execute(dependencies.npmCommand || 'npm', ['run', 'build:browser'], {
+    cwd: ROOT,
+    env: { ...process.env, ...buildUiEnv(env) },
+    stdio: dependencies.stdio || 'inherit',
+  });
+  const indexFile = path.join(ROOT, 'dist', 'index.html');
+  const exists = dependencies.existsSync || fs.existsSync;
+  if (!exists(indexFile)) throw new Error('Production UI build did not create dist/index.html.');
+  return Object.freeze({ built: true, indexFile });
+}
+
+module.exports = { prepareUiAssets };

--- a/scripts/factory-stack.js
+++ b/scripts/factory-stack.js
@@ -42,6 +42,7 @@ const {
   kickstart,
 } = require('../lib/task-platform/factory-stack/launchd');
 const { ensurePostgres, dockerAvailable, stopDockerPostgres } = require('../lib/task-platform/factory-stack/postgres');
+const { prepareUiAssets } = require('../lib/task-platform/factory-stack/ui');
 
 function usage() {
   process.stdout.write(`Usage: node scripts/factory-stack.js <up|down|status|restart|install|uninstall|accept> [options]
@@ -133,6 +134,7 @@ async function cmdInstall(options) {
   ensureExampleEnv();
   fs.mkdirSync(STATE_DIR, { recursive: true });
   const env = buildServiceEnv();
+  prepareUiAssets(env, options);
   const installed = installLaunchdServices(env, stackOptions(options));
   return {
     ok: true,
@@ -148,43 +150,56 @@ async function cmdUninstall() {
   return { ok: true, action: 'uninstall', ...result };
 }
 
-async function cmdUp(options) {
-  ensureExampleEnv();
-  const env = buildServiceEnv();
+function upFailure(postgres, error, extra = {}) {
+  return { ok: false, action: 'up', postgres, error, ...extra };
+}
+
+async function prepareStackRuntime(env, options) {
   const postgres = await ensurePostgres();
   if (!postgres.ok) {
-    return {
-      ok: false,
-      action: 'up',
-      postgres,
-      error: postgres.error,
+    return upFailure(postgres, postgres.error, {
       hint: 'Start Postgres on 15432 or install Docker Desktop/OrbStack, then re-run npm run factory:stack:up',
       remediation: postgres.remediation,
-    };
+    });
   }
-
   try {
     runMigrations(env);
   } catch (error) {
-    return {
-      ok: false,
-      action: 'up',
-      postgres,
-      error: `migrations failed: ${error.message}`,
-    };
+    return upFailure(postgres, `migrations failed: ${error.message}`);
   }
+  try {
+    prepareUiAssets(env, options);
+  } catch (error) {
+    return upFailure(postgres, `production UI build failed: ${error.message}`);
+  }
+  return { ok: true, postgres };
+}
 
+function startStackServices(env, options) {
   const installed = installLaunchdServices(env, stackOptions(options));
   for (const label of installed.labels || Object.values(LABELS)) {
     kickstart(label);
   }
+  return installed;
+}
 
-  const health = options.skipWait
+async function collectStartedStack(options, installed) {
+  return options.skipWait
     ? await collectHealthReport({
       requireUi: !options.skipUi,
       requireForgeadapter: !options.skipForgeadapter && Boolean(installed.forgeadapterDir),
     })
     : await waitForRequiredHealth(options);
+}
+
+async function cmdUp(options) {
+  ensureExampleEnv();
+  const env = buildServiceEnv();
+  const prepared = await prepareStackRuntime(env, options);
+  if (!prepared.ok) return prepared;
+  const { postgres } = prepared;
+  const installed = startStackServices(env, options);
+  const health = await collectStartedStack(options, installed);
 
   const launchd = launchdStatus();
   const acceptance = evaluateFactoryStackAcceptance({

--- a/tests/contract/factory-stack-root-binding.contract.test.js
+++ b/tests/contract/factory-stack-root-binding.contract.test.js
@@ -155,3 +155,13 @@ it('gives staging independent persistent identity, ports, state, and logs', () =
   assert.match(isolated.binding, /profiles\/staging\/repo-root\.json$/);
   assert.match(isolated.logs, /engineering-team-factory-staging$/);
 });
+
+it('serves production staging UI from built assets with the isolated API proxy', () => {
+  const env = { ...buildServiceEnv(), NODE_ENV: 'production' };
+  const ui = buildServiceSpecs(env, { skipForgeadapter: true }).specs
+    .find((service) => service.key === 'ui');
+  assert.ok(ui.programArgs.includes('preview'));
+  assert.equal(ui.programArgs.includes('dev'), false);
+  assert.equal(ui.env.VITE_TASK_API_BASE_URL, '/backend');
+  assert.match(ui.env.VITE_TASK_API_PROXY_TARGET, /127\.0\.0\.1:\d+$/);
+});

--- a/tests/unit/factory-stack-service.test.js
+++ b/tests/unit/factory-stack-service.test.js
@@ -23,6 +23,7 @@ const {
 } = require('../../lib/task-platform/factory-stack/health');
 const { resolveDockerBin, dockerAvailable, ensurePostgres } = require('../../lib/task-platform/factory-stack/postgres');
 const { ensureContainerEngine } = require('../../lib/task-platform/factory-stack/container-engine');
+const { prepareUiAssets } = require('../../lib/task-platform/factory-stack/ui');
 
 describe('factory-stack defaults', () => {
   it('builds live OpenClaw-oriented service env', () => {
@@ -113,8 +114,48 @@ describe('factory-stack launchd plist', () => {
     assert.deepEqual(keys.filter((k) => k !== 'forgeadapter'), ['postgresEnsure', 'api', 'workers', 'ui']);
     assert.equal(skipped.forgeadapter, true);
     assert.ok(specs.find((s) => s.key === 'postgresEnsure').programArgs.some((a) => String(a).includes('factory-stack-postgres-watch')));
+    assert.equal(specs.find((s) => s.key === 'ui').programArgs.includes('preview'), false);
+  });
+});
+
+describe('factory-stack production UI', () => {
+  it('builds and previews production UI assets while leaving development on the Vite server', () => {
+    const calls = [];
+    const productionEnv = { ...buildServiceEnv(), NODE_ENV: 'production' };
+    const result = prepareUiAssets(productionEnv, {}, {
+      execFileSync: (...args) => calls.push(args), existsSync: () => true, stdio: 'pipe',
+    });
+    assert.equal(result.built, true);
+    assert.deepEqual(calls[0].slice(0, 2), ['npm', ['run', 'build:browser']]);
+    assert.equal(calls[0][2].env.VITE_TASK_API_BASE_URL, '/backend');
+    const productionUi = buildServiceSpecs(productionEnv, { skipForgeadapter: true }).specs
+      .find((service) => service.key === 'ui');
+    assert.ok(productionUi.programArgs.includes('preview'));
+    assert.equal(productionUi.env.VITE_TASK_API_PROXY_TARGET, `http://127.0.0.1:${DEFAULT_PORTS.api}`);
+    assert.equal(prepareUiAssets({ ...productionEnv, NODE_ENV: 'development' }, {}, {
+      execFileSync: () => assert.fail('development UI must not build'),
+    }).reason, 'development');
   });
 
+  it('keeps the same-origin API proxy active in Vite preview', () => {
+    const previous = process.env.VITE_TASK_API_PROXY_TARGET;
+    process.env.VITE_TASK_API_PROXY_TARGET = 'http://127.0.0.1:23000';
+    const configPath = require.resolve('../../vite.config.js');
+    delete require.cache[configPath];
+    try {
+      const configure = require(configPath);
+      const config = configure({ mode: 'production', command: 'serve' });
+      assert.equal(config.preview.proxy['/backend'].target, 'http://127.0.0.1:23000');
+      assert.equal(config.preview.proxy['/backend'].rewrite('/backend/health'), '/health');
+    } finally {
+      if (previous === undefined) delete process.env.VITE_TASK_API_PROXY_TARGET;
+      else process.env.VITE_TASK_API_PROXY_TARGET = previous;
+      delete require.cache[configPath];
+    }
+  });
+});
+
+describe('factory-stack launchd diagnostics', () => {
   it('reports stale temporary checkout paths with remediation', () => {
     const fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'factory-plist-status-'));
     const plist = path.join(fixture, 'stale.plist');

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,26 +19,26 @@ function shouldBypassTasksProxy(req) {
 module.exports = defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const proxyTarget = env.VITE_TASK_API_PROXY_TARGET;
+  const proxy = proxyTarget
+    ? {
+        '/tasks': {
+          target: proxyTarget,
+          bypass: (req) => shouldBypassTasksProxy(req),
+        },
+        '/auth': {
+          target: proxyTarget,
+          bypass: (req) => (shouldBypassAuthProxy(req) ? req.url : undefined),
+        },
+        '/backend': {
+          target: proxyTarget,
+          rewrite: (path) => path.replace(/^\/backend/, '') || '/',
+        },
+      }
+    : undefined;
 
   return {
     plugins: [react()],
-    server: proxyTarget
-      ? {
-          proxy: {
-            '/tasks': {
-              target: proxyTarget,
-              bypass: (req) => shouldBypassTasksProxy(req),
-            },
-            '/auth': {
-              target: proxyTarget,
-              bypass: (req) => (shouldBypassAuthProxy(req) ? req.url : undefined),
-            },
-            '/backend': {
-              target: proxyTarget,
-              rewrite: (path) => path.replace(/^\/backend/, '') || '/',
-            },
-          },
-        }
-      : undefined,
+    server: proxy ? { proxy } : undefined,
+    preview: proxy ? { proxy } : undefined,
   };
 });


### PR DESCRIPTION
## Summary

- build the browser bundle before installing or starting a production factory-stack profile
- serve production UI assets with Vite preview while retaining the Vite development server for development profiles
- share the same-origin API proxy between development and preview so host-local staging reaches its isolated backend
- fail startup clearly when production assets cannot be built and document blank-page remediation

## Linked Task
- Task: Stage 4 exact-revision host-local staging evidence and 24-hour soak readiness

## Standards Compliance
- Standards baseline reviewed: yes
- Checklist completed or updated: yes
- Compliance checklist path: docs/runbooks/runtime-hardening-cutover.md
- Relevant standards areas: release integrity, runtime reliability, host-local staging isolation, browser production serving
- Standards gaps or exceptions: No standards gaps or exceptions identified; all applicable checks passed
- [ ] UI changes use generated DESIGN.md tokens. (not applicable; no authored UI source or visual semantics changed)
- [x] `npm run design:tokens:check` passed.
- [x] `npm run design:tokens:enforce` passed.
- [ ] `DESIGN.md` was updated when visual semantics changed. (not applicable)
- [ ] Any one-off visual exception is documented with `DESIGN-TOKEN-EXCEPTION`. (not applicable)

## Required Evidence
- Standards check result: passed in `make verify`
- Lint result: passed in `make verify`
- Tests: Python 100 passed; Node 1091 passed; UI 174 passed and 2 skipped; browser gates passed; coverage policy 98.165%; full `make verify` passed
- Test evidence paths: tests/unit/factory-stack-service.test.js, tests/contract/factory-stack-root-binding.contract.test.js
- Docs updated: yes
- Doc evidence paths: docs/architecture.md, docs/runbooks/runtime-hardening-cutover.md, docs/runbooks/golden-path-autonomous-delivery.md

## Risk and Rollback
- Risk level: medium
- Rollback path: revert commit be55831 to restore the former Vite launch behavior; no schema or persisted-data changes

## Notes

The live host-local staging browser exposed a blank page with `$RefreshReg$ is not defined` because launchd combined `NODE_ENV=production` with the Vite development server. A direct production-preview smoke test loaded the application with no page errors and proxied `/backend/health` to the exact staging API revision.